### PR TITLE
Translate header navigation and style buttons

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -92,10 +92,10 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
+  background: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
   z-index: 50;
-  box-shadow: var(--shadow);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
 }
 .header a {
   text-decoration: none;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,26 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-0 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class="text-[#1F1F1F] font-normal bg-[#F7F8F9] border border-[#DDDDDD] px-4 py-2 rounded-md hover:bg-[#EDEDED] sm:mr-3"
+            >Categories</a
+          >
+          <a
+            href="/all"
+            class="text-[#1F1F1F] font-normal bg-[#F7F8F9] border border-[#DDDDDD] px-4 py-2 rounded-md hover:bg-[#EDEDED]"
+            >All Calculators</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class="text-white font-bold bg-[#E03B32] px-5 py-2.5 rounded-lg hover:bg-[#C9302C] hover:shadow-sm sm:ml-4"
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Translate header links to English and add new "Categories" link
- Style header buttons with neutral and special red theme
- Adjust header background and border for subtle separation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8e448bee88321b0579b0c26737011