### PR TITLE
Avoid Math variable in circle area calculators

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -258,7 +258,7 @@
         "placeholder": "5"
       }
     ],
-    "expression": "Math.PI * r * r",
+    "expression": "3.141592653589793 * (r * r)",
     "examples": [
       {
         "description": "r = 5 ⇒ area ≈ 78.5398"

--- a/src/pages/calculators/circle-area-calculator.mdx
+++ b/src/pages/calculators/circle-area-calculator.mdx
@@ -21,7 +21,7 @@ export const schema = {
   "slug": "circle-area-calculator",
   "title": "Circle Area Calculator",
   "locale": "en",
-  "expression": "3.141592653589793 * radius ^ 2",
+  "expression": "3.141592653589793 * (radius * radius)",
   "intro": "Area of a circle.",
   "examples": [
     {

--- a/src/pages/calculators/circle-area.mdx
+++ b/src/pages/calculators/circle-area.mdx
@@ -22,7 +22,7 @@ export const schema = {
   "slug": "circle-area",
   "title": "Circle Area",
   "locale": "en",
-  "expression": "Math.PI * r * r",
+  "expression": "3.141592653589793 * (r * r)",
   "intro": "Compute area of a circle from its radius.",
   "examples": [
     {


### PR DESCRIPTION
## Summary
- use numeric π constant in circle area calculators to remove `Math` variable dependency
- harmonize circle area expressions across data and pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'yargs-parser')*


------
https://chatgpt.com/codex/tasks/task_b_68b179f0bd2c8321a8905bba8c29c485