### PR TITLE
feat: redesign navbar with centered tabs

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,4 +1,4 @@
-:root{
+:root {
   /*
     Global colour tokens.  The default palette in the original template
     used a very dark primary colour (#0E2A47) for the header and other
@@ -16,18 +16,18 @@
     content feeling airy and modern without a dull yellow tint.
     Muted text colours are softened for improved contrast.
   */
-  --bg:#F9FAFB;
-  --surface:#FFFFFF;
-  --ink:#0F172A;
-  --muted:#64748B;
-  --primary:#2C74B3;
-  --primary-ink:#FFFFFF;
-  --card:#FFFFFF;
-  --border:#E5E7EB;
-  --shadow:0 1px 2px rgba(15,23,42,.06), 0 8px 24px rgba(15,23,42,.04);
-  --radius:14px;
-  --space:14px;
-  --maxw:1120px;
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --ink: #0f172a;
+  --muted: #64748b;
+  --primary: #2c74b3;
+  --primary-ink: #ffffff;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 8px 24px rgba(15, 23, 42, 0.04);
+  --radius: 14px;
+  --space: 14px;
+  --maxw: 1120px;
 }
 /*
   When the user prefers a dark colour scheme we override the global
@@ -45,15 +45,15 @@
       softening the muted tones.  Shadows are strengthened slightly to
       preserve depth on dark surfaces.
     */
-    --bg:#0F172A;
-    --surface:#1E293B;
-    --ink:#F1F5F9;
-    --muted:#94A3B8;
-    --primary:#2C74B3;
-    --primary-ink:#FFFFFF;
-    --card:#1E293B;
-    --border:#334155;
-    --shadow:0 1px 2px rgba(0,0,0,.6), 0 8px 24px rgba(0,0,0,.3);
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --ink: #f1f5f9;
+    --muted: #94a3b8;
+    --primary: #2c74b3;
+    --primary-ink: #ffffff;
+    --card: #1e293b;
+    --border: #334155;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -66,34 +66,133 @@
   dark backgrounds.
 */
 @media (prefers-color-scheme: dark) {
-  :root{
-    --bg:#0F172A;
-    --surface:#1F2A37;
-    --ink:#F1F5F9;
-    --muted:#94A3B8;
-    --primary:#2C74B3;
-    --primary-ink:#FFFFFF;
-    --card:#1E293B;
-    --border:#334155;
-    --shadow:0 1px 2px rgba(0,0,0,.6), 0 8px 24px rgba(0,0,0,.3);
+  :root {
+    --bg: #0f172a;
+    --surface: #1f2a37;
+    --ink: #f1f5f9;
+    --muted: #94a3b8;
+    --primary: #2c74b3;
+    --primary-ink: #ffffff;
+    --card: #1e293b;
+    --border: #334155;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
   }
 }
-html,body{background:var(--bg);color:var(--ink);
-  font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif}
-.container{max-width:var(--maxw);margin-inline:auto;padding-inline:16px}
-.header{background:var(--primary);color:var(--primary-ink);border-radius:16px;margin:16px auto 24px;max-width:var(--maxw)}
-.header a{color:var(--primary-ink);text-decoration:none}
-.header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;flex-wrap:wrap;row-gap:12px}
-.nav{display:flex;gap:18px;font-weight:500;opacity:.95;flex-wrap:wrap}
-.nav a{font-weight:700;text-transform:uppercase;font-size:125%}
-@media (max-width:640px){
-  .header-inner{justify-content:center}
-  .nav{width:100%;justify-content:center;gap:12px}
-  footer .links{gap:12px}
+html,
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Inter,
+    Arial,
+    sans-serif;
 }
-.hero{text-align:center;padding:24px 0 12px}
-.hero h1{font-size:clamp(32px,5vw,48px);line-height:1.05;letter-spacing:-.02em}
-.hero p{margin-top:8px;color:var(--muted);max-width:56ch;margin-inline:auto}
+.container {
+  max-width: var(--maxw);
+  margin-inline: auto;
+  padding-inline: 16px;
+}
+.nav[data-nav] {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: transparent;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s;
+}
+.nav[data-nav].is-scrolled {
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+.nav[data-nav] .container {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.brand {
+  text-decoration: none;
+  font-weight: 700;
+  color: var(--ink);
+}
+.brand span {
+  color: var(--primary);
+}
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin: auto;
+}
+.tab {
+  padding: 8px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+}
+.tab:is(:hover, :focus-visible) {
+  border-color: #cbd5e1;
+  color: #0f172a;
+}
+.tab.is-active {
+  background: #0f172a;
+  color: #ffffff;
+  border-color: #0f172a;
+}
+.actions .btn {
+  padding: 8px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  border: 1px solid #2563eb;
+  color: #2563eb;
+  background: transparent;
+  white-space: nowrap;
+}
+.actions .btn:hover {
+  background: #2563eb;
+  color: #fff;
+}
+@media (max-width: 640px) {
+  .nav[data-nav] .container {
+    flex-wrap: wrap;
+  }
+  .actions {
+    order: 2;
+    margin-left: auto;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .tabs {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+    overflow-x: auto;
+  }
+  footer .links {
+    gap: 12px;
+  }
+}
+.hero {
+  text-align: center;
+  padding: 24px 0 12px;
+}
+.hero h1 {
+  font-size: clamp(32px, 5vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+.hero p {
+  margin-top: 8px;
+  color: var(--muted);
+  max-width: 56ch;
+  margin-inline: auto;
+}
 /* A custom grid class used on the dynamic category pages (e.g.
    /categories/[slug]).  It defines 1–3 columns at increasing
    breakpoints and removes list markers.  We avoid the generic `.grid`
@@ -120,9 +219,15 @@ html,body{background:var(--bg);color:var(--ink);
 
 /* Reset list styling on grid lists so category pages do not show
    unwanted bullets or padding.  Each `li` is rendered as a card. */
-ul.grid{list-style:none;padding:0;margin:0}
-ul.grid li{list-style:none}
-.card{
+ul.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+ul.grid li {
+  list-style: none;
+}
+.card {
   /* Make cards fill the available width of their grid cell and stack
      text vertically.  Using display:block ensures that anchor tags
      expand to the full width of their parent container, preventing
@@ -134,10 +239,17 @@ ul.grid li{list-style:none}
   border-radius: var(--radius);
   padding: 16px;
   box-shadow: var(--shadow);
-  transition: transform .12s ease, box-shadow .12s ease;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
 }
-.card:hover{transform:translateY(-1px);box-shadow:0 2px 4px rgba(15,23,42,.08),0 10px 28px rgba(15,23,42,.06)}
-.card h3{
+.card:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 2px 4px rgba(15, 23, 42, 0.08),
+    0 10px 28px rgba(15, 23, 42, 0.06);
+}
+.card h3 {
   margin: 2px 0 6px;
   font-size: 18px;
   /* Allow long calculator names to wrap onto multiple lines without
@@ -145,22 +257,65 @@ ul.grid li{list-style:none}
   word-wrap: break-word;
   white-space: normal;
 }
-.card p{
+.card p {
   color: var(--muted);
   font-size: 14px;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
 }
-.ad-slot{border:1px dashed var(--border);background:#F8FAFC;border-radius:var(--radius);
-  display:flex;align-items:center;justify-content:center;color:#64748B;font-size:14px}
-.section{margin-block:24px}
-.input{width:100%;border:1px solid var(--border);border-radius:12px;padding:10px 12px;background:#FFF}
-.input:focus{outline:2px solid #93C5FD;outline-offset:1px}
-.btn-primary{background:var(--primary);color:var(--primary-ink);border:none;border-radius:12px;
-  padding:12px 16px;font-weight:600;cursor:pointer}
-.btn-primary:hover{filter:brightness(1.05)}
-.faq summary{cursor:pointer;font-weight:600}
-footer .links{display:flex;gap:16px;justify-content:center;color:var(--muted);flex-wrap:wrap}
-footer .links a{color:inherit;text-decoration:none}
-footer .links a:hover{text-decoration:underline;color:var(--ink)}
+.ad-slot {
+  border: 1px dashed var(--border);
+  background: #f8fafc;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  font-size: 14px;
+}
+.section {
+  margin-block: 24px;
+}
+.input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #fff;
+}
+.input:focus {
+  outline: 2px solid #93c5fd;
+  outline-offset: 1px;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-ink);
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn-primary:hover {
+  filter: brightness(1.05);
+}
+.faq summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+footer .links {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+footer .links a {
+  color: inherit;
+  text-decoration: none;
+}
+footer .links a:hover {
+  text-decoration: underline;
+  color: var(--ink);
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ const site = Astro.site?.toString() || (import.meta.env.SITE_URL ?? 'https://exa
 const href = canonical ?? new URL(Astro.url.pathname, site).toString();
 const adsClient = import.meta.env.VITE_ADSENSE_CLIENT;
 const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
+const pathname = Astro.url.pathname;
 ---
 <html lang="en">
   <head>
@@ -40,14 +41,16 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
 </head>
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
-    <header class="header" role="banner">
-      <div class="header-inner">
-        <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
-        <nav class="nav" aria-label="Primary">
-          <a href="/categories/">CATEGORIES</a>
-          <a href="/all">ALL CALCULATORS</a>
-          <a href="/traditional-calculator/">TRADITIONAL CALCULATOR</a>
+    <header class="nav" data-nav>
+      <div class="container">
+        <a class="brand" href="/" aria-label="CalcSimpler">CalcSimpler<span>.com</span></a>
+        <nav class="tabs" aria-label="Primary">
+          <a href="/categories/" class={`tab${pathname.startsWith('/categories') ? ' is-active' : ''}`}>Categories</a>
+          <a href="/all" class={`tab${pathname === '/all' ? ' is-active' : ''}`}>All Calculators</a>
         </nav>
+        <div class="actions">
+          <a class="btn" href="/traditional-calculator/">Traditional Calculator</a>
+        </div>
       </div>
     </header>
     <main class="container" id="main" role="main">
@@ -65,5 +68,13 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
       </div>
       <div style="text-align:center;margin-top:8px;color:var(--muted)">© {new Date().getFullYear()} CalcSimpler.com</div>
     </footer>
+    <script is:inline>
+      const nav = document.querySelector('[data-nav]');
+      const setNav = () => {
+        nav.classList.toggle('is-scrolled', window.scrollY > 10);
+      };
+      setNav();
+      window.addEventListener('scroll', setNav);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace header with fixed navbar featuring Categories/All Calculators tabs and CTA to Traditional Calculator
- style new navbar with equal tab hierarchy, hover/focus states, and scroll-activated background
- add script to toggle solid background after scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b824a1e9c88321987e4ae04ef3f93c