### PR TITLE
feat: apply modern contrast palette and shadows

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -18,13 +18,13 @@
   */
   --bg: #ffffff;
   --surface: #f7f7f8;
-  --ink: #0f172a;
-  --muted: #64748b;
+  --ink: #0b0b0c;
+  --muted: #6b7280;
   --neutral-sky: #e0f2fe;
   --neutral-warm: #f5f5f4;
-  --primary: #2c74b3;
-  --accent: #a855f7;
-  --accent-red: #e11d48;
+  --primary: #1e40af;
+  --primary-red: #dc2626;
+  --accent: #facc15;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -55,9 +55,9 @@
     --muted: #94a3b8;
     --neutral-sky: #1e293b;
     --neutral-warm: #1f2937;
-    --primary: #2c74b3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --primary: #1e40af;
+    --primary-red: #dc2626;
+    --accent: #facc15;
     --primary-ink: #ffffff;
     --card: #1e293b;
     --border: #334155;
@@ -79,7 +79,9 @@
     --surface: #1f2a37;
     --ink: #f1f5f9;
     --muted: #94a3b8;
-    --primary: #2c74b3;
+    --primary: #1e40af;
+    --primary-red: #dc2626;
+    --accent: #facc15;
     --primary-ink: #ffffff;
     --card: #1e293b;
     --border: #334155;
@@ -127,6 +129,7 @@ body {
   width: 100%;
   color: var(--primary-ink);
   z-index: 50;
+  box-shadow: var(--shadow);
 }
 .header a {
   color: var(--primary-ink);
@@ -140,19 +143,19 @@ body {
 
 @media (prefers-color-scheme: light) {
   .top-bar a {
-    color: #000;
+    color: var(--ink);
   }
 
   .top-bar a:hover {
-    color: #000;
+    color: var(--ink);
   }
 
   .top-bar .traditional-btn {
-    border-color: #000;
+    border-color: var(--primary-red);
   }
 
   .top-bar .traditional-btn:focus {
-    outline-color: #000;
+    outline-color: var(--primary-red);
   }
 }
 
@@ -182,17 +185,21 @@ body {
 .traditional-btn {
   font-size: 14px;
   padding: 4px 10px;
-  border: 1px solid var(--primary-ink);
+  border: 1px solid var(--primary-red);
   border-radius: 9999px;
   background: rgba(255, 255, 255, 0.1);
-  transition: background 0.2s ease;
+  color: var(--primary-red);
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
 }
 .traditional-btn:hover,
 .traditional-btn:focus {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--primary-red);
+  color: var(--primary-ink);
 }
 .traditional-btn:focus {
-  outline: 2px solid var(--primary-ink);
+  outline: 2px solid var(--primary-red);
   outline-offset: 2px;
 }
 .nav-pill {
@@ -344,6 +351,7 @@ ul.grid li {
   padding: 12px 16px;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: var(--shadow);
 }
 .btn-primary:hover {
   filter: brightness(1.05);

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,20 +1,20 @@
-:root{
+:root {
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f7f7f8;
-  --text:#0b0b0c;
-  --muted:#6b7280;
+  --bg: #ffffff;
+  --surface: #f7f7f8;
+  --text: #0b0b0c;
+  --muted: #6b7280;
   /* Neutral palette combining sky blue and warm grey */
-  --neutral-sky:#e0f2fe;
-  --neutral-warm:#f5f5f4;
+  --neutral-sky: #e0f2fe;
+  --neutral-warm: #f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#2C74B3;
-  --accent:#a855f7; /* Soft purple accent */
-  --accent-red:#e11d48;
-  --ring:#6a82fb33;
-  --radius:12px;
-  --shadow:0 6px 20px rgba(0,0,0,.06);
+  --primary: #1e40af;
+  --primary-red: #dc2626;
+  --accent: #facc15; /* Vibrant yellow accent */
+  --ring: #6a82fb33;
+  --radius: 12px;
+  --shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
 }
 
 /*
@@ -28,18 +28,28 @@
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark background for page body */
-    --bg: #0D1A26;
+    --bg: #0d1a26;
     /* Darker surface for cards and containers */
     --surface: #152233;
     /* Primary text becomes light for readability */
-    --text: #F1F5F9;
+    --text: #f1f5f9;
     /* Muted text uses a mid‑tone grey */
-    --muted: #94A3B8;
+    --muted: #94a3b8;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #2C74B3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --primary: #1e40af;
+    --primary-red: #dc2626;
+    --accent: #facc15;
   }
 }
 
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -12,20 +12,20 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
     <main class="container mx-auto px-4 py-10">
-      <h1 class="text-3xl font-bold">{title}</h1>
+      <h1 class="text-3xl font-bold text-[var(--ink)]">{title}</h1>
       <AdBanner />
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="block rounded-xl border border-[var(--border)] p-4 hover:border-[var(--accent)] hover:shadow-sm transition">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--ink)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,21 @@
 module.exports = {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}"],
-  theme: { extend: { container: { center: true, padding: "1rem" } } },
-  plugins: []
+  theme: {
+    extend: {
+      container: { center: true, padding: "1rem" },
+      colors: {
+        primary: "#1e40af",
+        primaryRed: "#dc2626",
+        accent: "#facc15",
+        background: "#ffffff",
+        surface: "#f7f7f8",
+        ink: "#0b0b0c",
+        muted: "#6b7280",
+      },
+      boxShadow: {
+        site: "0 1px 2px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.04)",
+      },
+    },
+  },
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- add modern "Contraste Dinámico" palette variables and expose them in Tailwind
- style header, buttons and links with new colors and shared shadow
- align education page with palette tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8a0a1fab48321b25c0b7273c4e767