### PR TITLE
feat: add English header buttons and special traditional calculator style

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -105,14 +105,28 @@ body {
   padding: 8px 12px;
   font-weight: 600;
   color: var(--ink);
-  border-bottom: 2px solid transparent;
+  background: #f5f5f5;
+  border-radius: 8px;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: var(--accent);
+  background: #e0e0e0;
 }
 .nav-link.active {
-  border-bottom-color: var(--accent);
+  background: #e0e0e0;
+}
+
+.traditional-btn {
+  background: #e03b32;
+  color: #ffffff;
+  font-weight: 700;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.traditional-btn:hover,
+.traditional-btn:focus {
+  background: #c9302c;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
 </head>
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
-    <header class="header" role="banner">
+    <header class="header border-b border-[#E0E0E0]" role="banner">
       <div class="container flex items-center justify-between py-4">
         <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
@@ -48,9 +48,37 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class={[
+              'nav-link',
+              Astro.url.pathname.startsWith('/categories') && 'active'
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            >Categories</a
+          >
+          <a
+            href="/all"
+            class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+            >All Calculators</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class={[
+              'nav-link',
+              'traditional-btn',
+              Astro.url.pathname.startsWith('/traditional-calculator') && 'active'
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add Categories, All Calculators, and Traditional Calculator buttons to header
- style nav links with light backgrounds and red special button
- add subtle bottom border to header for visual separation

## Testing
- `npm test`
- `npx prettier public/styles/theme.css --write`
- `npx prettier src/layouts/BaseLayout.astro --parser astro --write` *(fails: Couldn't resolve parser "astro")*

------
https://chatgpt.com/codex/tasks/task_b_68b8ea70fcfc83218e27e0a0e417f49c