### PR TITLE
feat: add English header buttons and styling

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -93,9 +93,9 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid #e0e0e0;
   z-index: 50;
-  box-shadow: var(--shadow);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .header a {
   text-decoration: none;
@@ -113,6 +113,33 @@ body {
 }
 .nav-link.active {
   border-bottom-color: var(--accent);
+}
+.header-btn {
+  display: inline-block;
+  padding: 12px 24px;
+  font-weight: 600;
+  color: var(--ink);
+  background: #f5f5f5;
+  border-radius: 8px;
+}
+.header-btn:hover,
+.header-btn:focus,
+.header-btn.active {
+  background: #e5e5e5;
+}
+.special-btn {
+  display: inline-block;
+  padding: 12px 24px;
+  font-weight: 700;
+  color: #ffffff;
+  background: #e03b32;
+  border-radius: 8px;
+  margin: 16px 0;
+}
+.special-btn:hover,
+.special-btn:focus {
+  background: #c9302c;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,24 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class={["header-btn", Astro.url.pathname.startsWith('/categories') && 'active']
+              .filter(Boolean)
+              .join(' ')}
+          >Categories</a>
+          <a
+            href="/all"
+            class={["header-btn", Astro.url.pathname.startsWith('/all') && 'active']
+              .filter(Boolean)
+              .join(' ')}
+          >All Calculators</a>
+          <a href="/traditional-calculator/" class="special-btn">Traditional Calculator</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add English header buttons for Categories and All Calculators
- style Traditional Calculator as red call-to-action
- add subtle header divider

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8e87ef3188321b70dc21243606e4e