### PR TITLE
Remove duplicated examples sections

### DIFF
--- a/src/pages/calculators/banana-dose-converter.mdx
+++ b/src/pages/calculators/banana-dose-converter.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1 µSv ⇒ 10 bananas
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-

--- a/src/pages/calculators/bandwidth-delay-product.mdx
+++ b/src/pages/calculators/bandwidth-delay-product.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 100 Mbps with 50 ms ⇒ 625000 bytes
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Battery Life Estimator](/calculators/battery-life-estimator/)
-- [Cpu Power To Current](/calculators/cpu-power-to-current/)
-- [Ping Distance Estimator](/calculators/ping-distance-estimator/)
-- [Screen Ppi Calculator](/calculators/screen-ppi-calculator/)
-

--- a/src/pages/calculators/battery-life-estimator.mdx
+++ b/src/pages/calculators/battery-life-estimator.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 3000 mAh at 150 mA ⇒ 20 h
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Cpu Power To Current](/calculators/cpu-power-to-current/)
-- [Bandwidth Delay Product](/calculators/bandwidth-delay-product/)
-- [Ping Distance Estimator](/calculators/ping-distance-estimator/)
-- [Screen Ppi Calculator](/calculators/screen-ppi-calculator/)
-

--- a/src/pages/calculators/beard-second-to-meters.mdx
+++ b/src/pages/calculators/beard-second-to-meters.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1 beard-second ⇒ 5e-9 m
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-

--- a/src/pages/calculators/bmi-prime.mdx
+++ b/src/pages/calculators/bmi-prime.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 70 kg and 175 cm ⇒ 0.91
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sleep Debt Weekly](/calculators/sleep-debt-weekly/)
-- [Sugar Cube Equivalent](/calculators/sugar-cube-equivalent/)
-- [Caffeine Half Life](/calculators/caffeine-half-life/)
-- [Protein Calorie Percentage](/calculators/protein-calorie-percentage/)
-

--- a/src/pages/calculators/brick-count-estimator.mdx
+++ b/src/pages/calculators/brick-count-estimator.mdx
@@ -60,16 +60,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 10 m² wall, 20×6 cm bricks ⇒ ~833 bricks
-
-## Related calculators
-
-- [Paint Coverage](/calculators/paint-coverage/)
-- [Garden Soil Volume](/calculators/garden-soil-volume/)
-- [Home Diy Division Calculator](/calculators/home-diy-division-calculator/)
-- [Rainwater Harvest](/calculators/rainwater-harvest/)
-- [Garden Soil Weight](/calculators/garden-soil-weight/)
-- [Rain Barrel Fill Time](/calculators/rain-barrel-fill-time/)
-

--- a/src/pages/calculators/caffeine-half-life.mdx
+++ b/src/pages/calculators/caffeine-half-life.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 200 mg after 5 h ⇒ 100 mg
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sleep Debt Weekly](/calculators/sleep-debt-weekly/)
-- [Sugar Cube Equivalent](/calculators/sugar-cube-equivalent/)
-- [Protein Calorie Percentage](/calculators/protein-calorie-percentage/)
-- [Bmi Prime](/calculators/bmi-prime/)
-

--- a/src/pages/calculators/circumference-from-area.mdx
+++ b/src/pages/calculators/circumference-from-area.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- Area 50 ⇒ 25.07 circumference
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Geometric Series Sum](/calculators/geometric-series-sum/)
-- [Triangle Inradius](/calculators/triangle-inradius/)
-- [Triangle Area Heron](/calculators/triangle-area-heron/)
-

--- a/src/pages/calculators/coffee-to-water-ratio.mdx
+++ b/src/pages/calculators/coffee-to-water-ratio.mdx
@@ -54,16 +54,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 30 g at 1:15 ⇒ 450 g water
-
-## Related calculators
-
-- [Discount Calculator](/calculators/discount-calculator/)
-- [Discount Calculator 2](/calculators/discount-calculator-2/)
-- [Tip Calculator 2](/calculators/tip-calculator-2/)
-- [Reading Time Estimator](/calculators/reading-time-estimator/)
-- [Travel Budget Per Day](/calculators/travel-budget-per-day/)
-- [Recipe Scale Factor](/calculators/recipe-scale-factor/)
-

--- a/src/pages/calculators/cpu-power-to-current.mdx
+++ b/src/pages/calculators/cpu-power-to-current.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 95 W at 12 V ⇒ 7.92 A
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Battery Life Estimator](/calculators/battery-life-estimator/)
-- [Bandwidth Delay Product](/calculators/bandwidth-delay-product/)
-- [Ping Distance Estimator](/calculators/ping-distance-estimator/)
-- [Screen Ppi Calculator](/calculators/screen-ppi-calculator/)
-

--- a/src/pages/calculators/crypto-mining-breakeven.mdx
+++ b/src/pages/calculators/crypto-mining-breakeven.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $3000 cost, $10 profit ⇒ 300 days
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Freelancer Hourly Rate](/calculators/freelancer-hourly-rate/)
-- [Subscription Ltv](/calculators/subscription-ltv/)
-- [Emergency Fund Duration](/calculators/emergency-fund-duration/)
-- [Fire Number](/calculators/fire-number/)
-

--- a/src/pages/calculators/emergency-fund-duration.mdx
+++ b/src/pages/calculators/emergency-fund-duration.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $5000 and $1500 expenses ⇒ 3.33 months
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Crypto Mining Breakeven](/calculators/crypto-mining-breakeven/)
-- [Freelancer Hourly Rate](/calculators/freelancer-hourly-rate/)
-- [Subscription Ltv](/calculators/subscription-ltv/)
-- [Fire Number](/calculators/fire-number/)
-

--- a/src/pages/calculators/fire-number.mdx
+++ b/src/pages/calculators/fire-number.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $40k at 4% ⇒ $1,000,000
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Crypto Mining Breakeven](/calculators/crypto-mining-breakeven/)
-- [Freelancer Hourly Rate](/calculators/freelancer-hourly-rate/)
-- [Subscription Ltv](/calculators/subscription-ltv/)
-- [Emergency Fund Duration](/calculators/emergency-fund-duration/)
-

--- a/src/pages/calculators/freelancer-hourly-rate.mdx
+++ b/src/pages/calculators/freelancer-hourly-rate.mdx
@@ -59,16 +59,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $80k income, 30h/week, 48 weeks ⇒ ~$55.56/hr
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Crypto Mining Breakeven](/calculators/crypto-mining-breakeven/)
-- [Subscription Ltv](/calculators/subscription-ltv/)
-- [Emergency Fund Duration](/calculators/emergency-fund-duration/)
-- [Fire Number](/calculators/fire-number/)
-

--- a/src/pages/calculators/furlongs-per-fortnight.mdx
+++ b/src/pages/calculators/furlongs-per-fortnight.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1000 fpf ⇒ 0.1663 m/s
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Banana Dose Converter](/calculators/banana-dose-converter/)
-

--- a/src/pages/calculators/garden-soil-weight.mdx
+++ b/src/pages/calculators/garden-soil-weight.mdx
@@ -68,16 +68,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 2×1×0.5 m at 1200 kg/m³ ⇒ 1200 kg
-
-## Related calculators
-
-- [Paint Coverage](/calculators/paint-coverage/)
-- [Garden Soil Volume](/calculators/garden-soil-volume/)
-- [Home Diy Division Calculator](/calculators/home-diy-division-calculator/)
-- [Rainwater Harvest](/calculators/rainwater-harvest/)
-- [Brick Count Estimator](/calculators/brick-count-estimator/)
-- [Rain Barrel Fill Time](/calculators/rain-barrel-fill-time/)
-

--- a/src/pages/calculators/geometric-series-sum.mdx
+++ b/src/pages/calculators/geometric-series-sum.mdx
@@ -60,16 +60,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- a1=2, r=0.5, n=4 ⇒ 3.75
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Circumference From Area](/calculators/circumference-from-area/)
-- [Triangle Inradius](/calculators/triangle-inradius/)
-- [Triangle Area Heron](/calculators/triangle-area-heron/)
-

--- a/src/pages/calculators/heart-rate-reserve-percentage.mdx
+++ b/src/pages/calculators/heart-rate-reserve-percentage.mdx
@@ -59,16 +59,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- Rest 60, max 190, current 150 ⇒ 69%
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sleep Debt Weekly](/calculators/sleep-debt-weekly/)
-- [Sugar Cube Equivalent](/calculators/sugar-cube-equivalent/)
-- [Caffeine Half Life](/calculators/caffeine-half-life/)
-- [Protein Calorie Percentage](/calculators/protein-calorie-percentage/)
-

--- a/src/pages/calculators/hogsheads-to-liters.mdx
+++ b/src/pages/calculators/hogsheads-to-liters.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1 hogshead ⇒ 238.481 L
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-- [Banana Dose Converter](/calculators/banana-dose-converter/)
-

--- a/src/pages/calculators/loss-recovery-percentage.mdx
+++ b/src/pages/calculators/loss-recovery-percentage.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- A 25% drop needs ≈33.33% gain
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Crypto Mining Breakeven](/calculators/crypto-mining-breakeven/)
-- [Freelancer Hourly Rate](/calculators/freelancer-hourly-rate/)
-- [Subscription Ltv](/calculators/subscription-ltv/)
-- [Emergency Fund Duration](/calculators/emergency-fund-duration/)
-

--- a/src/pages/calculators/mars-sol-to-earth-days.mdx
+++ b/src/pages/calculators/mars-sol-to-earth-days.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 3 sols ⇒ 3.0825 Earth days
-
-## Related calculators
-
-- [Duration Seconds](/calculators/duration-seconds/)
-- [Days To Hours](/calculators/days-to-hours/)
-- [Microfortnight To Seconds](/calculators/microfortnight-to-seconds/)
-- [Pomodoro Planner](/calculators/pomodoro-planner/)
-- [Earth Years To Mars Years](/calculators/earth-years-to-mars-years/)
-- [Jiffies To Seconds](/calculators/jiffies-to-seconds/)
-

--- a/src/pages/calculators/meters-to-feet.mdx
+++ b/src/pages/calculators/meters-to-feet.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 2 m ⇒ 6.56168 ft
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-- [Banana Dose Converter](/calculators/banana-dose-converter/)
-

--- a/src/pages/calculators/microfortnight-to-seconds.mdx
+++ b/src/pages/calculators/microfortnight-to-seconds.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 10 µfortnights ⇒ 12.096 s
-
-## Related calculators
-
-- [Duration Seconds](/calculators/duration-seconds/)
-- [Days To Hours](/calculators/days-to-hours/)
-- [Mars Sol To Earth Days](/calculators/mars-sol-to-earth-days/)
-- [Pomodoro Planner](/calculators/pomodoro-planner/)
-- [Earth Years To Mars Years](/calculators/earth-years-to-mars-years/)
-- [Jiffies To Seconds](/calculators/jiffies-to-seconds/)
-

--- a/src/pages/calculators/ping-distance-estimator.mdx
+++ b/src/pages/calculators/ping-distance-estimator.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 50 ms ⇒ ~7494 km
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Battery Life Estimator](/calculators/battery-life-estimator/)
-- [Cpu Power To Current](/calculators/cpu-power-to-current/)
-- [Bandwidth Delay Product](/calculators/bandwidth-delay-product/)
-- [Screen Ppi Calculator](/calculators/screen-ppi-calculator/)
-

--- a/src/pages/calculators/point-distance.mdx
+++ b/src/pages/calculators/point-distance.mdx
@@ -65,16 +65,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- (0,0) to (3,4) ⇒ 5
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Geometric Series Sum](/calculators/geometric-series-sum/)
-- [Circumference From Area](/calculators/circumference-from-area/)
-- [Triangle Inradius](/calculators/triangle-inradius/)
-

--- a/src/pages/calculators/polygon-diagonals.mdx
+++ b/src/pages/calculators/polygon-diagonals.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- Hexagon ⇒ 9 diagonals
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Geometric Series Sum](/calculators/geometric-series-sum/)
-- [Circumference From Area](/calculators/circumference-from-area/)
-- [Triangle Inradius](/calculators/triangle-inradius/)
-

--- a/src/pages/calculators/pomodoro-planner.mdx
+++ b/src/pages/calculators/pomodoro-planner.mdx
@@ -59,16 +59,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 4 sessions ⇒ 110 minutes
-
-## Related calculators
-
-- [Duration Seconds](/calculators/duration-seconds/)
-- [Days To Hours](/calculators/days-to-hours/)
-- [Mars Sol To Earth Days](/calculators/mars-sol-to-earth-days/)
-- [Microfortnight To Seconds](/calculators/microfortnight-to-seconds/)
-- [Earth Years To Mars Years](/calculators/earth-years-to-mars-years/)
-- [Jiffies To Seconds](/calculators/jiffies-to-seconds/)
-

--- a/src/pages/calculators/protein-calorie-percentage.mdx
+++ b/src/pages/calculators/protein-calorie-percentage.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 50 g protein in 2000 kcal ⇒ 10%
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sleep Debt Weekly](/calculators/sleep-debt-weekly/)
-- [Sugar Cube Equivalent](/calculators/sugar-cube-equivalent/)
-- [Caffeine Half Life](/calculators/caffeine-half-life/)
-- [Bmi Prime](/calculators/bmi-prime/)
-

--- a/src/pages/calculators/rainwater-harvest.mdx
+++ b/src/pages/calculators/rainwater-harvest.mdx
@@ -62,16 +62,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 50 m², 20 mm, 80% ⇒ 0.8 m³
-
-## Related calculators
-
-- [Paint Coverage](/calculators/paint-coverage/)
-- [Garden Soil Volume](/calculators/garden-soil-volume/)
-- [Home Diy Division Calculator](/calculators/home-diy-division-calculator/)
-- [Garden Soil Weight](/calculators/garden-soil-weight/)
-- [Brick Count Estimator](/calculators/brick-count-estimator/)
-- [Rain Barrel Fill Time](/calculators/rain-barrel-fill-time/)
-

--- a/src/pages/calculators/reading-time-estimator.mdx
+++ b/src/pages/calculators/reading-time-estimator.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1200 words at 200 wpm ⇒ 6 minutes
-
-## Related calculators
-
-- [Discount Calculator](/calculators/discount-calculator/)
-- [Discount Calculator 2](/calculators/discount-calculator-2/)
-- [Tip Calculator 2](/calculators/tip-calculator-2/)
-- [Coffee To Water Ratio](/calculators/coffee-to-water-ratio/)
-- [Travel Budget Per Day](/calculators/travel-budget-per-day/)
-- [Recipe Scale Factor](/calculators/recipe-scale-factor/)
-

--- a/src/pages/calculators/screen-ppi-calculator.mdx
+++ b/src/pages/calculators/screen-ppi-calculator.mdx
@@ -59,16 +59,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1920×1080 at 24" ⇒ ~92 PPI
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Battery Life Estimator](/calculators/battery-life-estimator/)
-- [Cpu Power To Current](/calculators/cpu-power-to-current/)
-- [Bandwidth Delay Product](/calculators/bandwidth-delay-product/)
-- [Ping Distance Estimator](/calculators/ping-distance-estimator/)
-

--- a/src/pages/calculators/sheppey-to-meters.mdx
+++ b/src/pages/calculators/sheppey-to-meters.mdx
@@ -47,16 +47,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 1 sheppey ⇒ 1400 m
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Smoots To Meters](/calculators/smoots-to-meters/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-

--- a/src/pages/calculators/sleep-debt-weekly.mdx
+++ b/src/pages/calculators/sleep-debt-weekly.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 6 h/night ⇒ 14 h debt
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sugar Cube Equivalent](/calculators/sugar-cube-equivalent/)
-- [Caffeine Half Life](/calculators/caffeine-half-life/)
-- [Protein Calorie Percentage](/calculators/protein-calorie-percentage/)
-- [Bmi Prime](/calculators/bmi-prime/)
-

--- a/src/pages/calculators/smoots-to-meters.mdx
+++ b/src/pages/calculators/smoots-to-meters.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 5 smoots ⇒ 8.509 m
-
-## Related calculators
-
-- [Celsius To Fahrenheit](/calculators/celsius-to-fahrenheit/)
-- [Km To Miles](/calculators/km-to-miles/)
-- [Meters To Feet](/calculators/meters-to-feet/)
-- [Hogsheads To Liters](/calculators/hogsheads-to-liters/)
-- [Furlongs Per Fortnight](/calculators/furlongs-per-fortnight/)
-- [Banana Dose Converter](/calculators/banana-dose-converter/)
-

--- a/src/pages/calculators/ssd-lifespan-years.mdx
+++ b/src/pages/calculators/ssd-lifespan-years.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 600 TBW with 50 GB/day ⇒ 32.9 years
-
-## Related calculators
-
-- [Download Time](/calculators/download-time/)
-- [Storage Redundancy Overhead](/calculators/storage-redundancy-overhead/)
-- [Battery Life Estimator](/calculators/battery-life-estimator/)
-- [Cpu Power To Current](/calculators/cpu-power-to-current/)
-- [Bandwidth Delay Product](/calculators/bandwidth-delay-product/)
-- [Ping Distance Estimator](/calculators/ping-distance-estimator/)
-

--- a/src/pages/calculators/subscription-ltv.mdx
+++ b/src/pages/calculators/subscription-ltv.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $20 for 12 months ⇒ $240 LTV
-
-## Related calculators
-
-- [Percentage Discount](/calculators/percentage-discount/)
-- [Simple Interest](/calculators/simple-interest/)
-- [Crypto Mining Breakeven](/calculators/crypto-mining-breakeven/)
-- [Freelancer Hourly Rate](/calculators/freelancer-hourly-rate/)
-- [Emergency Fund Duration](/calculators/emergency-fund-duration/)
-- [Fire Number](/calculators/fire-number/)
-

--- a/src/pages/calculators/sugar-cube-equivalent.mdx
+++ b/src/pages/calculators/sugar-cube-equivalent.mdx
@@ -48,16 +48,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 16 g ⇒ 4 cubes
-
-## Related calculators
-
-- [Bmi Calculator](/calculators/bmi-calculator/)
-- [Daily Calorie Burn](/calculators/daily-calorie-burn/)
-- [Sleep Debt Weekly](/calculators/sleep-debt-weekly/)
-- [Caffeine Half Life](/calculators/caffeine-half-life/)
-- [Protein Calorie Percentage](/calculators/protein-calorie-percentage/)
-- [Bmi Prime](/calculators/bmi-prime/)
-

--- a/src/pages/calculators/travel-budget-per-day.mdx
+++ b/src/pages/calculators/travel-budget-per-day.mdx
@@ -53,16 +53,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- $1000 over 5 days ⇒ $200/day
-
-## Related calculators
-
-- [Discount Calculator](/calculators/discount-calculator/)
-- [Discount Calculator 2](/calculators/discount-calculator-2/)
-- [Tip Calculator 2](/calculators/tip-calculator-2/)
-- [Coffee To Water Ratio](/calculators/coffee-to-water-ratio/)
-- [Reading Time Estimator](/calculators/reading-time-estimator/)
-- [Recipe Scale Factor](/calculators/recipe-scale-factor/)
-

--- a/src/pages/calculators/triangle-area-heron.mdx
+++ b/src/pages/calculators/triangle-area-heron.mdx
@@ -59,16 +59,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 3,4,5 ⇒ 6
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Geometric Series Sum](/calculators/geometric-series-sum/)
-- [Circumference From Area](/calculators/circumference-from-area/)
-- [Triangle Inradius](/calculators/triangle-inradius/)
-

--- a/src/pages/calculators/triangle-inradius.mdx
+++ b/src/pages/calculators/triangle-inradius.mdx
@@ -62,16 +62,3 @@ export const schema = {
 
 <Calculator schema={schema} />
 
-## Examples
-
-- 3-4-5 triangle ⇒ 1 radius
-
-## Related calculators
-
-- [Percentage Increase](/calculators/percentage-increase/)
-- [Circle Area](/calculators/circle-area/)
-- [Pythagorean Theorem Calculator](/calculators/pythagorean-theorem-calculator/)
-- [Geometric Series Sum](/calculators/geometric-series-sum/)
-- [Circumference From Area](/calculators/circumference-from-area/)
-- [Triangle Area Heron](/calculators/triangle-area-heron/)
-


### PR DESCRIPTION
## Summary
- remove manual `Examples` and `Related calculators` sections, relying on the `<Calculator>` component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8b45955b08321903b8c6bb297b1f9