### PR TITLE
Fix duplicate headings and FAQs in generated calculators

### DIFF
--- a/scripts/generate_calcs.js
+++ b/scripts/generate_calcs.js
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from "node:fs";
+import path from "node:path";
 
 /**
  * Advanced calculator generator (plain JS)
@@ -10,70 +10,71 @@ import path from 'node:path';
  * being regenerated.  The `MAX_PER_DAY` environment variable controls
  * how many new calculators are emitted on each run.  Values are
  * clamped between 20 and 100 to ensure a steady flow of fresh
- * content without overloading the site.
+ * content without overloading the site.  Title, intro and FAQ content
+ * are rendered by the Calculator component itself.
  */
 
-const ROOT      = process.cwd();
-const DATA_PATH = path.join(ROOT, 'data', 'calculators.json');
-const OUT_DIR   = path.join(ROOT, 'src', 'pages', 'calculators');
-const LOG_PATH  = path.join(ROOT, 'meta', 'publish_log.json');
+const ROOT = process.cwd();
+const DATA_PATH = path.join(ROOT, "data", "calculators.json");
+const OUT_DIR = path.join(ROOT, "src", "pages", "calculators");
+const LOG_PATH = path.join(ROOT, "meta", "publish_log.json");
 
 // Mapping of various cluster names to one of the eight top‑level
 // categories.  All keys are lower‑case for case‑insensitive lookups.
 const CATEGORY_MAP = {
   // finance
-  'finance & loans':       'Finance',
-  'percentages & ratios':  'Finance',
-  'finance':               'Finance',
-  'business':              'Finance',
-  'business & commerce':   'Finance',
-  'taxes':                 'Finance',
+  "finance & loans": "Finance",
+  "percentages & ratios": "Finance",
+  finance: "Finance",
+  business: "Finance",
+  "business & commerce": "Finance",
+  taxes: "Finance",
   // health
-  'health & fitness':      'Health',
-  'health':                'Health',
-  'bmi':                   'Health',
+  "health & fitness": "Health",
+  health: "Health",
+  bmi: "Health",
   // conversions
-  'conversions & units':   'Conversions',
-  'unit conversions':      'Conversions',
-  'unit and currency conversions': 'Conversions',
-  'conversions':           'Conversions',
+  "conversions & units": "Conversions",
+  "unit conversions": "Conversions",
+  "unit and currency conversions": "Conversions",
+  conversions: "Conversions",
   // math
-  'math':                  'Math',
-  'geometry':              'Math',
-  'geometry & math':       'Math',
-  'areas & volumes':       'Math',
-  'algebra':               'Math',
-  'statistics':            'Math',
-  'averages and probabilities': 'Math',
+  math: "Math",
+  geometry: "Math",
+  "geometry & math": "Math",
+  "areas & volumes": "Math",
+  algebra: "Math",
+  statistics: "Math",
+  "averages and probabilities": "Math",
   // technology
-  'technology':            'Technology',
-  'tech':                  'Technology',
-  'computing':             'Technology',
-  'technology & computing':'Technology',
+  technology: "Technology",
+  tech: "Technology",
+  computing: "Technology",
+  "technology & computing": "Technology",
   // date & time
-  'date & time':           'Date & Time',
-  'time & date':           'Date & Time',
-  'time-date':             'Date & Time',
-  'durations and schedules': 'Date & Time',
+  "date & time": "Date & Time",
+  "time & date": "Date & Time",
+  "time-date": "Date & Time",
+  "durations and schedules": "Date & Time",
   // home & diy
-  'home & diy':            'Home & DIY',
-  'home and diy':          'Home & DIY',
-  'diy':                   'Home & DIY',
-  'household':             'Home & DIY',
+  "home & diy": "Home & DIY",
+  "home and diy": "Home & DIY",
+  diy: "Home & DIY",
+  household: "Home & DIY",
   // other/misc
-  'misc':                  'Other',
-  'miscellaneous':         'Other',
-  'other':                 'Other',
-  'everyday':              'Other',
-  'general':               'Other',
-  'education':             'Other',
-  'science':               'Other'
+  misc: "Other",
+  miscellaneous: "Other",
+  other: "Other",
+  everyday: "Other",
+  general: "Other",
+  education: "Other",
+  science: "Other",
 };
 
 // Utility to safely parse JSON with fallback.
 function readJSON(p, fallback) {
   try {
-    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+    return JSON.parse(fs.readFileSync(p, "utf-8"));
   } catch (_) {
     return fallback;
   }
@@ -81,22 +82,25 @@ function readJSON(p, fallback) {
 
 function writeJSON(p, data) {
   fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8');
+  fs.writeFileSync(p, JSON.stringify(data, null, 2), "utf-8");
 }
 
 // Replace ** with ^ to suit the calculator evaluator.
 function sanitizeExpr(expr) {
-  return typeof expr === 'string' ? expr.replace(/\*\*/g, '^') : '';
+  return typeof expr === "string" ? expr.replace(/\*\*/g, "^") : "";
 }
 
 function pickRelated(base, all, count = 6) {
-  const same = all.filter((c) => c.slug !== base.slug && c.cluster === base.cluster);
-  const pool = same.length >= count ? same : all.filter((c) => c.slug !== base.slug);
+  const same = all.filter(
+    (c) => c.slug !== base.slug && c.cluster === base.cluster,
+  );
+  const pool =
+    same.length >= count ? same : all.filter((c) => c.slug !== base.slug);
   return pool.slice(0, count).map((c) => c.slug);
 }
 
 function titleize(slug) {
-  return slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  return slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 // Immediately invoked main function
@@ -106,71 +110,71 @@ function titleize(slug) {
   const published = new Set(log.map((r) => r.slug));
   const backlog = items.filter((c) => !published.has(c.slug));
   if (!backlog.length) {
-    console.log('No new calculators to generate');
+    console.log("No new calculators to generate");
     return;
   }
-  const rawMax = parseInt(process.env.MAX_PER_DAY || process.env.MAX_PER_DAY_GITHUB || '50', 10);
+  const rawMax = parseInt(
+    process.env.MAX_PER_DAY || process.env.MAX_PER_DAY_GITHUB || "50",
+    10,
+  );
   const limit = Math.max(20, Math.min(100, isNaN(rawMax) ? 50 : rawMax));
   const today = new Date().toISOString().slice(0, 10);
   fs.mkdirSync(OUT_DIR, { recursive: true });
   const toPublish = backlog.slice(0, limit);
   for (const calc of toPublish) {
-    const rawCluster = (calc.cluster || '').toString().toLowerCase();
-    const normCluster = CATEGORY_MAP[rawCluster] || calc.cluster || 'Other';
+    const rawCluster = (calc.cluster || "").toString().toLowerCase();
+    const normCluster = CATEGORY_MAP[rawCluster] || calc.cluster || "Other";
     const related = pickRelated(calc, items);
     const schema = {
       slug: calc.slug,
       title: calc.title,
-      locale: 'en',
+      locale: "en",
       inputs: Array.isArray(calc.inputs) ? calc.inputs : [],
-      expression: sanitizeExpr(calc.expression || ''),
-      intro: calc.intro || calc.description || '',
-      examples: Array.isArray(calc.examples) && calc.examples.length
-        ? calc.examples
-        : [ { description: 'Enter the values and press Calculate.' } ],
+      expression: sanitizeExpr(calc.expression || ""),
+      intro: calc.intro || calc.description || "",
+      examples:
+        Array.isArray(calc.examples) && calc.examples.length
+          ? calc.examples
+          : [{ description: "Enter the values and press Calculate." }],
       faqs: Array.isArray(calc.faqs) ? calc.faqs : [],
-      disclaimer: calc.disclaimer || 'Educational information, not professional advice.',
+      disclaimer:
+        calc.disclaimer || "Educational information, not professional advice.",
       cluster: normCluster,
       related,
     };
     const frontmatter = [];
-    frontmatter.push('---');
-    frontmatter.push('layout: ../../layouts/CalculatorLayout.astro');
+    frontmatter.push("---");
+    frontmatter.push("layout: ../../layouts/CalculatorLayout.astro");
     frontmatter.push(`title: ${JSON.stringify(calc.title)}`);
     frontmatter.push(`description: ${JSON.stringify(schema.intro)}`);
     frontmatter.push(`date: ${today}`);
     frontmatter.push(`updated: ${today}`);
     frontmatter.push(`cluster: ${JSON.stringify(normCluster)}`);
-    frontmatter.push('---\n');
-    let body = '';
+    frontmatter.push("---\n");
+    let body = "";
     body += "import Calculator from '../../components/Calculator.astro';\n\n";
     body += `export const schema = ${JSON.stringify(schema, null, 2)}\n\n`;
-    body += `# ${calc.title}\n\n`;
-    if (schema.intro) body += `${schema.intro}\n\n`;
-    body += '<Calculator schema={schema} />\n\n';
+    // Title, intro and FAQ are rendered inside the Calculator component to
+    // avoid duplicated sections in the generated pages.
+    body += "<Calculator schema={schema} />\n\n";
     if (schema.examples && schema.examples.length) {
-      body += '## Examples\n\n';
+      body += "## Examples\n\n";
       schema.examples.forEach((ex) => {
         body += `- ${ex.description}\n`;
       });
-      body += '\n';
+      body += "\n";
     }
-    if (schema.faqs && schema.faqs.length) {
-      body += '## FAQ\n\n';
-      schema.faqs.forEach((f) => {
-        body += `### ${f.question}\n\n${f.answer}\n\n`;
-      });
-    }
+    // FAQ section omitted – handled inside Calculator component.
     if (related.length) {
-      body += '## Related calculators\n\n';
+      body += "## Related calculators\n\n";
       related.forEach((slug) => {
         body += `- [${titleize(slug)}](/calculators/${slug}/)\n`;
       });
-      body += '\n';
+      body += "\n";
     }
-    const mdxContent = frontmatter.join('\n') + body;
+    const mdxContent = frontmatter.join("\n") + body;
     const outPath = path.join(OUT_DIR, `${calc.slug}.mdx`);
-    fs.writeFileSync(outPath, mdxContent, 'utf-8');
+    fs.writeFileSync(outPath, mdxContent, "utf-8");
     log.push({ slug: calc.slug, date: today });
   }
   writeJSON(LOG_PATH, log);

--- a/scripts/generate_calcs_v2.js
+++ b/scripts/generate_calcs_v2.js
@@ -1,38 +1,47 @@
-// Minimal generator with validation & daily cap
-import fs from 'node:fs';
-import path from 'node:path';
+// Minimal generator with validation & daily cap. Relies on the Calculator
+// component to render title, intro and FAQ sections.
+import fs from "node:fs";
+import path from "node:path";
 
 const root = process.cwd();
-const dataPath = path.join(root, 'data', 'calculators.json');
-const outDir = path.join(root, 'src', 'pages', 'calculators');
-const logPath = path.join(root, 'meta', 'publish_log.json');
-const maxPerDay = parseInt(process.env.MAX_PER_DAY || '50', 10);
+const dataPath = path.join(root, "data", "calculators.json");
+const outDir = path.join(root, "src", "pages", "calculators");
+const logPath = path.join(root, "meta", "publish_log.json");
+const maxPerDay = parseInt(process.env.MAX_PER_DAY || "50", 10);
 
-const items = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const items = JSON.parse(fs.readFileSync(dataPath, "utf8"));
 fs.mkdirSync(outDir, { recursive: true });
-const log = fs.existsSync(logPath) ? JSON.parse(fs.readFileSync(logPath, 'utf8')) : [];
-const publishedSlugs = new Set(log.map(e => e.slug));
+const log = fs.existsSync(logPath)
+  ? JSON.parse(fs.readFileSync(logPath, "utf8"))
+  : [];
+const publishedSlugs = new Set(log.map((e) => e.slug));
 let published = 0;
 
 for (const it of items) {
   if (published >= maxPerDay) break;
-  if (!it || !it.slug || !it.title || !it.expression || !Array.isArray(it.inputs)) continue;
+  if (
+    !it ||
+    !it.slug ||
+    !it.title ||
+    !it.expression ||
+    !Array.isArray(it.inputs)
+  )
+    continue;
   if (publishedSlugs.has(it.slug)) continue;
   const mdx = `---
 title: ${JSON.stringify(it.title)}
 description: ${JSON.stringify(it.intro || it.title)}
-cluster: ${JSON.stringify(it.cluster || '')}
+cluster: ${JSON.stringify(it.cluster || "")}
 ---
 import Calculator from '../../components/Calculator.astro';
-# ${it.title}
-${it.intro || ''}
+
 <Calculator schema={${JSON.stringify(it)}} />
 `;
   fs.writeFileSync(path.join(outDir, `${it.slug}.mdx`), mdx);
-  log.push({ slug: it.slug, date: new Date().toISOString().slice(0,10) });
+  log.push({ slug: it.slug, date: new Date().toISOString().slice(0, 10) });
   published++;
 }
 
 fs.mkdirSync(path.dirname(logPath), { recursive: true });
 fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
-console.log('Generated', published, 'calculators');
+console.log("Generated", published, "calculators");


### PR DESCRIPTION
## Summary
- avoid adding title/intro/FAQ in generator scripts; Calculator component now handles them
- update generator comments accordingly

## Testing
- `npx prettier scripts/generate_calcs.ts scripts/generate_calcs.js scripts/generate_calcs_v2.js --write`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b1f23cd9f88321abecfd312c959004