### PR TITLE
Rename Other category to Everyday & Misc

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -498,7 +498,7 @@
   {
     "slug": "tip-calculator",
     "title": "Tip Calculator",
-    "cluster": "other",
+    "cluster": "Everyday & Misc",
     "description": "Calculate total bill including tip percentage.",
     "inputs": [
       {
@@ -534,7 +534,7 @@
   {
     "slug": "grade-average",
     "title": "Grade Average",
-    "cluster": "other",
+    "cluster": "Everyday & Misc",
     "description": "Compute the average from three test scores.",
     "inputs": [
       {
@@ -848,7 +848,7 @@
   {
     "slug": "fuel-trip-cost",
     "title": "Fuel Trip Cost",
-    "cluster": "Other",
+    "cluster": "Everyday & Misc",
     "intro": "Estimate fuel trip cost.",
     "inputs": [
       {

--- a/data/calculators_extra.json
+++ b/data/calculators_extra.json
@@ -282,7 +282,7 @@
   {
     "slug": "tip-calculator",
     "title": "Tip Calculator",
-    "cluster": "Other",
+    "cluster": "Everyday & Misc",
     "intro": "Calculate tip amount.",
     "inputs": [
       {
@@ -299,7 +299,7 @@
   {
     "slug": "fuel-trip-cost",
     "title": "Fuel Trip Cost",
-    "cluster": "Other",
+    "cluster": "Everyday & Misc",
     "intro": "Estimate fuel trip cost.",
     "inputs": [
       {

--- a/scripts/generate_calcs.js
+++ b/scripts/generate_calcs.js
@@ -61,14 +61,14 @@ const CATEGORY_MAP = {
   "home and diy": "Home & DIY",
   diy: "Home & DIY",
   household: "Home & DIY",
-  // other/misc
-  misc: "Other",
-  miscellaneous: "Other",
-  other: "Other",
-  everyday: "Other",
-  general: "Other",
-  education: "Other",
-  science: "Other",
+  // everyday & misc
+  misc: "Everyday & Misc",
+  miscellaneous: "Everyday & Misc",
+  other: "Everyday & Misc",
+  everyday: "Everyday & Misc",
+  general: "Everyday & Misc",
+  education: "Everyday & Misc",
+  science: "Everyday & Misc",
 };
 
 // Utility to safely parse JSON with fallback.
@@ -123,7 +123,8 @@ function titleize(slug) {
   const toPublish = backlog.slice(0, limit);
   for (const calc of toPublish) {
     const rawCluster = (calc.cluster || "").toString().toLowerCase();
-    const normCluster = CATEGORY_MAP[rawCluster] || calc.cluster || "Other";
+    const normCluster =
+      CATEGORY_MAP[rawCluster] || calc.cluster || "Everyday & Misc";
     const related = pickRelated(calc, items);
     const schema = {
       slug: calc.slug,

--- a/scripts/generate_calcs.ts
+++ b/scripts/generate_calcs.ts
@@ -65,14 +65,14 @@ const CATEGORY_MAP: Record<string, string> = {
   "home and diy": "Home & DIY",
   diy: "Home & DIY",
   household: "Home & DIY",
-  // other/misc
-  misc: "Other",
-  miscellaneous: "Other",
-  other: "Other",
-  everyday: "Other",
-  general: "Other",
-  education: "Other",
-  science: "Other",
+  // everyday & misc
+  misc: "Everyday & Misc",
+  miscellaneous: "Everyday & Misc",
+  other: "Everyday & Misc",
+  everyday: "Everyday & Misc",
+  general: "Everyday & Misc",
+  education: "Everyday & Misc",
+  science: "Everyday & Misc",
 };
 
 // Safely parse a JSON file, returning a fallback value on error.  This
@@ -137,9 +137,10 @@ function titleize(slug: string): string {
 
   for (const calc of toPublish) {
     // Normalise the cluster using CATEGORY_MAP.  Fall back to the original
-    // cluster or 'Other' if nothing matches.
+    // cluster or 'Everyday & Misc' if nothing matches.
     const rawCluster = (calc.cluster || "").toString().toLowerCase();
-    const normCluster = CATEGORY_MAP[rawCluster] || calc.cluster || "Other";
+    const normCluster =
+      CATEGORY_MAP[rawCluster] || calc.cluster || "Everyday & Misc";
     // Determine related calculators ahead of time.
     const related = pickRelated(calc, items);
     // Build a runtime schema used by the Calculator component.  Provide

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -50,10 +50,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           <a href="/technology">Technology</a>
           <a href="/date-time">Date &amp; Time</a>
           <a href="/home-diy">Home &amp; DIY</a>
-          {/* Route for miscellaneous calculators.  Historically this page was
-              called `everyday`, but has been renamed to `other` to match the
-              unified category list. */}
-          <a href="/other">Other</a>
+          {/* Route for general calculators. The slug remains `/other` but the
+              category is displayed as Everyday & Misc for consistency. */}
+          <a href="/other">Everyday &amp; Misc</a>
           <a href="/all">All</a>
         </nav>
       </div>

--- a/src/pages/calculators/fuel-trip-cost.mdx
+++ b/src/pages/calculators/fuel-trip-cost.mdx
@@ -4,47 +4,48 @@ title: "Fuel Trip Cost"
 description: "Estimate fuel trip cost."
 date: 2025-08-26
 updated: 2025-08-26
-cluster: "Other"
+cluster: "Everyday & Misc"
 ---
-import Calculator from '../../components/Calculator.astro';
+
+import Calculator from "../../components/Calculator.astro";
 
 export const schema = {
-  "slug": "fuel-trip-cost",
-  "title": "Fuel Trip Cost",
-  "locale": "en",
-  "inputs": [
+  slug: "fuel-trip-cost",
+  title: "Fuel Trip Cost",
+  locale: "en",
+  inputs: [
     {
-      "name": "distance",
-      "hint": "Distance (km)"
+      name: "distance",
+      hint: "Distance (km)",
     },
     {
-      "name": "consumption",
-      "hint": "Consumption (L/100km)"
+      name: "consumption",
+      hint: "Consumption (L/100km)",
     },
     {
-      "name": "price",
-      "hint": "Price per L ($)"
-    }
+      name: "price",
+      hint: "Price per L ($)",
+    },
   ],
-  "expression": "(distance*consumption/100)*price",
-  "intro": "Estimate fuel trip cost.",
-  "examples": [
+  expression: "(distance*consumption/100)*price",
+  intro: "Estimate fuel trip cost.",
+  examples: [
     {
-      "description": "Enter the values and press Calculate."
-    }
+      description: "Enter the values and press Calculate.",
+    },
   ],
-  "faqs": [],
-  "disclaimer": "Educational information, not professional advice.",
-  "cluster": "Other",
-  "related": [
+  faqs: [],
+  disclaimer: "Educational information, not professional advice.",
+  cluster: "Everyday & Misc",
+  related: [
     "percentage-discount-calculator",
     "loan-payment-calculator",
     "compound-interest-calculator",
     "bmi-calculator",
     "percentage-increase-calculator",
-    "sales-tax-calculator"
-  ]
-}
+    "sales-tax-calculator",
+  ],
+};
 
 # Fuel Trip Cost
 
@@ -64,4 +65,3 @@ Estimate fuel trip cost.
 - [Bmi Calculator](/calculators/bmi-calculator/)
 - [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
 - [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/grade-average.mdx
+++ b/src/pages/calculators/grade-average.mdx
@@ -3,59 +3,59 @@ layout: ../../layouts/CalculatorLayout.astro
 title: "Grade Average"
 description: "Compute the average from three test scores."
 updated: "2025-08-26"
-cluster: "Other"
+cluster: "Everyday & Misc"
 ---
 
-import Calculator from '../../components/Calculator.astro';
+import Calculator from "../../components/Calculator.astro";
 
 export const schema = {
-  "inputs": [
+  inputs: [
     {
-      "name": "a",
-      "label": "Score A",
-      "type": "number",
-      "min": 0,
-      "max": 100,
-      "step": "any",
-      "placeholder": "80"
+      name: "a",
+      label: "Score A",
+      type: "number",
+      min: 0,
+      max: 100,
+      step: "any",
+      placeholder: "80",
     },
     {
-      "name": "b",
-      "label": "Score B",
-      "type": "number",
-      "min": 0,
-      "max": 100,
-      "step": "any",
-      "placeholder": "90"
+      name: "b",
+      label: "Score B",
+      type: "number",
+      min: 0,
+      max: 100,
+      step: "any",
+      placeholder: "90",
     },
     {
-      "name": "c",
-      "label": "Score C",
-      "type": "number",
-      "min": 0,
-      "max": 100,
-      "step": "any",
-      "placeholder": "70"
-    }
+      name: "c",
+      label: "Score C",
+      type: "number",
+      min: 0,
+      max: 100,
+      step: "any",
+      placeholder: "70",
+    },
   ],
-  "slug": "grade-average",
-  "title": "Grade Average",
-  "locale": "en",
-  "expression": "(a + b + c) / 3",
-  "intro": "Compute the average from three test scores.",
-  "examples": [
+  slug: "grade-average",
+  title: "Grade Average",
+  locale: "en",
+  expression: "(a + b + c) / 3",
+  intro: "Compute the average from three test scores.",
+  examples: [
     {
-      "description": "80, 90, 70 \u21d2 80"
-    }
+      description: "80, 90, 70 \u21d2 80",
+    },
   ],
-  "faqs": [
+  faqs: [
     {
-      "question": "Weighted average?",
-      "answer": "This tool uses a simple mean (unweighted)."
-    }
+      question: "Weighted average?",
+      answer: "This tool uses a simple mean (unweighted).",
+    },
   ],
-  "disclaimer": "Educational purposes only. Not professional advice.",
-  "cluster": "Other"
-}
+  disclaimer: "Educational purposes only. Not professional advice.",
+  cluster: "Everyday & Misc",
+};
 
 <Calculator schema={schema} />

--- a/src/pages/calculators/tip-calculator.mdx
+++ b/src/pages/calculators/tip-calculator.mdx
@@ -4,43 +4,44 @@ title: "Tip Calculator"
 description: "Calculate tip amount."
 date: 2025-08-26
 updated: 2025-08-26
-cluster: "Other"
+cluster: "Everyday & Misc"
 ---
-import Calculator from '../../components/Calculator.astro';
+
+import Calculator from "../../components/Calculator.astro";
 
 export const schema = {
-  "slug": "tip-calculator",
-  "title": "Tip Calculator",
-  "locale": "en",
-  "inputs": [
+  slug: "tip-calculator",
+  title: "Tip Calculator",
+  locale: "en",
+  inputs: [
     {
-      "name": "bill",
-      "hint": "Bill ($)"
+      name: "bill",
+      hint: "Bill ($)",
     },
     {
-      "name": "tip",
-      "hint": "Tip (%)"
-    }
+      name: "tip",
+      hint: "Tip (%)",
+    },
   ],
-  "expression": "bill*tip/100",
-  "intro": "Calculate tip amount.",
-  "examples": [
+  expression: "bill*tip/100",
+  intro: "Calculate tip amount.",
+  examples: [
     {
-      "description": "Enter the values and press Calculate."
-    }
+      description: "Enter the values and press Calculate.",
+    },
   ],
-  "faqs": [],
-  "disclaimer": "Educational information, not professional advice.",
-  "cluster": "Other",
-  "related": [
+  faqs: [],
+  disclaimer: "Educational information, not professional advice.",
+  cluster: "Everyday & Misc",
+  related: [
     "percentage-discount-calculator",
     "loan-payment-calculator",
     "compound-interest-calculator",
     "bmi-calculator",
     "percentage-increase-calculator",
-    "sales-tax-calculator"
-  ]
-}
+    "sales-tax-calculator",
+  ],
+};
 
 # Tip Calculator
 
@@ -60,4 +61,3 @@ Calculate tip amount.
 - [Bmi Calculator](/calculators/bmi-calculator/)
 - [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
 - [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -12,14 +12,14 @@ export async function getStaticPaths() {
   // one of the listed aliases will be grouped into the corresponding
   // category page.
   const CATEGORIES = [
-    { slug: 'finance',     map: ['finance','finance & loans','taxes','business','business & commerce','percentages & ratios'] },
-    { slug: 'health',      map: ['health','health & fitness','bmi'] },
-    { slug: 'conversions', map: ['conversions','unit conversions','unit and currency conversions'] },
-    { slug: 'math',        map: ['math','geometry','geometry & math','areas & volumes','algebra','percentages & ratios','statistics','averages and probabilities'] },
-    { slug: 'technology',  map: ['technology','tech','computing','technology & computing'] },
-    { slug: 'date-time',   map: ['date & time','time & date','time-date','durations and schedules'] },
-    { slug: 'home-diy',    map: ['home & diy','home and diy','diy','household'] },
-    { slug: 'other',       map: ['other','misc','miscellaneous','everyday','everyday & misc','general'] }
+    { slug: 'finance',     title: 'Finance',          map: ['finance','finance & loans','taxes','business','business & commerce','percentages & ratios'] },
+    { slug: 'health',      title: 'Health',           map: ['health','health & fitness','bmi'] },
+    { slug: 'conversions', title: 'Conversions',      map: ['conversions','unit conversions','unit and currency conversions'] },
+    { slug: 'math',        title: 'Math',             map: ['math','geometry','geometry & math','areas & volumes','algebra','percentages & ratios','statistics','averages and probabilities'] },
+    { slug: 'technology',  title: 'Technology',       map: ['technology','tech','computing','technology & computing'] },
+    { slug: 'date-time',   title: 'Date & Time',      map: ['date & time','time & date','time-date','durations and schedules'] },
+    { slug: 'home-diy',    title: 'Home & DIY',       map: ['home & diy','home and diy','diy','household'] },
+    { slug: 'other',       title: 'Everyday & Misc',  map: ['other','misc','miscellaneous','everyday','everyday & misc','general'] }
   ];
 
   // 2) Lee calculators.json en build
@@ -55,9 +55,9 @@ export async function getStaticPaths() {
 const { cat, list = [] } = Astro.props;
 ---
 
-<BaseLayout title={`${cat.slug} calculators`} description={`Browse ${cat.slug} calculators`}>
+<BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.slug} Calculators</h1>
+    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -16,7 +16,7 @@ const CATEGORIES = [
   { slug: 'technology',  title: 'Technology',  desc: 'Computing and tech topics',            icon: 'algebra' },
   { slug: 'date-time',   title: 'Date & Time', desc: 'Schedules and durations',              icon: 'time-date' },
   { slug: 'home-diy',    title: 'Home & DIY',  desc: 'Household projects and DIY',           icon: 'business' },
-  { slug: 'other',       title: 'Other',       desc: 'Everyday & misc calculators',          icon: 'statistics' }
+  { slug: 'other',       title: 'Everyday & Misc',       desc: 'Everyday & misc calculators',          icon: 'statistics' }
 ];
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -1,10 +1,10 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-// Education calculators have been merged into the miscellaneous category.  We
-// reuse the Other page implementation here so visitors are directed to the
+// Education calculators have been merged into the everyday & misc category.
+// Reuse the shared page implementation so visitors are directed to the
 // correct list.  See `src/pages/other.astro` for details.
 const slug = "other";
-const title = "Other Calculators";
+const title = "Everyday & Misc Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter || {} }));
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);

--- a/src/pages/everyday.astro
+++ b/src/pages/everyday.astro
@@ -1,10 +1,10 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 const slug = "other";
-const title = "Other Calculators";
+const title = "Everyday & Misc Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter || {} }));
-const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "other");
+const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
   <main class="container mx-auto px-4 py-10">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
  * `title`, a short `desc` and an `icon` file stored under `/public/icons/`.
  * For some topics we reuse the closest existing icon (e.g. `geometry.svg` for
  * Math, `algebra.svg` for Technology, `business.svg` for Home & DIY and
- * `statistics.svg` for Other).
+ * `statistics.svg` for Everyday & Misc).
  */
 const CATEGORIES = [
   { slug: 'finance',     title: 'Finance',     desc: 'Loans, interest, ROI, taxes',          icon: 'finance' },
@@ -18,7 +18,7 @@ const CATEGORIES = [
   { slug: 'technology',  title: 'Technology',  desc: 'Computing and tech topics',            icon: 'algebra' },
   { slug: 'date-time',   title: 'Date & Time', desc: 'Schedules and durations',              icon: 'time-date' },
   { slug: 'home-diy',    title: 'Home & DIY',  desc: 'Household projects and DIY',           icon: 'business' },
-  { slug: 'other',       title: 'Other',       desc: 'Everyday & misc calculators',          icon: 'statistics' }
+  { slug: 'other',       title: 'Everyday & Misc',       desc: 'Everyday & misc calculators',          icon: 'statistics' }
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -5,12 +5,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 // calculators whose `cluster` (category) is lower‑cased to `other`.  If no
 // calculators are available a placeholder message is shown.
 const slug = "other";
-const title = "Other Calculators";
+const title = "Everyday & Misc Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter || {} }));
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
-<BaseLayout title={title} description={`Browse ${slug} calculators`}>
+<BaseLayout title={title} description="Browse everyday & misc calculators">
   <section class="hero container mx-auto max-w-5xl px-4">
     <h1 style="color: var(--ink)">{title}</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>

--- a/src/pages/science.astro
+++ b/src/pages/science.astro
@@ -1,9 +1,9 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-// Science calculators have been merged into the miscellaneous category.  Use
-// the `other` slug to display them.
+// Science calculators have been merged into the everyday & misc category.
+// Use the `other` slug to display them.
 const slug = "other";
-const title = "Other Calculators";
+const title = "Everyday & Misc Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter || {} }));
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);


### PR DESCRIPTION
## Summary
- rename "Other" category to "Everyday & Misc" across navigation, category listings, and individual calculators
- update generator mappings and data to normalize everyday/misc calculators
- adjust dynamic category page to support display titles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b1f901913c8321bdc37e649f9273ec