### PR TITLE
feat: modernize navigation layout

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -80,7 +80,7 @@ a:hover {
   color: var(--accent-red);
 }
 body {
-  padding-top: 96px;
+  padding-top: 72px;
 }
 .container {
   max-width: var(--maxw);
@@ -92,98 +92,27 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  color: var(--primary-ink);
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
   z-index: 50;
   box-shadow: var(--shadow);
 }
 .header a {
-  color: var(--primary-ink);
   text-decoration: none;
 }
-
-.top-bar {
-  background: rgba(0, 87, 184, 0.15);
-  backdrop-filter: blur(8px);
-}
-
-@media (prefers-color-scheme: light) {
-  .top-bar a {
-    color: #000;
-  }
-
-  .top-bar a:hover {
-    color: #000;
-  }
-
-  .top-bar .traditional-btn {
-    border-color: #000;
-  }
-
-  .top-bar .traditional-btn:focus {
-    outline-color: #000;
-  }
-}
-
-.nav-bar {
-  background: rgba(0, 87, 184, 0.6);
-  backdrop-filter: blur(8px);
-  transition: background 0.3s ease;
-  margin-top: 4px;
-  box-shadow: var(--shadow);
-}
-
-.header.scrolled .nav-bar {
-  background: var(--primary);
-  backdrop-filter: none;
-}
-
-.top-bar .container,
-.nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-block: 8px;
-}
-
-.nav {
-  width: 100%;
-}
-.traditional-btn {
-  font-size: 14px;
-  padding: 4px 10px;
-  border: 1px solid var(--primary-ink);
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.1);
-  transition: background 0.2s ease;
-  box-shadow: var(--shadow);
-}
-.traditional-btn:hover,
-.traditional-btn:focus {
-  background: rgba(255, 255, 255, 0.2);
-}
-.traditional-btn:focus {
-  outline: 2px solid var(--primary-ink);
-  outline-offset: 2px;
-}
-.nav-pill {
-  display: block;
-  padding: 6px 14px;
-  border-radius: 9999px;
+.nav-link {
+  display: inline-block;
+  padding: 8px 12px;
   font-weight: 600;
-  text-align: center;
-  transition: background 0.2s ease;
+  color: var(--ink);
+  border-bottom: 2px solid transparent;
 }
-.nav-pill:hover,
-.nav-pill:focus {
-  background: rgba(255, 255, 255, 0.2);
+.nav-link:hover,
+.nav-link:focus {
+  color: var(--accent);
 }
-.nav-pill:focus {
-  outline: 2px solid var(--primary-ink);
-  outline-offset: 2px;
-}
-.nav-pill.active {
-  background: var(--primary-ink);
-  color: var(--primary);
+.nav-link.active {
+  border-bottom-color: var(--accent);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -41,16 +41,16 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
-      <div class="top-bar">
-        <div class="container">
-          <a href="/" aria-label="CalcSimpler" class="logo">CalcSimpler.com</a>
-          <a href="/traditional-calculator/" class="traditional-btn">Traditional Calculator</a>
-        </div>
-      </div>
-      <div class="nav-bar">
-        <nav class="container nav" aria-label="Primary">
-          <a href="/categories/" class={['nav-pill', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
-          <a href="/all" class={['nav-pill', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>All Calculators</a>
+      <div class="container flex items-center justify-between py-4">
+        <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+          <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
+          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
+          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
         </nav>
       </div>
     </header>
@@ -70,12 +70,13 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
       <div style="text-align:center;margin-top:8px;color:var(--muted)">© {new Date().getFullYear()} CalcSimpler.com</div>
     </footer>
     <script is:inline>
-      const header = document.querySelector('.header');
-      const toggleHeader = () => {
-        header.classList.toggle('scrolled', window.scrollY > 0);
-      };
-      toggleHeader();
-      window.addEventListener('scroll', toggleHeader);
+      const btn = document.getElementById('menu-btn');
+      const nav = document.getElementById('nav');
+      btn?.addEventListener('click', () => {
+        const expanded = btn.getAttribute('aria-expanded') === 'true';
+        btn.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('hidden');
+      });
     </script>
   </body>
 </html>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -32,8 +32,7 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`}
-             class="group block rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm hover:shadow-md hover:border-[var(--accent)] transition-all">
+          <a href={`/categories/${cat.slug}/`} class="card group">
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,9 +39,7 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`}
-             class="group block rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm hover:shadow-md hover:border-[var(--accent)] transition-all"
-             aria-label={`${cat.title} calculators`}>
+          <a href={`/categories/${cat.slug}/`} class="card group" aria-label={`${cat.title} calculators`}>
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.


### PR DESCRIPTION
## Summary
- redesign header with neutral style and responsive hamburger menu
- convert category listings to reusable card design
- style navigation links with active state

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8dc8093408321ae9c6ed453bdce70