### PR TITLE
Simplify top navigation menu

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,17 +43,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
       <div class="header-inner">
         <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
         <nav class="nav" aria-label="Primary">
-          <a href="/finance">Finance</a>
-          <a href="/health">Health</a>
-          <a href="/math">Math</a>
-          <a href="/conversions">Conversions</a>
-          <a href="/technology">Technology</a>
-          <a href="/date-time">Date &amp; Time</a>
-          <a href="/home-diy">Home &amp; DIY</a>
-          {/* Route for general calculators. The slug remains `/other` but the
-              category is displayed as Everyday & Misc for consistency. */}
-          <a href="/other">Everyday &amp; Misc</a>
-          <a href="/all">All</a>
+          <a href="/">Home</a>
+          <a href="/categories/">Categories</a>
+          <a href="/all">All Calculators</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- show only Home, Categories, and All Calculators in top navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b2f2a1b5ec83218a3bc1fb5b0ea5cd