### PR TITLE
Reorganize header layout

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -105,35 +105,41 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: rgba(44, 116, 179, 0.6);
-  backdrop-filter: blur(8px);
   color: var(--primary-ink);
   z-index: 50;
-  transition: background 0.3s ease;
-}
-.header.scrolled {
-  background: var(--primary);
-  backdrop-filter: none;
 }
 .header a {
   color: var(--primary-ink);
   text-decoration: none;
 }
-.header-inner {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  max-width: var(--maxw);
-  margin-inline: auto;
-  padding: 12px 16px;
-  flex-wrap: wrap;
-  row-gap: 8px;
+
+.top-bar {
+  background: rgba(44, 116, 179, 0.15);
+  backdrop-filter: blur(8px);
 }
-.logo-area {
+
+.nav-bar {
+  background: rgba(44, 116, 179, 0.6);
+  backdrop-filter: blur(8px);
+  transition: background 0.3s ease;
+  margin-top: 4px;
+}
+
+.header.scrolled .nav-bar {
+  background: var(--primary);
+  backdrop-filter: none;
+}
+
+.top-bar .container,
+.nav {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 8px;
+}
+
+.nav {
+  width: 100%;
 }
 .traditional-btn {
   font-size: 14px;
@@ -151,12 +157,6 @@ body {
   outline: 2px solid var(--primary-ink);
   outline-offset: 2px;
 }
-.nav {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-end;
-}
 .nav-pill {
   display: block;
   padding: 6px 14px;
@@ -164,10 +164,6 @@ body {
   font-weight: 600;
   text-align: center;
   transition: background 0.2s ease;
-}
-.nav-pill span {
-  display: block;
-  line-height: 1;
 }
 .nav-pill:hover,
 .nav-pill:focus {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -41,17 +41,16 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
-      <div class="header-inner">
-        <div class="logo-area">
+      <div class="top-bar">
+        <div class="container">
           <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
           <a href="/traditional-calculator/" class="traditional-btn">Traditional Calculator</a>
         </div>
-        <nav class="nav" aria-label="Primary">
+      </div>
+      <div class="nav-bar">
+        <nav class="container nav" aria-label="Primary">
           <a href="/categories/" class={['nav-pill', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
-          <a href="/all" class={['nav-pill', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>
-            <span>All</span>
-            <span>Calculators</span>
-          </a>
+          <a href="/all" class={['nav-pill', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>All Calculators</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Split header into light top bar with logo and Traditional Calculator button
- Move category navigation into separate bar with balanced left/right links and single-line "All Calculators"
- Style top and bottom bars with contrasting backgrounds and responsive spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b868c0da708321bca192ff290d35a8