### PR TITLE
feat: apply modern palette and depth to calculators

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,15 +1,15 @@
 :root {
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
+    The base relies on celeste, grey and white tones to keep content
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
   --bg: #ffffff;
-  --surface: #f2f2f2;
+  --surface: #f0f9ff;
   --ink: #000000;
   --muted: #4b5563;
-  --neutral-sky: #e5e7eb;
+  --neutral-sky: #e0f2fe;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
   --accent: #facc15;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,20 +1,20 @@
-:root{
+:root {
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
-  /* Neutral palette combining soft greys */
-  --neutral-sky:#e5e7eb;
-  --neutral-warm:#f5f5f4;
+  --bg: #ffffff;
+  --surface: #f0f9ff;
+  --text: #000000;
+  --muted: #4b5563;
+  /* Neutral palette combining soft celeste and greys */
+  --neutral-sky: #e0f2fe;
+  --neutral-warm: #f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
-  --ring:#0057B833;
-  --radius:12px;
-  --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
+  --primary: #0057b8;
+  --accent: #facc15; /* Energetic yellow accent */
+  --accent-red: #dc2626;
+  --ring: #0057b833;
+  --radius: 12px;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
 /*
@@ -36,10 +36,20 @@
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #0057b8;
+    --accent: #facc15;
+    --accent-red: #dc2626;
   }
 }
 
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -132,7 +132,16 @@ const jsonLd = {
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 
 <style>
-  .calc { max-width: 720px; margin: 0 auto; padding: 8px; color: var(--ink); }
+  .calc {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px;
+    color: var(--ink);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   h1 { margin: 0 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
@@ -141,29 +150,44 @@ const jsonLd = {
     width: 100%;
     padding: 10px 12px;
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--card);
     color: var(--ink);
+    box-shadow: var(--shadow);
   }
   .btn {
     display: inline-block;
     padding: 12px 16px;
-    border-radius: 12px;
+    border-radius: var(--radius);
     border: 0;
     background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
   }
   .btn:hover{ filter:brightness(1.05); }
-  .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
+  .result {
+    margin-top: 16px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--surface);
+    padding: 12px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   .examples,
   .faq,
   .related {
     max-width: 720px;
     margin: 24px auto 0;
-    padding: 8px;
+    padding: 16px;
     color: var(--ink);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
   }
   .examples ul { margin: 8px 0 0 20px; }
   .faq details { margin: 8px 0; }


### PR DESCRIPTION
## Summary
- update global theme to use celeste-based neutral palette with vibrant accents
- add shadows and card styling to calculator pages for better depth
- sync design tokens with new colors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8abead59c8321844e341c20f1a946