### PR TITLE
feat: enrich calculator template with examples and related sections

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
 const slug = schema?.slug ?? 'calculator';
@@ -11,16 +12,40 @@ const inputs = Array.isArray(schema?.inputs) ? schema.inputs : [];
 const intro = schema?.intro ?? '';
 const expression = schema?.expression ?? schema?.formula ?? schema?.formula_expression ?? '';
 
+const examples = Array.isArray(schema?.examples) && schema.examples.length
+  ? schema.examples
+  : [{ description: 'Enter the values and press Calculate.' }];
+const faqs = Array.isArray(schema?.faqs) && schema.faqs.length
+  ? schema.faqs
+  : [{
+      question: 'How do I use this calculator?',
+      answer: 'Enter the required values and press Calculate to get the result.'
+    }];
+
+function pickRelated(slug: string, cluster: string): string[] {
+  const same = allCalcs.filter(
+    (c) => c.slug !== slug && c.cluster && c.cluster.toLowerCase() === (cluster || '').toLowerCase()
+  );
+  const pool = same.length >= 6 ? same : allCalcs.filter((c) => c.slug !== slug);
+  return pool.slice(0, 6).map((c) => c.slug);
+}
+
+const related = Array.isArray(schema?.related) && schema.related.length
+  ? schema.related
+  : pickRelated(slug, schema?.cluster);
+
+function titleize(s: string): string {
+  return s.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 // Build Schema.org data for the calculator including FAQs when available.
 const site = Astro.site?.toString() || (import.meta.env.SITE_URL ?? 'https://example.com');
 const url  = new URL(Astro.url.pathname, site).toString();
-const faqEntities = Array.isArray(schema?.faqs)
-  ? schema.faqs.map((q) => ({
-      '@type': 'Question',
-      name: q.question,
-      acceptedAnswer: { '@type': 'Answer', text: q.answer }
-    }))
-  : [];
+const faqEntities = faqs.map((q) => ({
+  '@type': 'Question',
+  name: q.question,
+  acceptedAnswer: { '@type': 'Answer', text: q.answer }
+}));
 const jsonLd = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -33,7 +58,7 @@ const jsonLd = {
       description: intro,
       offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' }
     },
-    ...(faqEntities.length ? [{ '@type': 'FAQPage', mainEntity: faqEntities }] : [])
+    { '@type': 'FAQPage', mainEntity: faqEntities }
   ]
 };
 ---
@@ -69,17 +94,33 @@ const jsonLd = {
   <script type="application/json" data-schema set:html={JSON.stringify(schema)}></script>
 </section>
 
-{Array.isArray(schema?.faqs) && schema.faqs.length > 0 && (
-  <section class="faq">
-    <h2>FAQ</h2>
-    {schema.faqs.map((f) => (
-      <details>
-        <summary>{f.question}</summary>
-        <p>{f.answer}</p>
-      </details>
+<section class="examples">
+  <h2>Examples</h2>
+  <ul>
+    {examples.map((ex) => (
+      <li>{ex.description}</li>
     ))}
-  </section>
-)}
+  </ul>
+</section>
+
+<section class="faq">
+  <h2>FAQ</h2>
+  {faqs.map((f) => (
+    <details>
+      <summary>{f.question}</summary>
+      <p>{f.answer}</p>
+    </details>
+  ))}
+</section>
+
+<section class="related">
+  <h2>Related calculators</h2>
+  <ul>
+    {related.map((r) => (
+      <li><a href={`/calculators/${r}/`}>{titleize(r)}</a></li>
+    ))}
+  </ul>
+</section>
 
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 
@@ -109,10 +150,14 @@ const jsonLd = {
   }
   .btn:hover{ filter:brightness(1.05); }
   .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
+  .examples { margin-top: 24px; }
+  .examples ul { margin: 8px 0 0 20px; }
   .faq { margin-top: 24px; }
   .faq details { margin: 8px 0; }
   .faq summary { cursor: pointer; font-weight: 600; }
   .faq p { margin: 4px 0 0 16px; }
+  .related { margin-top: 24px; }
+  .related ul { margin: 8px 0 0 20px; }
 </style>
 
 

--- a/src/pages/calculators/calories-burned-met.mdx
+++ b/src/pages/calculators/calories-burned-met.mdx
@@ -63,27 +63,4 @@ export const schema = {
   ],
 };
 
-# Calories Burned (MET) Calculator
-
-Estimate calories burned using MET, weight, and duration.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Jogging at MET 7, 70 kg, 30 minutes → about 257 kcal
-
-## FAQ
-
-### What is a MET?
-
-A MET is a unit that estimates energy cost of physical activities.
-
-## Related calculators
-
-- [BMI Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Daily Water Intake](/calculators/daily-water-intake/)
-- [Waist To Height Ratio](/calculators/waist-to-height-ratio/)
-- [Weight To BMI Projection Calculator](/calculators/weight-to-bmi-projection-calculator/)
-- [Kg To Lb Calculator](/calculators/kg-to-lb-calculator/)

--- a/src/pages/calculators/concrete-slab-volume.mdx
+++ b/src/pages/calculators/concrete-slab-volume.mdx
@@ -46,22 +46,4 @@ export const schema = {
   ]
 }
 
-# Concrete Slab Volume
-
-Volume for a slab in cubic meters.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/daily-water-intake.mdx
+++ b/src/pages/calculators/daily-water-intake.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# Daily Water Intake Calculator
-
-Rough estimate of daily water intake from body weight.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 75 kg → ~2.48 liters/day
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/data-transfer-time.mdx
+++ b/src/pages/calculators/data-transfer-time.mdx
@@ -45,21 +45,4 @@ export const schema = {
   ],
 };
 
-# Data Transfer Time Calculator
-
-Estimate time to transfer data over a connection speed.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 700 MB at 20 Mbps → ~4.67 minutes
-
-## Related calculators
-
-- [Download Time Calculator](/calculators/download-time/)
-- [Download Cost Calculator](/calculators/download-cost/)
-- [KB To MB](/calculators/kb-to-mb/)
-- [DPI Calculator](/calculators/dpi-calculator/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Time To Seconds Calculator](/calculators/time-to-seconds-calculator/)

--- a/src/pages/calculators/days-to-hours.mdx
+++ b/src/pages/calculators/days-to-hours.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# Days to Hours Calculator
-
-Convert days to hours.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/download-cost.mdx
+++ b/src/pages/calculators/download-cost.mdx
@@ -45,21 +45,4 @@ export const schema = {
   ],
 };
 
-# Download Cost Calculator
-
-Estimate download cost from data size and price per GB.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 10 GB at $0.10/GB → $1
-
-## Related calculators
-
-- [Download Time Calculator](/calculators/download-time/)
-- [Data Transfer Time Calculator](/calculators/data-transfer-time/)
-- [KB To MB](/calculators/kb-to-mb/)
-- [DPI Calculator](/calculators/dpi-calculator/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Time To Seconds Calculator](/calculators/time-to-seconds-calculator/)

--- a/src/pages/calculators/dpi-calculator.mdx
+++ b/src/pages/calculators/dpi-calculator.mdx
@@ -45,21 +45,4 @@ export const schema = {
   ],
 };
 
-# DPI Calculator
-
-Dots per inch from pixels and inches.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 3000 px across 10 inches → 300 DPI
-
-## Related calculators
-
-- [Download Time Calculator](/calculators/download-time/)
-- [Download Cost Calculator](/calculators/download-cost/)
-- [Data Transfer Time Calculator](/calculators/data-transfer-time/)
-- [KB To MB](/calculators/kb-to-mb/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Time To Seconds Calculator](/calculators/time-to-seconds-calculator/)

--- a/src/pages/calculators/flooring-cost.mdx
+++ b/src/pages/calculators/flooring-cost.mdx
@@ -42,22 +42,4 @@ export const schema = {
   ]
 }
 
-# Flooring Cost Calculator
-
-Estimate total floor cost.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/fuel-trip-cost.mdx
+++ b/src/pages/calculators/fuel-trip-cost.mdx
@@ -47,21 +47,4 @@ export const schema = {
   ],
 };
 
-# Fuel Trip Cost
-
-Estimate fuel trip cost.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)

--- a/src/pages/calculators/kb-to-mb.mdx
+++ b/src/pages/calculators/kb-to-mb.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# KB to MB Converter
-
-Convert kilobytes to megabytes.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 2048 KB → 2 MB
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/minutes-to-seconds.mdx
+++ b/src/pages/calculators/minutes-to-seconds.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# Minutes to Seconds Calculator
-
-Convert minutes to seconds.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/paint-needed.mdx
+++ b/src/pages/calculators/paint-needed.mdx
@@ -42,22 +42,4 @@ export const schema = {
   ]
 }
 
-# Paint Needed Calculator
-
-Estimate liters of paint required.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/tip-calculator.mdx
+++ b/src/pages/calculators/tip-calculator.mdx
@@ -43,21 +43,4 @@ export const schema = {
   ],
 };
 
-# Tip Calculator
-
-Calculate tip amount.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)

--- a/src/pages/calculators/waist-to-height-ratio.mdx
+++ b/src/pages/calculators/waist-to-height-ratio.mdx
@@ -42,22 +42,4 @@ export const schema = {
   ]
 }
 
-# Waist-to-Height Ratio Calculator
-
-Compute waist-to-height ratio (WHtR).
-
 <Calculator schema={schema} />
-
-## Examples
-
-- 80 cm waist, 170 cm height → 0.47
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/wallpaper-roll-coverage.mdx
+++ b/src/pages/calculators/wallpaper-roll-coverage.mdx
@@ -42,22 +42,4 @@ export const schema = {
   ]
 }
 
-# Wallpaper Roll Coverage
-
-Number of rolls needed.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/weeks-to-days.mdx
+++ b/src/pages/calculators/weeks-to-days.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# Weeks to Days Calculator
-
-Convert weeks to days.
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-

--- a/src/pages/calculators/years-to-days.mdx
+++ b/src/pages/calculators/years-to-days.mdx
@@ -38,22 +38,4 @@ export const schema = {
   ]
 }
 
-# Years to Days Calculator
-
-Approximate years to days (365).
-
 <Calculator schema={schema} />
-
-## Examples
-
-- Enter the values and press Calculate.
-
-## Related calculators
-
-- [Percentage Discount Calculator](/calculators/percentage-discount-calculator/)
-- [Loan Payment Calculator](/calculators/loan-payment-calculator/)
-- [Compound Interest Calculator](/calculators/compound-interest-calculator/)
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Percentage Increase Calculator](/calculators/percentage-increase-calculator/)
-- [Sales Tax Calculator](/calculators/sales-tax-calculator/)
-


### PR DESCRIPTION
## Summary
- render Examples, FAQ, and Related calculators directly in the shared Calculator component
- compute default example, FAQ, and related links for calculators without custom entries
- clean existing calculator pages to rely on the enriched template

## Testing
- `npm run build` (fails: Cannot find module 'yargs-parser')

------
https://chatgpt.com/codex/tasks/task_b_68b448533aa8832193f84bc0f40e4a1d