### PR TITLE
feat: format results with four decimals

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -220,9 +220,20 @@ const jsonLd = {
   }
 
   function fmt(n){
-    return isFinite(n)
-      ? new Intl.NumberFormat('en-US', { maximumFractionDigits: 3 }).format(n)
-      : '—';
+    if (!isFinite(n)) return '—';
+    const rounded = n.toFixed(4); // round to 4 decimals
+    let [intPart, fracPart] = rounded.split('.');
+    if (fracPart) {
+      fracPart = fracPart.replace(/0+$/, ''); // strip trailing zeros
+      if (fracPart.length === 0) {
+        return Number(intPart).toLocaleString('en-US');
+      }
+      if (fracPart.length === 3) {
+        fracPart += '0';
+      }
+      return Number(intPart).toLocaleString('en-US') + '.' + fracPart;
+    }
+    return Number(intPart).toLocaleString('en-US');
   }
   function num(v){ let n=Number(v); return isFinite(n)?n:NaN; }
 

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,6 +1,22 @@
+function formatNumber(n) {
+  const rounded = n.toFixed(4);
+  let [intPart, fracPart] = rounded.split('.');
+  if (fracPart) {
+    fracPart = fracPart.replace(/0+$/, '');
+    if (fracPart.length === 0) {
+      return intPart;
+    }
+    if (fracPart.length === 3) {
+      fracPart += '0';
+    }
+    return `${intPart}.${fracPart}`;
+  }
+  return intPart;
+}
+
 export function formatResult(value, isMoney = false, currency = "$") {
   if (typeof value === "number") {
-    let v = Number(value.toFixed(3));
+    const v = formatNumber(value);
     return isMoney ? `${currency}${v}` : v;
   }
   return value;


### PR DESCRIPTION
## Summary
- format calculator results to round to four decimals and avoid three-decimal outputs
- add shared helper for consistent decimal formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'yargs-parser')*

------
https://chatgpt.com/codex/tasks/task_b_68b712f11c6083218632b700b16b5351