### PR TITLE
feat: apply modern palette and shadows to calculators

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -132,7 +132,15 @@ const jsonLd = {
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 
 <style>
-  .calc { max-width: 720px; margin: 0 auto; padding: 8px; color: var(--ink); }
+  .calc {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space);
+    color: var(--ink);
+    background: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   h1 { margin: 0 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
@@ -141,29 +149,53 @@ const jsonLd = {
     width: 100%;
     padding: 10px 12px;
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--card);
     color: var(--ink);
+    box-shadow: var(--shadow);
+  }
+  .field input:focus,
+  .field select:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   .btn {
     display: inline-block;
     padding: 12px 16px;
-    border-radius: 12px;
+    border-radius: var(--radius);
     border: 0;
     background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: background 0.2s ease;
   }
-  .btn:hover{ filter:brightness(1.05); }
-  .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
+  .btn:hover { background: var(--accent-red); }
+  .btn:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .result {
+    margin-top: 16px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--surface);
+    padding: var(--space);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   .examples,
   .faq,
   .related {
     max-width: 720px;
     margin: 24px auto 0;
-    padding: 8px;
+    padding: var(--space);
     color: var(--ink);
+    background: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
   }
   .examples ul { margin: 8px 0 0 20px; }
   .faq details { margin: 8px 0; }


### PR DESCRIPTION
## Summary
- style calculator layout with Equilibrio Moderno palette variables
- add shadows, radius, and focus accents to inputs, buttons and sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8a9fea0c48321a5962e60addcd4c5