### PR TITLE
Align calculator sections with main content

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -150,13 +150,18 @@ const jsonLd = {
   }
   .btn:hover{ filter:brightness(1.05); }
   .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
-  .examples { margin-top: 24px; }
+  .examples,
+  .faq,
+  .related {
+    max-width: 720px;
+    margin: 24px auto 0;
+    padding: 8px;
+    color: var(--ink);
+  }
   .examples ul { margin: 8px 0 0 20px; }
-  .faq { margin-top: 24px; }
   .faq details { margin: 8px 0; }
   .faq summary { cursor: pointer; font-weight: 600; }
   .faq p { margin: 4px 0 0 16px; }
-  .related { margin-top: 24px; }
   .related ul { margin: 8px 0 0 20px; }
 </style>
 


### PR DESCRIPTION
## Summary
- Align Examples, FAQ, and Related calculators sections with the calculator title by giving them the same max width and centered margin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'yargs-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68b44c84140483218adb852a20d745e5