### PR TITLE
feat: enhance calculator theming

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -9,7 +9,7 @@
   --surface: #f2f2f2;
   --ink: #000000;
   --muted: #4b5563;
-  --neutral-sky: #e5e7eb;
+    --neutral-sky: #e0f2fe;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
   --accent: #facc15;
@@ -42,7 +42,7 @@
     --surface: #1a1a1a;
     --ink: #f5f5f5;
     --muted: #9ca3af;
-    --neutral-sky: #1a1a1a;
+      --neutral-sky: #0c4a6e;
     --neutral-warm: #262626;
     --primary: #0057b8;
     --accent: #facc15;

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -132,11 +132,29 @@ const jsonLd = {
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 
 <style>
-  .calc { max-width: 720px; margin: 0 auto; padding: 8px; color: var(--ink); }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  .calc {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px;
+    background: var(--neutral-sky);
+    border: 2px solid var(--primary);
+    border-radius: var(--radius);
+    color: var(--ink);
+    box-shadow: var(--shadow);
+  }
+  h1 {
+    margin: 0 0 16px;
+    font-size: 28px;
+    color: var(--accent-red);
+  }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
-  .field label { display:block; margin: 0 0 6px; font-weight: 600; }
+  .field label {
+    display:block;
+    margin: 0 0 6px;
+    font-weight: 600;
+    color: var(--primary);
+  }
   .field input[type=number], .field input, .field select {
     width: 100%;
     padding: 10px 12px;
@@ -144,30 +162,45 @@ const jsonLd = {
     border-radius: 12px;
     background: var(--card);
     color: var(--ink);
+    box-shadow: var(--shadow);
   }
   .btn {
     display: inline-block;
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--primary);
+    background: var(--accent-red);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
   }
   .btn:hover{ filter:brightness(1.05); }
-  .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
+  .result {
+    margin-top: 16px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--accent);
+    padding: 12px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   .examples,
   .faq,
   .related {
     max-width: 720px;
     margin: 24px auto 0;
-    padding: 8px;
+    padding: 16px;
     color: var(--ink);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
   }
   .examples ul { margin: 8px 0 0 20px; }
   .faq details { margin: 8px 0; }
-  .faq summary { cursor: pointer; font-weight: 600; }
+  .faq summary { cursor: pointer; font-weight: 600; color: var(--primary); }
   .faq p { margin: 4px 0 0 16px; }
   .related ul { margin: 8px 0 0 20px; }
 </style>


### PR DESCRIPTION
## Summary
- apply dynamic Equilibrio Moderno palette to calculator pages
- add stronger shadows and accent colors
- introduce light blue neutral sky tone

## Testing
- `npm test` *(fails: bash: command not found: npm)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.)*

------
https://chatgpt.com/codex/tasks/task_b_68b8adfb315c83218b5dcc9d518b8e9e