### PR TITLE
feat: redesign header navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -93,9 +93,9 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 3px solid #e0e0e0;
   z-index: 50;
-  box-shadow: var(--shadow);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 .header a {
   text-decoration: none;
@@ -105,14 +105,29 @@ body {
   padding: 8px 12px;
   font-weight: 600;
   color: var(--ink);
-  border-bottom: 2px solid transparent;
+  background: var(--surface);
+  border-radius: 8px;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: var(--accent);
+  background: var(--neutral-sky);
+  color: var(--ink);
 }
 .nav-link.active {
-  border-bottom-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent) inset;
+}
+.nav-link.nav-special {
+  background: #e03b32;
+  color: #ffffff;
+  font-weight: 700;
+  margin-block: 10px;
+}
+.nav-link.nav-special:hover,
+.nav-link.nav-special:focus {
+  background: #003b73;
+  color: #ffffff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,32 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+          aria-label="Primary"
+        >
+          <a
+            href="/categories/"
+            class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
+            >Categories</a
+          >
+          <a
+            href="/all"
+            class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+            >All Calculators</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class={[
+              'nav-link',
+              'nav-special',
+              Astro.url.pathname.startsWith('/traditional-calculator') && 'active',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- localize header navigation to English
- add Categories and All Calculators buttons
- highlight Traditional Calculator with a special red button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8ee959e488321aebe393e0901093b