### PR TITLE
feat: invent calculators when backlog empty

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,14 +2,14 @@ name: Nightly calculator publish (V037.2 - stable)
 
 on:
   schedule:
-    - cron: '30 2 * * *'  # 02:30 UTC diario
+    - cron: "30 2 * * *" # 02:30 UTC diario
   workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # permite git push con GITHUB_TOKEN
+      contents: write # permite git push con GITHUB_TOKEN
     env:
       SITE_URL: https://calcsimpler.com
       MAX_PER_DAY: 40
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js (no cache)
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Preflight (env & tree)
         run: |
@@ -102,7 +102,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add src/pages/calculators meta/publish_log.json || true
+          git add src/pages/calculators meta/publish_log.json data/calculators.json || true
           if git diff --cached --quiet; then
             echo 'No new calculators to commit.'
           else

--- a/scripts/generate_calcs.js
+++ b/scripts/generate_calcs.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execSync } from "node:child_process";
 
 /**
  * Advanced calculator generator (plain JS)
@@ -120,9 +121,12 @@ function titleize(slug) {
   if (!backlog.length) {
     console.log(
       categoryFilter
-        ? `No new calculators to generate for category ${categoryFilter}`
-        : "No new calculators to generate",
+        ? `No new calculators to generate for category ${categoryFilter}; inventing one`
+        : "No new calculators to generate; inventing one",
     );
+    execSync(`node ${path.join(ROOT, "scripts", "invent_calculator.js")}`, {
+      stdio: "inherit",
+    });
     return;
   }
   const rawMax = parseInt(


### PR DESCRIPTION
## Summary
- auto-create a calculator when generator backlog is empty
- commit data/calculators.json in nightly workflow

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b3cbc249748321a60b7309d5f59ec2