### PR TITLE
Reestructura cabecera con barra superior y navegación

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -105,13 +105,11 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: rgba(44, 116, 179, 0.6);
-  backdrop-filter: blur(8px);
-  color: var(--primary-ink);
   z-index: 50;
-  transition: background 0.3s ease;
+  display: flex;
+  flex-direction: column;
 }
-.header.scrolled {
+.header.scrolled .nav {
   background: var(--primary);
   backdrop-filter: none;
 }
@@ -120,20 +118,15 @@ body {
   text-decoration: none;
 }
 .header-inner {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
   max-width: var(--maxw);
   margin-inline: auto;
-  padding: 12px 16px;
-  flex-wrap: wrap;
-  row-gap: 8px;
+  padding: 8px 16px;
 }
-.logo-area {
+.top-bar {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--primary);
 }
 .traditional-btn {
   font-size: 14px;
@@ -153,9 +146,14 @@ body {
 }
 .nav {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-end;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 0;
+  background: rgba(44, 116, 179, 0.6);
+  backdrop-filter: blur(8px);
+  margin-top: 4px;
+  transition: background 0.3s ease;
 }
 .nav-pill {
   display: block;
@@ -164,10 +162,6 @@ body {
   font-weight: 600;
   text-align: center;
   transition: background 0.2s ease;
-}
-.nav-pill span {
-  display: block;
-  line-height: 1;
 }
 .nav-pill:hover,
 .nav-pill:focus {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -41,19 +41,14 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
-      <div class="header-inner">
-        <div class="logo-area">
-          <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
-          <a href="/traditional-calculator/" class="traditional-btn">Traditional Calculator</a>
-        </div>
-        <nav class="nav" aria-label="Primary">
-          <a href="/categories/" class={['nav-pill', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
-          <a href="/all" class={['nav-pill', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>
-            <span>All</span>
-            <span>Calculators</span>
-          </a>
-        </nav>
+      <div class="top-bar header-inner">
+        <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
+        <a href="/traditional-calculator/" class="traditional-btn">Traditional Calculator</a>
       </div>
+      <nav class="nav header-inner" aria-label="Primary">
+        <a href="/categories/" class={['nav-pill', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
+        <a href="/all" class={['nav-pill', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>All Calculators</a>
+      </nav>
     </header>
     <main class="container" id="main" role="main">
       <slot />


### PR DESCRIPTION
## Summary
- Reorganiza la cabecera para incluir una barra superior con enlaces a CalcSimpler.com y Traditional Calculator.
- Separa la navegación principal y alinea los enlaces de Categories y All Calculators en extremos opuestos.
- Añade estilos con fondos contrastantes y margen para diferenciar visualmente ambas secciones.

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8642bd7f88321b56f689935cca084