### PR TITLE
feat: English header with special traditional calculator button

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -93,9 +93,8 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid #E0E0E0;
   z-index: 50;
-  box-shadow: var(--shadow);
 }
 .header a {
   text-decoration: none;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,26 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class={["nav-link bg-[var(--surface)] rounded-lg", Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
+            >Categories</a
+          >
+          <a
+            href="/all"
+            class={["nav-link bg-[var(--surface)] rounded-lg", Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+            >All Calculators</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class="px-4 py-2 my-4 bg-[#E03B32] text-white font-bold rounded-lg hover:bg-[#C9302C] hover:shadow"
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- update navigation to show English buttons for Categories, All Calculators, and a highlighted Traditional Calculator
- add subtle grey divider beneath header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8e91c9d40832193aa963f8923c3ee