### PR TITLE
Reposition header buttons above navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -121,19 +121,18 @@ body {
 }
 .header-inner {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
   max-width: var(--maxw);
   margin-inline: auto;
   padding: 12px 16px;
-  flex-wrap: wrap;
-  row-gap: 8px;
+  gap: 8px;
 }
-.logo-area {
+.top-links {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  justify-content: space-between;
+  align-items: center;
 }
 .traditional-btn {
   font-size: 14px;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="header-inner">
-        <div class="logo-area">
+        <div class="top-links">
           <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
           <a href="/traditional-calculator/" class="traditional-btn">Traditional Calculator</a>
         </div>


### PR DESCRIPTION
## Summary
- Move CalcSimpler.com and Traditional Calculator buttons above the navigation menu
- Arrange top buttons left and right with spacing before Categories/All links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b85ed1479883219f321a9d7a1d2de3