### PR TITLE
feat: redesign top navigation with english buttons

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,17 +40,20 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
 </head>
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
-    <header class="header" role="banner">
-      <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
-          <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+    <header class="header mb-4" role="banner">
+      <div class="container flex flex-col py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex w-full items-center justify-between sm:w-auto">
+          <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+          <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+        <nav id="nav" class="hidden flex flex-col gap-2 mt-4 sm:mt-0 sm:flex sm:flex-row sm:items-center sm:gap-4" aria-label="Primary">
+          <a href="/categories/" class={['px-4 py-2 rounded-md font-semibold text-[var(--ink)] bg-[var(--surface)] hover:bg-[var(--neutral-sky)]', Astro.url.pathname.startsWith('/categories') && 'bg-[var(--neutral-sky)]'].filter(Boolean).join(' ')}>Categories</a>
+          <a href="/all" class={['px-4 py-2 rounded-md font-semibold text-[var(--ink)] bg-[var(--surface)] hover:bg-[var(--neutral-sky)]', Astro.url.pathname.startsWith('/all') && 'bg-[var(--neutral-sky)]'].filter(Boolean).join(' ')}>All Calculators</a>
+          <a href="/traditional-calculator/" class={['px-4 py-2 rounded-md font-bold text-white bg-[#E03B32] hover:bg-[#C9302C] hover:shadow', Astro.url.pathname.startsWith('/traditional-calculator') && 'shadow'].filter(Boolean).join(' ')}>Traditional Calculator</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- restructure header layout to keep logo left and navigation buttons on right
- add Categories, All Calculators, and special red Traditional Calculator button
- ensure header pushes content down when mobile menu opens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8eb6d3b748321afc816b699461185