### PR TITLE
Show ad banner below page titles

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -3,6 +3,7 @@
   - Simplificado: usa atributos data-* para pasar slug y expression.
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
+import AdBanner from './AdBanner.astro';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
 const slug = schema?.slug ?? 'calculator';
@@ -40,6 +41,7 @@ const jsonLd = {
 <section class="calc" data-calculator data-slug={slug} data-exp={expression} aria-labelledby={`h-${slug}`}>
   <h1 id={`h-${slug}`}>{title}</h1>
   {intro && <p class="muted">{intro}</p>}
+  <AdBanner />
 
   <form data-role="form" onsubmit="compute(); return false">
     {inputs.map((i) => (

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter || {} }));
 ---
@@ -8,6 +9,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
     <h1 style="color: var(--ink)">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
+  <AdBanner />
   <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="list-all">
     <h2 id="list-all" class="sr-only">All calculators list</h2>
     <!-- Use a responsive Tailwind grid for consistent card sizes across breakpoints -->

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdBanner from '../../components/AdBanner.astro';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -60,6 +61,8 @@ const { cat, list = [] } = Astro.props;
     <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
+
+  <AdBanner />
 
   {list.length === 0 ? (
     <p class="section container mx-auto max-w-5xl px-4">No calculators yet in this category.</p>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdBanner from '../../components/AdBanner.astro';
 
 /*
  * Provide the same normalised list of categories as the home page.  Each
@@ -24,6 +25,8 @@ const CATEGORIES = [
     <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
+
+  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "conversions";
 const title = "Conversions Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversions");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "date-time";
 const title = "Date & Time Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & time");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 // Education calculators have been merged into the everyday & misc category.
 // Reuse the shared page implementation so visitors are directed to the
 // correct list.  See `src/pages/other.astro` for details.
@@ -10,9 +11,10 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
-  <main class="container mx-auto px-4 py-10">
-    <h1 class="text-3xl font-bold">{title}</h1>
-    {list.length ? (
+    <main class="container mx-auto px-4 py-10">
+      <h1 class="text-3xl font-bold">{title}</h1>
+      <AdBanner />
+      {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
           <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">

--- a/src/pages/everyday.astro
+++ b/src/pages/everyday.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "other";
 const title = "Everyday & Misc Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,9 +8,10 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
-  <main class="container mx-auto px-4 py-10">
-    <h1 class="text-3xl font-bold">{title}</h1>
-    {list.length ? (
+    <main class="container mx-auto px-4 py-10">
+      <h1 class="text-3xl font-bold">{title}</h1>
+      <AdBanner />
+      {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
           <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "finance";
 const title = "Finance Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -14,11 +15,12 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     calculators in a responsive grid of cards or show a friendly
     placeholder when the list is empty.
   */}
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "health";
 const title = "Health Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "home-diy";
 const title = "Home & DIY Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & diy");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import AdBanner from '../components/AdBanner.astro';
 
 /*
  * The home page lists eight high‑level calculator categories.  To avoid
@@ -30,6 +31,8 @@ const CATEGORIES = [
       Calculate anything quickly and easily with our collection of online calculators.
     </p>
   </section>
+
+  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <h2 class="sr-only">Categories</h2>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "math";
 const title = "Math Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 // This page lists calculators that do not fit into another major category.
 // The slug is `other` and it reads all available MDX files, filtering
 // calculators whose `cluster` (category) is lower‑cased to `other`.  If no
@@ -11,11 +12,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 

--- a/src/pages/science.astro
+++ b/src/pages/science.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 // Science calculators have been merged into the everyday & misc category.
 // Use the `other` slug to display them.
 const slug = "other";
@@ -9,9 +10,10 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
-  <main class="container mx-auto px-4 py-10">
-    <h1 class="text-3xl font-bold">{title}</h1>
-    {list.length ? (
+    <main class="container mx-auto px-4 py-10">
+      <h1 class="text-3xl font-bold">{title}</h1>
+      <AdBanner />
+      {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
           <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
 const slug = "technology";
 const title = "Technology Calculators";
 const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
@@ -7,11 +8,12 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technology");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
-  <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">{title}</h1>
-    <p style="color: var(--muted)">Explore calculators in this category.</p>
-  </section>
-  {list.length === 0 ? (
+    <section class="hero container mx-auto max-w-5xl px-4">
+      <h1 style="color: var(--ink)">{title}</h1>
+      <p style="color: var(--muted)">Explore calculators in this category.</p>
+    </section>
+    <AdBanner />
+    {list.length === 0 ? (
     <p class="section"><em>No calculators available in this category.</em></p>
   ) : (
     <section class="section container mx-auto max-w-5xl px-4" aria-labelledby={`list-${slug}`}> 


### PR DESCRIPTION
## Summary
- Display AdBanner below the main heading on the homepage and category pages.
- Inject AdBanner beneath calculator titles for all calculator pages.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b3142e64b483219ea80d562a5ab7f2