### PR TITLE
feat: invent calculators via manual workflow

### DIFF
--- a/.github/workflows/manual-category.yml
+++ b/.github/workflows/manual-category.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       category:
-        description: 'Category for the calculator'
+        description: "Category for the calculator"
         required: true
         type: choice
         options:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Ensure required files
         run: |
@@ -43,7 +43,7 @@ jobs:
         run: npm install --no-audit --no-fund
 
       - name: Generate calculator
-        run: npm run generate
+        run: npm run generate:invent
 
       - name: Commit and push
         run: |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "generate": "node scripts/generate_calcs.js",
+    "generate:invent": "node scripts/invent_calculator.js",
     "format": "prettier --write .",
     "generate:all": "MAX_PER_DAY=100 node scripts/generate_calcs_v2.js"
   },

--- a/scripts/invent_calculator.js
+++ b/scripts/invent_calculator.js
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const outDir = path.join(root, "src", "pages", "calculators");
+const logPath = path.join(root, "meta", "publish_log.json");
+const category = process.env.CATEGORY || "Everyday & Misc";
+
+// Basic random operation generator
+const ops = [
+  { symbol: "+", name: "Addition", example: { a: 2, b: 3, result: 5 } },
+  { symbol: "-", name: "Subtraction", example: { a: 5, b: 2, result: 3 } },
+  { symbol: "*", name: "Multiplication", example: { a: 4, b: 2, result: 8 } },
+  { symbol: "/", name: "Division", example: { a: 8, b: 4, result: 2 } },
+];
+const op = ops[Math.floor(Math.random() * ops.length)];
+
+const safeCategory = category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+const slug = `${safeCategory}-${op.name.toLowerCase()}-${Date.now()}`;
+const title = `${op.name} Calculator`;
+const today = new Date().toISOString().slice(0, 10);
+
+const schema = {
+  slug,
+  title,
+  locale: "en",
+  inputs: [
+    { label: "Value A", name: "a", type: "number" },
+    { label: "Value B", name: "b", type: "number" },
+  ],
+  expression: `a ${op.symbol} b`,
+  intro: `Performs ${op.name.toLowerCase()} in the ${category} category.`,
+  examples: [
+    {
+      description: `${op.example.a} ${op.symbol} ${op.example.b} = ${op.example.result}`,
+    },
+  ],
+  faqs: [],
+  disclaimer: "Educational information, not professional advice.",
+  cluster: category,
+  related: [],
+};
+
+const frontmatter = `---\nlayout: ../../layouts/CalculatorLayout.astro\ntitle: ${JSON.stringify(
+  title,
+)}\ndescription: ${JSON.stringify(
+  schema.intro,
+)}\ndate: ${today}\nupdated: ${today}\ncluster: ${JSON.stringify(
+  category,
+)}\n---\n`;
+
+const body = `import Calculator from '../../components/Calculator.astro';\n\nexport const schema = ${JSON.stringify(
+  schema,
+  null,
+  2,
+)}\n\n<Calculator schema={schema} />\n`;
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(path.join(outDir, `${slug}.mdx`), frontmatter + body, "utf8");
+
+const log = fs.existsSync(logPath)
+  ? JSON.parse(fs.readFileSync(logPath, "utf8"))
+  : [];
+log.push({ slug, date: today });
+fs.mkdirSync(path.dirname(logPath), { recursive: true });
+fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
+
+console.log(`Invented calculator ${slug}`);


### PR DESCRIPTION
## Summary
- add `invent_calculator.js` to generate a random calculator in the requested category
- expose `generate:invent` script and use it in manual workflow

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b375ba22dc832182845ed45e817b1f