### PR TITLE
Improve traditional calculator contrast and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.34.2] - 2025-09-03
+### Changed
+- Improved contrast and modern styling on the traditional calculator to enhance readability and usability.
+
 ## [0.34.1] - 2025-08-22
 ### Changed
 - Home con **8 categorías** e **iconos**.

--- a/src/pages/traditional-calculator.astro
+++ b/src/pages/traditional-calculator.astro
@@ -4,26 +4,81 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout title="Traditional Calculator" description="Perform basic arithmetic operations with this traditional calculator.">
   <div class="max-w-sm mx-auto mt-8">
-    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow">
-      <input id="display" class="w-full mb-2 p-2 border rounded text-right" readonly />
+    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-lg">
+      <input
+        id="display"
+        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100"
+        readonly
+      />
       <div class="grid grid-cols-4 gap-2">
-        <button data-value="7" class="p-2 rounded border">7</button>
-        <button data-value="8" class="p-2 rounded border">8</button>
-        <button data-value="9" class="p-2 rounded border">9</button>
-        <button data-value="/" class="p-2 rounded border">÷</button>
-        <button data-value="4" class="p-2 rounded border">4</button>
-        <button data-value="5" class="p-2 rounded border">5</button>
-        <button data-value="6" class="p-2 rounded border">6</button>
-        <button data-value="*" class="p-2 rounded border">×</button>
-        <button data-value="1" class="p-2 rounded border">1</button>
-        <button data-value="2" class="p-2 rounded border">2</button>
-        <button data-value="3" class="p-2 rounded border">3</button>
-        <button data-value="-" class="p-2 rounded border">−</button>
-        <button data-value="0" class="p-2 rounded border">0</button>
-        <button data-value="." class="p-2 rounded border">.</button>
-        <button data-value="=" class="p-2 rounded border">=</button>
-        <button data-value="+" class="p-2 rounded border">+</button>
-        <button data-value="C" class="col-span-4 p-2 rounded border bg-red-500 text-white">C</button>
+        <button
+          data-value="7"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >7</button>
+        <button
+          data-value="8"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >8</button>
+        <button
+          data-value="9"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >9</button>
+        <button
+          data-value="/"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >÷</button>
+        <button
+          data-value="4"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >4</button>
+        <button
+          data-value="5"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >5</button>
+        <button
+          data-value="6"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >6</button>
+        <button
+          data-value="*"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >×</button>
+        <button
+          data-value="1"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >1</button>
+        <button
+          data-value="2"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >2</button>
+        <button
+          data-value="3"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >3</button>
+        <button
+          data-value="-"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >−</button>
+        <button
+          data-value="0"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >0</button>
+        <button
+          data-value="."
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >.</button>
+        <button
+          data-value="="
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >=</button>
+        <button
+          data-value="+"
+          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+        >+</button>
+        <button
+          data-value="C"
+          class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold"
+        >C</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enhance traditional calculator display and buttons with high-contrast colors, hover and active states
- document styling improvement in changelog

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*
- `npm run build` *(fails: Cannot find module 'yargs-parser')*


------
https://chatgpt.com/codex/tasks/task_b_68b78d28de4c8321844fa9bfac85e91c