### PR TITLE
feat: apply modern color palette with shadows

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,34 +1,23 @@
 :root {
   /*
-    Global colour tokens.  The default palette in the original template
-    used a very dark primary colour (#0E2A47) for the header and other
-    accents.  This resulted in a high‑contrast, almost navy look which
-    clashed with the otherwise light UI.  To achieve a brighter and
-    friendlier appearance we select a medium blue for the primary hue
-    and leave all other colours unchanged.  The background remains
-    off‑white for warmth and readability.
-
-    Primary: #2C74B3 – a mid‑tone blue inspired by the web‑safe palette.
-    Primary ink: white text for sufficient contrast on the header.
-  */
-  /*
-    Use a very light background for the body and surfaces.  This keeps
-    content feeling airy and modern without a dull yellow tint.
-    Muted text colours are softened for improved contrast.
+    Equilibrio Moderno palette. A neutral foundation of blacks, greys and
+    whites establishes clarity while vibrant accents introduce dynamic
+    contrast. Blue and red serve as primary highlights and yellow acts as a
+    warm secondary accent.
   */
   --bg: #ffffff;
-  --surface: #f7f7f8;
-  --ink: #0f172a;
-  --muted: #64748b;
-  --neutral-sky: #e0f2fe;
+  --surface: #f5f5f5;
+  --ink: #000000;
+  --muted: #6b7280;
+  --neutral-sky: #f3f4f6;
   --neutral-warm: #f5f5f4;
-  --primary: #2c74b3;
-  --accent: #a855f7;
-  --accent-red: #e11d48;
+  --primary: #1d4ed8;
+  --accent: #dc2626;
+  --secondary: #facc15;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
-  --shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 8px 24px rgba(15, 23, 42, 0.04);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 8px 24px rgba(0, 0, 0, 0.04);
   --radius: 14px;
   --space: 14px;
   --maxw: 1120px;
@@ -49,17 +38,17 @@
       softening the muted tones.  Shadows are strengthened slightly to
       preserve depth on dark surfaces.
     */
-    --bg: #0f172a;
-    --surface: #1e293b;
-    --ink: #f1f5f9;
-    --muted: #94a3b8;
+    --bg: #000000;
+    --surface: #1f2937;
+    --ink: #f9fafb;
+    --muted: #9ca3af;
     --neutral-sky: #1e293b;
-    --neutral-warm: #1f2937;
-    --primary: #2c74b3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --neutral-warm: #374151;
+    --primary: #3b82f6;
+    --accent: #ef4444;
+    --secondary: #facc15;
     --primary-ink: #ffffff;
-    --card: #1e293b;
+    --card: #1f2937;
     --border: #334155;
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
   }
@@ -75,13 +64,13 @@
 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0f172a;
-    --surface: #1f2a37;
-    --ink: #f1f5f9;
-    --muted: #94a3b8;
-    --primary: #2c74b3;
+    --bg: #000000;
+    --surface: #1f2937;
+    --ink: #f9fafb;
+    --muted: #9ca3af;
+    --primary: #3b82f6;
     --primary-ink: #ffffff;
-    --card: #1e293b;
+    --card: #1f2937;
     --border: #334155;
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.6), 0 8px 24px rgba(0, 0, 0, 0.3);
   }
@@ -157,7 +146,7 @@ body {
 }
 
 .nav-bar {
-  background: rgba(44, 116, 179, 0.6);
+  background: rgba(29, 78, 216, 0.6);
   backdrop-filter: blur(8px);
   transition: background 0.3s ease;
   margin-top: 4px;
@@ -333,7 +322,7 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid var(--primary);
   outline-offset: 1px;
 }
 .btn-primary {

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -2,17 +2,17 @@
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
   --bg:#ffffff;
-  --surface:#f7f7f8;
-  --text:#0b0b0c;
+  --surface:#f5f5f5;
+  --text:#000000;
   --muted:#6b7280;
-  /* Neutral palette combining sky blue and warm grey */
-  --neutral-sky:#e0f2fe;
+  /* Neutral greys for subtle surfaces */
+  --neutral-sky:#f3f4f6;
   --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#2C74B3;
-  --accent:#a855f7; /* Soft purple accent */
-  --accent-red:#e11d48;
-  --ring:#6a82fb33;
+  /* Brand colours and vivid accents */
+  --primary:#1d4ed8; /* Blue */
+  --accent:#dc2626; /* Red */
+  --secondary:#facc15; /* Yellow */
+  --ring:#1d4ed833;
   --radius:12px;
   --shadow:0 6px 20px rgba(0,0,0,.06);
 }
@@ -28,17 +28,17 @@
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark background for page body */
-    --bg: #0D1A26;
+    --bg: #000000;
     /* Darker surface for cards and containers */
-    --surface: #152233;
+    --surface: #1f2937;
     /* Primary text becomes light for readability */
-    --text: #F1F5F9;
+    --text: #f9fafb;
     /* Muted text uses a mid‑tone grey */
-    --muted: #94A3B8;
+    --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #2C74B3;
-    --accent: #a855f7;
-    --accent-red: #e11d48;
+    --primary: #3b82f6;
+    --accent: #ef4444;
+    --secondary: #facc15;
   }
 }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#2C74B3">
+    <meta name="theme-color" content="#1D4ED8">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Page not found" description="The page you were looking for does not exist.">
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
-    <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
+    <p class="mb-6 text-lg text-[var(--muted)]">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
     <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
   </main>
 </BaseLayout>

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -17,15 +17,15 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="group block rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm hover:shadow-md hover:border-[var(--accent)] transition-all">
+            <div class="text-sm text-[var(--secondary)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/everyday.astro
+++ b/src/pages/everyday.astro
@@ -14,15 +14,15 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="group block rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm hover:shadow-md hover:border-[var(--accent)] transition-all">
+            <div class="text-sm text-[var(--secondary)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/science.astro
+++ b/src/pages/science.astro
@@ -16,15 +16,15 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="group block rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm hover:shadow-md hover:border-[var(--accent)] transition-all">
+            <div class="text-sm text-[var(--secondary)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/traditional-calculator.astro
+++ b/src/pages/traditional-calculator.astro
@@ -1,84 +1,34 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+const keyClass = "p-2 rounded border border-[var(--border)] bg-[var(--surface)] text-[var(--ink)] hover:bg-[var(--neutral-sky)] active:bg-[var(--neutral-warm)] transition-colors font-semibold";
 ---
 
 <BaseLayout title="Traditional Calculator" description="Perform basic arithmetic operations with this traditional calculator.">
   <div class="max-w-sm mx-auto mt-8">
-    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-lg">
+    <div id="calc" class="card">
       <input
         id="display"
-        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100"
+        class="w-full mb-2 p-3 border border-[var(--border)] rounded text-right text-2xl bg-[var(--surface)] text-[var(--ink)]"
         readonly
       />
       <div class="grid grid-cols-4 gap-2">
-        <button
-          data-value="7"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >7</button>
-        <button
-          data-value="8"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >8</button>
-        <button
-          data-value="9"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >9</button>
-        <button
-          data-value="/"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >÷</button>
-        <button
-          data-value="4"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >4</button>
-        <button
-          data-value="5"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >5</button>
-        <button
-          data-value="6"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >6</button>
-        <button
-          data-value="*"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >×</button>
-        <button
-          data-value="1"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >1</button>
-        <button
-          data-value="2"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >2</button>
-        <button
-          data-value="3"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >3</button>
-        <button
-          data-value="-"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >−</button>
-        <button
-          data-value="0"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >0</button>
-        <button
-          data-value="."
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >.</button>
-        <button
-          data-value="="
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >=</button>
-        <button
-          data-value="+"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
-        >+</button>
-        <button
-          data-value="C"
-          class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold"
-        >C</button>
+        <button data-value="7" class={keyClass}>7</button>
+        <button data-value="8" class={keyClass}>8</button>
+        <button data-value="9" class={keyClass}>9</button>
+        <button data-value="/" class={keyClass}>÷</button>
+        <button data-value="4" class={keyClass}>4</button>
+        <button data-value="5" class={keyClass}>5</button>
+        <button data-value="6" class={keyClass}>6</button>
+        <button data-value="*" class={keyClass}>×</button>
+        <button data-value="1" class={keyClass}>1</button>
+        <button data-value="2" class={keyClass}>2</button>
+        <button data-value="3" class={keyClass}>3</button>
+        <button data-value="-" class={keyClass}>−</button>
+        <button data-value="0" class={keyClass}>0</button>
+        <button data-value="." class={keyClass}>.</button>
+        <button data-value="=" class={keyClass}>=</button>
+        <button data-value="+" class={keyClass}>+</button>
+        <button data-value="C" class="col-span-4 p-2 rounded border border-[var(--border)] bg-[var(--accent)] text-[var(--primary-ink)] hover:brightness-110 font-semibold">C</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- refresh theme with “Equilibrio Moderno” palette, adding blue, red and yellow accents and updated shadows
- restyle category and calculator pages to use new CSS variables and card shadows
- set site meta theme color to match new primary blue

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '.../yargs-parser/build/lib/index.js')*


------
https://chatgpt.com/codex/tasks/task_b_68b8a4b4dc048321b137001fce8cd4bb