### PR TITLE
style: apply Equilibrio Moderno palette to calculators

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -132,7 +132,15 @@ const jsonLd = {
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 
 <style>
-  .calc { max-width: 720px; margin: 0 auto; padding: 8px; color: var(--ink); }
+  .calc {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 8px;
+    color: var(--ink);
+    background: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+  }
   h1 { margin: 0 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
@@ -144,19 +152,34 @@ const jsonLd = {
     border-radius: 12px;
     background: var(--card);
     color: var(--ink);
+    box-shadow: var(--shadow);
   }
   .btn {
     display: inline-block;
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--primary);
+    background: var(--accent-red);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
   }
   .btn:hover{ filter:brightness(1.05); }
-  .result { margin-top: 16px; font-size: 18px; font-weight: 600; color: var(--ink); }
+  .result {
+    margin-top: 16px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--bg);
+    border-radius: var(--radius);
+    box-shadow: none;
+    padding: 12px;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+  }
+  .result:not(:empty) {
+    background: var(--accent);
+    box-shadow: var(--shadow);
+  }
   .examples,
   .faq,
   .related {
@@ -164,6 +187,9 @@ const jsonLd = {
     margin: 24px auto 0;
     padding: 8px;
     color: var(--ink);
+    background: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
   }
   .examples ul { margin: 8px 0 0 20px; }
   .faq details { margin: 8px 0; }


### PR DESCRIPTION
## Summary
- Add card-like background and shadow to calculator sections
- Style inputs, results, and related sections with Equilibrio Moderno palette
- Make calculate button red and highlight results in mustard yellow with depth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b17bed04832190c122108168dbf0