### PR TITLE
feat: style English header buttons

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -92,27 +92,12 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
+  background: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
   z-index: 50;
-  box-shadow: var(--shadow);
 }
 .header a {
   text-decoration: none;
-}
-.nav-link {
-  display: inline-block;
-  padding: 8px 12px;
-  font-weight: 600;
-  color: var(--ink);
-  border-bottom: 2px solid transparent;
-}
-.nav-link:hover,
-.nav-link:focus {
-  color: var(--accent);
-}
-.nav-link.active {
-  border-bottom-color: var(--accent);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,26 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-white border border-[#E0E0E0] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-3 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class="bg-[#F7F8F9] border border-[#DDDDDD] text-[#1F1F1F] font-normal py-2 px-4 rounded-md hover:bg-[#EDEDED]"
+            >Categories</a
+          >
+          <a
+            href="/all"
+            class="bg-[#F7F8F9] border border-[#DDDDDD] text-[#1F1F1F] font-normal py-2 px-4 rounded-md hover:bg-[#EDEDED]"
+            >All Calculators</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class="bg-[#E03B32] text-white font-bold py-2.5 px-5 rounded-lg hover:bg-[#C9302C] hover:shadow sm:ml-1"
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Translate header navigation to English and add Categories link
- Style navigation buttons and highlight Traditional Calculator
- Simplify header styling with white background and subtle divider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8e2daae648321a29d065cf4d96bec