### PR TITLE
feat: apply modern palette to calculators

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,15 +1,15 @@
 :root {
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
+    The base relies on celeste, grey and white tones to keep content
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
   --bg: #ffffff;
-  --surface: #f2f2f2;
+  --surface: #f0f9ff;
   --ink: #000000;
   --muted: #4b5563;
-  --neutral-sky: #e5e7eb;
+  --neutral-sky: #e0f2fe;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
   --accent: #facc15;
@@ -199,14 +199,17 @@ body {
   line-height: 1.05;
   letter-spacing: -0.02em;
 }
-.hero p {
-  margin-top: 8px;
-  color: var(--muted);
-  max-width: 56ch;
-  margin-inline: auto;
-}
-/* A custom grid class used on the dynamic category pages (e.g.
-   /categories/[slug]).  It defines 1–3 columns at increasing
+  .hero p {
+    margin-top: 8px;
+    color: var(--muted);
+    max-width: 56ch;
+    margin-inline: auto;
+  }
+  .muted {
+    color: var(--muted);
+  }
+  /* A custom grid class used on the dynamic category pages (e.g.
+    /categories/[slug]).  It defines 1–3 columns at increasing
    breakpoints and removes list markers.  We avoid the generic `.grid`
    class name to prevent conflicts with Tailwind’s own `grid` utility. */
 .cards-grid {
@@ -275,17 +278,42 @@ ul.grid li {
 .card:hover h3 {
   color: var(--accent);
 }
-.card p {
-  color: var(--muted);
-  font-size: 14px;
-  /* Ensure descriptions wrap naturally within the card. */
-  word-wrap: break-word;
-  white-space: normal;
-}
-.ad-slot {
-  border: 1px dashed var(--border);
-  background: #f8fafc;
-  border-radius: var(--radius);
+  .card p {
+    color: var(--muted);
+    font-size: 14px;
+    /* Ensure descriptions wrap naturally within the card. */
+    word-wrap: break-word;
+    white-space: normal;
+  }
+  .calc {
+    margin-block: 24px;
+    padding: 24px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
+  .calc .field {
+    margin-bottom: 16px;
+  }
+  .calc label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .calc .result {
+    margin-top: 16px;
+    padding: 12px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    color: var(--primary);
+  }
+  .ad-slot {
+    border: 1px dashed var(--border);
+    background: #f8fafc;
+    border-radius: var(--radius);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -301,6 +329,7 @@ ul.grid li {
   border-radius: 12px;
   padding: 10px 12px;
   background: #fff;
+  box-shadow: var(--shadow);
 }
 .input:focus {
   outline: 2px solid var(--accent);

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -63,10 +63,10 @@ const jsonLd = {
 };
 ---
 
-<section
-  class="calc"
-  data-calculator
-  data-slug={slug}
+  <section
+    class="calc"
+    data-calculator
+    data-slug={slug}
   data-exp={expression}
   data-unit={schema?.unit}
   aria-labelledby={`h-${slug}`}
@@ -80,6 +80,7 @@ const jsonLd = {
       <div class="field">
         <label for={`in-${slug}-${i.name}`}>{i.label ?? i.name}</label>
         <input
+          class="input"
           id={`in-${slug}-${i.name}`}
           name={i.name}
           type="number"
@@ -93,7 +94,7 @@ const jsonLd = {
         <div id={`hint-${slug}-${i.name}`} class="hint">{i.hint ? i.hint : (i.units ? i.units : '')}</div>
       </div>
     ))}
-    <button type="button" data-action="calc" class="btn">Calculate</button>
+    <button type="button" data-action="calc" class="btn-primary">Calculate</button>
   </form>
 
   <div class="result" data-role="result" aria-live="polite"></div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
       colors: {
         primary: "#0057B8",
         accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        neutral: { ink: "#000000", muted: "#4B5563", sky: "#E0F2FE", surface: "#F0F9FF" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- refresh theme with celeste-based "Equilibrio Moderno" palette
- style calculator pages with shadows and depth
- wire calculator component to new input and button styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8acccbdcc8321881bb049950b0a4b