### PR TITLE
fix: wrap navigation menus on small screens

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -83,8 +83,13 @@ html,body{background:var(--bg);color:var(--ink);
 .container{max-width:var(--maxw);margin-inline:auto;padding-inline:16px}
 .header{background:var(--primary);color:var(--primary-ink);border-radius:16px;margin:16px auto 24px;max-width:var(--maxw)}
 .header a{color:var(--primary-ink);text-decoration:none}
-.header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 18px}
-.nav{display:flex;gap:18px;font-weight:500;opacity:.95}
+.header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;flex-wrap:wrap;row-gap:12px}
+.nav{display:flex;gap:18px;font-weight:500;opacity:.95;flex-wrap:wrap}
+@media (max-width:640px){
+  .header-inner{justify-content:center}
+  .nav{width:100%;justify-content:center;gap:12px}
+  footer .links{gap:12px}
+}
 .hero{text-align:center;padding:24px 0 12px}
 .hero h1{font-size:clamp(32px,5vw,48px);line-height:1.05;letter-spacing:-.02em}
 .hero p{margin-top:8px;color:var(--muted);max-width:56ch;margin-inline:auto}
@@ -155,6 +160,6 @@ ul.grid li{list-style:none}
   padding:12px 16px;font-weight:600;cursor:pointer}
 .btn-primary:hover{filter:brightness(1.05)}
 .faq summary{cursor:pointer;font-weight:600}
-footer .links{display:flex;gap:16px;justify-content:center;color:var(--muted)}
+footer .links{display:flex;gap:16px;justify-content:center;color:var(--muted);flex-wrap:wrap}
 footer .links a{color:inherit;text-decoration:none}
 footer .links a:hover{text-decoration:underline;color:var(--ink)}


### PR DESCRIPTION
## Summary
- allow top navigation to wrap and center on narrow viewports
- wrap footer links to prevent overflow on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b17c7decb083219736676559b884cc