### PR TITLE
fix: remove unsupported operators from loan payment calc

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -167,7 +167,7 @@ const expression = schema?.expression ?? schema?.formula ?? schema?.formula_expr
         }
         try {
           value = evalExpr(expr, vars);
-          usedExpr = true;
+          usedExpr = isFinite(value);
         } catch (e) {
           usedExpr = false;
         }

--- a/src/pages/calculators/loan-payment-calculator.mdx
+++ b/src/pages/calculators/loan-payment-calculator.mdx
@@ -40,7 +40,7 @@ export const schema = {
   "title": "Loan Payment Calculator",
   "locale": "en",
   // Monthly payment formula: P * (r / (1 - (1 + r)^(-n))) with r=annualRate/100/12 and n=years*12
-  "expression": "(annualRate == 0 ? (principal / (years * 12)) : (principal * ((annualRate / 100 / 12) * (1 + (annualRate / 100 / 12)) ^ (years * 12))) / ((1 + (annualRate / 100 / 12)) ^ (years * 12) - 1))",
+  "expression": "(principal * ((annualRate / 100 / 12) * (1 + (annualRate / 100 / 12)) ^ (years * 12))) / ((1 + (annualRate / 100 / 12)) ^ (years * 12) - 1)",
   "intro": "Compute fixed monthly payment for a loan.",
   "examples": [
     {


### PR DESCRIPTION
## Summary
- remove unsupported conditional operators from Loan Payment Calculator formula
- ensure calculator parser falls back when expression evaluation produces invalid values

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'yargs-parser')

------
https://chatgpt.com/codex/tasks/task_b_68b1aebb8b2c8321bb12d22bf601c08a