### PR TITLE
Fix circle area calculator expression

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -258,7 +258,7 @@
         "placeholder": "5"
       }
     ],
-    "expression": "Math.PI * r * r",
+    "expression": "3.141592653589793 * r * r",
     "examples": [
       {
         "description": "r = 5 ⇒ area ≈ 78.5398"

--- a/src/pages/calculators/circle-area.mdx
+++ b/src/pages/calculators/circle-area.mdx
@@ -22,7 +22,7 @@ export const schema = {
   "slug": "circle-area",
   "title": "Circle Area",
   "locale": "en",
-  "expression": "Math.PI * r * r",
+  "expression": "3.141592653589793 * r * r",
   "intro": "Compute area of a circle from its radius.",
   "examples": [
     {


### PR DESCRIPTION
## Summary
- replace `Math.PI` usage in circle area calculator with numeric constant to avoid unknown variable error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b179f0bd2c8321a8905bba8c29c485