### PR TITLE
feat: apply elegant color palette

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,26 +1,10 @@
 :root {
-  /*
-    Global colour tokens.  The default palette in the original template
-    used a very dark primary colour (#0E2A47) for the header and other
-    accents.  This resulted in a high‑contrast, almost navy look which
-    clashed with the otherwise light UI.  To achieve a brighter and
-    friendlier appearance we select a medium blue for the primary hue
-    and leave all other colours unchanged.  The background remains
-    off‑white for warmth and readability.
-
-    Primary: #2C74B3 – a mid‑tone blue inspired by the web‑safe palette.
-    Primary ink: white text for sufficient contrast on the header.
-  */
-  /*
-    Use a very light background for the body and surfaces.  This keeps
-    content feeling airy and modern without a dull yellow tint.
-    Muted text colours are softened for improved contrast.
-  */
-  --bg: #f9fafb;
-  --surface: #ffffff;
-  --ink: #0f172a;
-  --muted: #64748b;
-  --primary: #2c74b3;
+  /* Elegant palette: warm neutrals with a blue accent. */
+  --bg: #ffffff;
+  --surface: #f5f5f4;
+  --ink: #1f2937;
+  --muted: #6b7280;
+  --primary: #3b82f6;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -28,55 +12,6 @@
   --radius: 14px;
   --space: 14px;
   --maxw: 1120px;
-}
-/*
-  When the user prefers a dark colour scheme we override the global
-  variables with a complementary dark palette.  Colours are chosen
-  to provide sufficient contrast on dark backgrounds while maintaining
-  the same hue relationships as the light theme.  Cards and headers
-  remain distinct from the background and the primary accent colour
-  stays constant across both modes.
-*/
-@media (prefers-color-scheme: dark) {
-  :root {
-    /*
-      Adopt a dark palette that remains comfortable on the eyes.  We
-      retain the same blue accent colour while brightening the ink and
-      softening the muted tones.  Shadows are strengthened slightly to
-      preserve depth on dark surfaces.
-    */
-    --bg: #0f172a;
-    --surface: #1e293b;
-    --ink: #f1f5f9;
-    --muted: #94a3b8;
-    --primary: #2c74b3;
-    --primary-ink: #ffffff;
-    --card: #1e293b;
-    --border: #334155;
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
-  }
-}
-
-/*
-  Support dark mode.  When the user prefers a dark colour scheme we
-  override the root variables with darker backgrounds and lighter
-  text.  The primary colour is kept the same (a mid‑tone blue) to
-  maintain brand consistency, while secondary surfaces and borders
-  become darker.  Shadows are increased slightly to preserve depth on
-  dark backgrounds.
-*/
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0f172a;
-    --surface: #1f2a37;
-    --ink: #f1f5f9;
-    --muted: #94a3b8;
-    --primary: #2c74b3;
-    --primary-ink: #ffffff;
-    --card: #1e293b;
-    --border: #334155;
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
-  }
 }
 html,
 body {
@@ -114,12 +49,12 @@ body {
 }
 
 .top-bar {
-  background: rgba(44, 116, 179, 0.15);
+  background: rgba(59, 130, 246, 0.15);
   backdrop-filter: blur(8px);
 }
 
 .nav-bar {
-  background: rgba(44, 116, 179, 0.6);
+  background: rgba(59, 130, 246, 0.6);
   backdrop-filter: blur(8px);
   transition: background 0.3s ease;
   margin-top: 4px;
@@ -321,5 +256,5 @@ footer .links a {
 }
 footer .links a:hover {
   text-decoration: underline;
-  color: var(--ink);
+  color: var(--primary);
 }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,37 +1,25 @@
-:root{
-  /* Base tokens for light mode.  These values define the default
-     backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f7f7f8;
-  --text:#0b0b0c;
-  --muted:#6b7280;
-  --accent:#2C74B3; /* Align accent with the primary colour in theme.css */
-  --ring:#6a82fb33;
-  --radius:12px;
-  --shadow:0 6px 20px rgba(0,0,0,.06);
+:root {
+  /* Neutral palette for the site.  Whites and warm greys provide a
+     clean base that works across the whole interface. */
+  --bg: #ffffff;
+  --surface: #f5f5f4;
+  --text: #1f2937;
+  --muted: #6b7280;
+  /* Primary accent used for buttons, hovers and important links */
+  --accent: #3b82f6;
+  --ring: #3b82f633;
+  --radius: 12px;
+  --shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
 }
 
-/*
-  Define a dark palette for users who prefer dark mode via the
-  `prefers‑color‑scheme` media query.  The dark colours mirror the
-  semantic roles used in light mode (background, surface, text and
-  muted text) but with darker hues for a comfortable low‑light
-  experience.  The accent colour remains the same across both
-  palettes to maintain brand consistency.
-*/
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* Dark background for page body */
-    --bg: #0D1A26;
-    /* Darker surface for cards and containers */
-    --surface: #152233;
-    /* Primary text becomes light for readability */
-    --text: #F1F5F9;
-    /* Muted text uses a mid‑tone grey */
-    --muted: #94A3B8;
-    /* Accent colour remains the same */
-    --accent: #2C74B3;
-  }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
-
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}

--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <div class="container mx-auto max-w-5xl px-4 pb-10">
-  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 dark:border-slate-600 grid place-items-center text-slate-500">
+  <div class="min-h-[90px] rounded-xl border border-dashed border-gray-300 grid place-items-center text-gray-500">
     Ad — 728 × 90 reserved
   </div>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#2C74B3">
+      <meta name="theme-color" content="#3B82F6">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -32,8 +32,9 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`}
-             class="group block rounded-xl border border-slate-200/80 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm hover:shadow-md transition-shadow">
+            <a
+              href={`/categories/${cat.slug}/`}
+              class="group block rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:border-blue-500 hover:shadow-md">
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.
@@ -46,8 +47,8 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-50 group-hover:underline">{cat.title}</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">{cat.desc}</p>
+                  <h3 class="text-lg font-semibold text-gray-900 group-hover:underline group-hover:text-blue-600">{cat.title}</h3>
+                  <p class="text-sm text-gray-600">{cat.desc}</p>
               </div>
             </div>
           </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,9 +39,10 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`}
-             class="group block rounded-xl border border-slate-200/80 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 shadow-sm hover:shadow-md transition-shadow"
-             aria-label={`${cat.title} calculators`}>
+            <a
+              href={`/categories/${cat.slug}/`}
+              class="group block rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:border-blue-500 hover:shadow-md"
+              aria-label={`${cat.title} calculators`}>
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.
@@ -55,8 +56,8 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-50 group-hover:underline">{cat.title}</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">{cat.desc}</p>
+                  <h3 class="text-lg font-semibold text-gray-900 group-hover:underline group-hover:text-blue-600">{cat.title}</h3>
+                  <p class="text-sm text-gray-600">{cat.desc}</p>
               </div>
             </div>
           </a>

--- a/src/pages/traditional-calculator.astro
+++ b/src/pages/traditional-calculator.astro
@@ -4,81 +4,81 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout title="Traditional Calculator" description="Perform basic arithmetic operations with this traditional calculator.">
   <div class="max-w-sm mx-auto mt-8">
-    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-lg">
+      <div id="calc" class="bg-white p-4 rounded-lg shadow-lg">
       <input
-        id="display"
-        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100"
-        readonly
-      />
+          id="display"
+          class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 text-gray-800"
+          readonly
+        />
       <div class="grid grid-cols-4 gap-2">
         <button
           data-value="7"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >7</button>
         <button
           data-value="8"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >8</button>
         <button
           data-value="9"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >9</button>
         <button
           data-value="/"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >÷</button>
         <button
           data-value="4"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >4</button>
         <button
           data-value="5"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >5</button>
         <button
           data-value="6"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >6</button>
         <button
           data-value="*"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >×</button>
         <button
           data-value="1"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >1</button>
         <button
           data-value="2"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >2</button>
         <button
           data-value="3"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >3</button>
         <button
           data-value="-"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >−</button>
         <button
           data-value="0"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >0</button>
         <button
           data-value="."
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >.</button>
         <button
           data-value="="
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >=</button>
         <button
           data-value="+"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 transition-colors font-semibold"
         >+</button>
-        <button
-          data-value="C"
-          class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold"
-        >C</button>
+          <button
+            data-value="C"
+            class="col-span-4 p-2 rounded border bg-blue-500 hover:bg-blue-600 active:bg-blue-700 text-white font-semibold"
+          >C</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove dark theme and introduce neutral + blue palette
- style categories, header and buttons with accent colors
- refresh calculator buttons with new primary color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b883692a0c83219b462e768135776a