### PR TITLE
style: update header navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -105,14 +105,29 @@ body {
   padding: 8px 12px;
   font-weight: 600;
   color: var(--ink);
-  border-bottom: 2px solid transparent;
+  background: var(--card);
+  border-radius: 12px;
+  text-decoration: none;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: var(--accent);
+  background: #f0f0f0;
 }
 .nav-link.active {
-  border-bottom-color: var(--accent);
+  background: #e0e0e0;
+}
+.nav-link.special {
+  background: #e03b32;
+  color: #ffffff;
+  font-weight: 700;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.nav-link.special:hover,
+.nav-link.special:focus {
+  background: #c9302c;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  color: #ffffff;
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,8 +40,8 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
 </head>
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
-    <header class="header" role="banner">
-      <div class="container flex items-center justify-between py-4">
+    <header class="header border-b-[3px] border-[#E0E0E0]" role="banner">
+      <div class="container relative flex items-center justify-between py-4">
         <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -49,8 +49,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           </svg>
         </button>
         <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+          <a href="/categories/" class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
+          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>All Calculators</a>
+          <a href="/traditional-calculator/" class={['nav-link', 'special', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Traditional Calculator</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- show site navigation in English with new Categories, All Calculators, and Traditional Calculator buttons
- add distinct styling for navigation buttons and highlight the Traditional Calculator link in red
- add a subtle bottom border to the header for visual separation

## Testing
- `npm test`
- `npx prettier --write src/layouts/BaseLayout.astro public/styles/theme.css` *(fails: No parser could be inferred for file "/workspace/niche-calculator-network/src/layouts/BaseLayout.astro".)*


------
https://chatgpt.com/codex/tasks/task_b_68b8ece59d4c8321b79d5bd89db4ed5f