### PR TITLE
feat: apply Equilibrio Moderno color palette

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -17,14 +17,14 @@
     Muted text colours are softened for improved contrast.
   */
   --bg: #ffffff;
-  --surface: #f7f7f8;
-  --ink: #0f172a;
-  --muted: #64748b;
-  --neutral-sky: #e0f2fe;
+  --surface: #f3f4f6;
+  --ink: #000000;
+  --muted: #6b7280;
+  --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #2c74b3;
-  --accent: #a855f7;
-  --accent-red: #e11d48;
+  --primary: #2563eb;
+  --accent: #ef4444;
+  --secondary: #facc15;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -51,13 +51,13 @@
     */
     --bg: #0f172a;
     --surface: #1e293b;
-    --ink: #f1f5f9;
+    --ink: #f9fafb;
     --muted: #94a3b8;
     --neutral-sky: #1e293b;
     --neutral-warm: #1f2937;
-    --primary: #2c74b3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --primary: #2563eb;
+    --accent: #ef4444;
+    --secondary: #facc15;
     --primary-ink: #ffffff;
     --card: #1e293b;
     --border: #334155;
@@ -77,9 +77,11 @@
   :root {
     --bg: #0f172a;
     --surface: #1f2a37;
-    --ink: #f1f5f9;
+    --ink: #f9fafb;
     --muted: #94a3b8;
-    --primary: #2c74b3;
+    --primary: #2563eb;
+    --accent: #ef4444;
+    --secondary: #facc15;
     --primary-ink: #ffffff;
     --card: #1e293b;
     --border: #334155;
@@ -330,10 +332,11 @@ ul.grid li {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 10px 12px;
-  background: #fff;
+  background: var(--card);
+  color: var(--ink);
 }
 .input:focus {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--secondary);
   outline-offset: 1px;
 }
 .btn-primary {

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -2,17 +2,17 @@
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
   --bg:#ffffff;
-  --surface:#f7f7f8;
-  --text:#0b0b0c;
+  --surface:#f3f4f6;
+  --text:#000000;
   --muted:#6b7280;
-  /* Neutral palette combining sky blue and warm grey */
-  --neutral-sky:#e0f2fe;
+  /* Neutral palette combining sky and warm greys */
+  --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#2C74B3;
-  --accent:#a855f7; /* Soft purple accent */
-  --accent-red:#e11d48;
-  --ring:#6a82fb33;
+  --primary:#2563eb;
+  --accent:#ef4444;
+  --secondary:#facc15;
+  --ring:#2563eb33;
   --radius:12px;
   --shadow:0 6px 20px rgba(0,0,0,.06);
 }
@@ -28,17 +28,17 @@
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark background for page body */
-    --bg: #0D1A26;
+    --bg: #0f172a;
     /* Darker surface for cards and containers */
-    --surface: #152233;
+    --surface: #1f2a37;
     /* Primary text becomes light for readability */
-    --text: #F1F5F9;
+    --text: #f9fafb;
     /* Muted text uses a mid‑tone grey */
     --muted: #94A3B8;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #2C74B3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --primary: #2563eb;
+    --accent: #ef4444;
+    --secondary: #facc15;
   }
 }
 

--- a/src/pages/traditional-calculator.astro
+++ b/src/pages/traditional-calculator.astro
@@ -4,81 +4,26 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout title="Traditional Calculator" description="Perform basic arithmetic operations with this traditional calculator.">
   <div class="max-w-sm mx-auto mt-8">
-    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-lg">
-      <input
-        id="display"
-        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100"
-        readonly
-      />
+    <div id="calc" class="calc-container p-4 rounded-lg shadow-lg">
+      <input id="display" class="input w-full mb-2 p-3 text-right text-2xl" readonly />
       <div class="grid grid-cols-4 gap-2">
-        <button
-          data-value="7"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >7</button>
-        <button
-          data-value="8"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >8</button>
-        <button
-          data-value="9"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >9</button>
-        <button
-          data-value="/"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >÷</button>
-        <button
-          data-value="4"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >4</button>
-        <button
-          data-value="5"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >5</button>
-        <button
-          data-value="6"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >6</button>
-        <button
-          data-value="*"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >×</button>
-        <button
-          data-value="1"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >1</button>
-        <button
-          data-value="2"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >2</button>
-        <button
-          data-value="3"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >3</button>
-        <button
-          data-value="-"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >−</button>
-        <button
-          data-value="0"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >0</button>
-        <button
-          data-value="."
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >.</button>
-        <button
-          data-value="="
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >=</button>
-        <button
-          data-value="+"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >+</button>
-        <button
-          data-value="C"
-          class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold"
-        >C</button>
+        <button data-value="7" class="calc-btn p-2 rounded font-semibold">7</button>
+        <button data-value="8" class="calc-btn p-2 rounded font-semibold">8</button>
+        <button data-value="9" class="calc-btn p-2 rounded font-semibold">9</button>
+        <button data-value="/" class="calc-btn p-2 rounded font-semibold">÷</button>
+        <button data-value="4" class="calc-btn p-2 rounded font-semibold">4</button>
+        <button data-value="5" class="calc-btn p-2 rounded font-semibold">5</button>
+        <button data-value="6" class="calc-btn p-2 rounded font-semibold">6</button>
+        <button data-value="*" class="calc-btn p-2 rounded font-semibold">×</button>
+        <button data-value="1" class="calc-btn p-2 rounded font-semibold">1</button>
+        <button data-value="2" class="calc-btn p-2 rounded font-semibold">2</button>
+        <button data-value="3" class="calc-btn p-2 rounded font-semibold">3</button>
+        <button data-value="-" class="calc-btn p-2 rounded font-semibold">−</button>
+        <button data-value="0" class="calc-btn p-2 rounded font-semibold">0</button>
+        <button data-value="." class="calc-btn p-2 rounded font-semibold">.</button>
+        <button data-value="=" class="calc-btn p-2 rounded font-semibold">=</button>
+        <button data-value="+" class="calc-btn p-2 rounded font-semibold">+</button>
+        <button data-value="C" class="calc-btn clear col-span-4 p-2 rounded font-semibold">C</button>
       </div>
     </div>
   </div>
@@ -105,5 +50,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       });
     });
   </script>
+  <style>
+    .calc-container { background: var(--card); border: 1px solid var(--border); }
+    .calc-btn { background: var(--surface); color: var(--ink); border: 1px solid var(--border); transition: background 0.2s ease; }
+    .calc-btn:hover { background: var(--neutral-warm); }
+    .calc-btn:active { background: var(--neutral-sky); }
+    .calc-btn.clear { background: var(--accent); color: var(--primary-ink); }
+    .calc-btn.clear:hover { filter: brightness(1.05); }
+  </style>
 </BaseLayout>
-

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,21 @@
 module.exports = {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}"],
-  theme: { extend: { container: { center: true, padding: "1rem" } } },
+  theme: {
+    extend: {
+      container: { center: true, padding: "1rem" },
+      colors: {
+        base: {
+          black: "#000000",
+          gray: "#6b7280",
+          white: "#ffffff"
+        },
+        accent: {
+          red: "#ef4444",
+          blue: "#2563eb",
+          yellow: "#facc15"
+        }
+      }
+    }
+  },
   plugins: []
 };


### PR DESCRIPTION
## Summary
- add "Equilibrio Moderno" palette to Tailwind config and global CSS
- introduce red, blue and yellow accent variables
- restyle traditional calculator to use palette tokens

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b89ce210b08321b65fc22984d01a63