### PR TITLE
Refine header navigation with styled buttons

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -93,26 +93,41 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 3px solid #E0E0E0;
   z-index: 50;
-  box-shadow: var(--shadow);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .header a {
   text-decoration: none;
 }
-.nav-link {
+.nav-btn {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 600;
   color: var(--ink);
-  border-bottom: 2px solid transparent;
+  background: #f5f5f4;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background 0.12s ease, color 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
 }
-.nav-link:hover,
-.nav-link:focus {
-  color: var(--accent);
+.nav-btn:hover,
+.nav-btn:focus {
+  background: #FFDB58;
+  color: #ffffff;
+  font-weight: 700;
+  box-shadow: none;
+  transform: translateY(1px);
 }
-.nav-link.active {
-  border-bottom-color: var(--accent);
+.nav-btn.special {
+  background: #E03B32;
+  color: #ffffff;
+}
+.nav-btn.special:hover,
+.nav-btn.special:focus {
+  background: #003366;
+  color: #ffffff;
+  box-shadow: none;
+  transform: translateY(1px);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -41,16 +41,17 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
-      <div class="container flex items-center justify-between py-4">
+      <div class="container flex items-center justify-between py-4 relative">
         <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)] relative z-20" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav id="nav" class="hidden absolute z-10 top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
+          <a href="/categories/" class={['nav-btn', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}>Categories</a>
+          <a href="/all" class={['nav-btn', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>All Calculators</a>
+          <a href="/traditional-calculator/" class={['nav-btn', 'special', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Traditional Calculator</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Add English navigation buttons for Categories, All Calculators, and a special Traditional Calculator button.
- Style navigation buttons with hover effects and persistent hamburger visibility.
- Add 3px light gray bottom border and subtle shadow to separate header from content.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8ef70cc2883218f13a11a2bb4ca17