### PR TITLE
feat: add traditional calculator header button

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -80,7 +80,7 @@ a:hover {
   color: var(--accent-red);
 }
 body {
-  padding-top: 72px;
+  padding-top: 144px;
 }
 .container {
   max-width: var(--maxw);
@@ -93,7 +93,7 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid #e0e0e0;
   z-index: 50;
   box-shadow: var(--shadow);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -49,9 +49,12 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           </svg>
         </button>
         <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+          <a href="/categories/" class="px-4 py-2 rounded-md font-semibold text-[var(--ink)] bg-[var(--surface)] hover:bg-[var(--neutral-sky)]">Categories</a>
+          <a href="/all" class="px-4 py-2 rounded-md font-semibold text-[var(--ink)] bg-[var(--surface)] hover:bg-[var(--neutral-sky)]">All Calculators</a>
         </nav>
+      </div>
+      <div class="container">
+        <a href="/traditional-calculator/" class="inline-block bg-[#E03B32] text-white font-bold py-3 px-6 rounded-lg my-4 hover:bg-[#C9302C] hover:shadow">Traditional Calculator</a>
       </div>
     </header>
     <main class="container" id="main" role="main">


### PR DESCRIPTION
## Summary
- place Categories and All Calculators buttons in the header top row
- add dedicated Traditional Calculator button below the header with red styling
- add light gray separator under the header and adjust body offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8e68d0b3c83218574c8cfe7f5fbfe