### PR TITLE
feat: auto-generate calculators by category

### DIFF
--- a/.github/workflows/manual-category.yml
+++ b/.github/workflows/manual-category.yml
@@ -1,0 +1,58 @@
+name: Manual category calculator publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      category:
+        description: 'Category for the calculator'
+        required: true
+        type: choice
+        options:
+          - Finance
+          - Health
+          - Conversions
+          - Math
+          - Technology
+          - Date & Time
+          - Home & DIY
+          - Everyday & Misc
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      MAX_PER_DAY: 1
+      CATEGORY: ${{ inputs.category }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Ensure required files
+        run: |
+          mkdir -p src/pages/calculators meta
+          [ -f meta/publish_log.json ] || echo '[]' > meta/publish_log.json
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Generate calculator
+        run: npm run generate
+
+      - name: Commit and push
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add src/pages/calculators meta/publish_log.json || true
+          if git diff --cached --quiet; then
+            echo 'No new calculator generated.'
+          else
+            git commit -m "chore: publish calculator for ${CATEGORY}"
+            git push || true
+          fi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "generate": "node scripts/generate_calcs.js",
+    "generate": "node scripts/generate_random_calc.js",
     "format": "prettier --write .",
     "generate:all": "MAX_PER_DAY=100 node scripts/generate_calcs_v2.js"
   },

--- a/scripts/generate_random_calc.js
+++ b/scripts/generate_random_calc.js
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const OUT_DIR = path.join(ROOT, "src", "pages", "calculators");
+const LOG_PATH = path.join(ROOT, "meta", "publish_log.json");
+
+function readJSON(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function writeJSON(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), "utf-8");
+}
+
+const category = process.env.CATEGORY || "Everyday & Misc";
+const today = new Date().toISOString().slice(0, 10);
+const log = readJSON(LOG_PATH);
+const slugBase = category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+const existingCount = log.filter((r) => r.slug.startsWith(`${slugBase}-calc-`)).length;
+const index = existingCount + 1;
+const slug = `${slugBase}-calc-${index}`;
+const title = `${category} Calculator ${index}`;
+
+// Create random expression with 2-3 variables
+const varNames = ["x", "y", "z", "w"];
+const ops = ["+", "-", "*", "/"];
+const varCount = 2 + Math.floor(Math.random() * 2); // 2 or 3 vars
+const inputs = varNames.slice(0, varCount).map((n) => ({
+  name: n,
+  label: n.toUpperCase(),
+  type: "number",
+}));
+let expression = inputs[0].name;
+for (let i = 1; i < inputs.length; i++) {
+  const op = ops[Math.floor(Math.random() * ops.length)];
+  expression += ` ${op} ${inputs[i].name}`;
+}
+
+const exampleDesc = inputs
+  .map((inp, i) => `${inp.label}=${i + 1}`)
+  .join(", ");
+
+const schema = {
+  slug,
+  title,
+  locale: "en",
+  inputs,
+  expression,
+  intro: `Auto-generated calculator for ${category}.`,
+  examples: [{ description: exampleDesc }],
+  faqs: [],
+  disclaimer: "Educational use only.",
+  cluster: category,
+  related: [],
+};
+
+const frontmatter = [
+  "---",
+  "layout: ../../layouts/CalculatorLayout.astro",
+  `title: ${JSON.stringify(title)}`,
+  `description: ${JSON.stringify(schema.intro)}`,
+  `date: ${today}`,
+  `updated: ${today}`,
+  `cluster: ${JSON.stringify(category)}`,
+  "---\n",
+].join("\n");
+
+let body = "";
+body += "import Calculator from '../../components/Calculator.astro';\n\n";
+body += `export const schema = ${JSON.stringify(schema, null, 2)}\n\n`;
+body += "<Calculator schema={schema} />\n\n";
+if (schema.examples && schema.examples.length) {
+  body += "## Examples\n\n";
+  schema.examples.forEach((ex) => {
+    body += `- ${ex.description}\n`;
+  });
+  body += "\n";
+}
+
+const content = frontmatter + body;
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+fs.writeFileSync(path.join(OUT_DIR, `${slug}.mdx`), content, "utf-8");
+
+log.push({ slug, date: today });
+writeJSON(LOG_PATH, log);
+
+console.log(`Generated ${slug}`);


### PR DESCRIPTION
## Summary
- auto-generate a calculator per selected category with random inputs and expression
- streamline manual workflow to only prepare needed paths and commit generated files
- point `npm run generate` at the new generator script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b347f2787c8321982282a720632762