### PR TITLE
feat: make calculator inputs inset

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -152,7 +152,8 @@ const jsonLd = {
     border-radius: 12px;
     background: var(--card);
     color: var(--ink);
-    box-shadow: var(--shadow);
+    box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.1),
+      inset -2px -2px 4px rgba(255, 255, 255, 0.6);
   }
   .btn {
     display: inline-block;


### PR DESCRIPTION
## Summary
- make calculator input fields appear inset using inner box shadow

## Testing
- `npm test`
- `npx prettier src/components/Calculator.astro --write` *(fails: No parser could be inferred for .astro)*

------
https://chatgpt.com/codex/tasks/task_b_68b8c201ab6083218b79506f2507679e