### PR TITLE
fix: wrap footer links on small screens

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -155,6 +155,6 @@ ul.grid li{list-style:none}
   padding:12px 16px;font-weight:600;cursor:pointer}
 .btn-primary:hover{filter:brightness(1.05)}
 .faq summary{cursor:pointer;font-weight:600}
-footer .links{display:flex;gap:16px;justify-content:center;color:var(--muted)}
+footer .links{display:flex;gap:16px;flex-wrap:wrap;justify-content:center;color:var(--muted)}
 footer .links a{color:inherit;text-decoration:none}
 footer .links a:hover{text-decoration:underline;color:var(--ink)}


### PR DESCRIPTION
## Summary
- allow footer links to wrap so navigation doesn't overflow on mobile

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b180411b2c8321ae7732a2f580fba0