### PR TITLE
feat: redesign header buttons

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -93,26 +93,49 @@ body {
   left: 0;
   width: 100%;
   background: var(--card);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 3px solid #E0E0E0;
   z-index: 50;
   box-shadow: var(--shadow);
 }
 .header a {
   text-decoration: none;
 }
-.nav-link {
+
+.header-btn {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 600;
+  background: #F3F4F6;
+  border-radius: 8px;
   color: var(--ink);
-  border-bottom: 2px solid transparent;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  transition: all 0.15s ease-in-out;
 }
-.nav-link:hover,
-.nav-link:focus {
-  color: var(--accent);
+.header-btn:hover,
+.header-btn:focus {
+  background: #D4A017;
+  color: #FFFFFF;
+  font-weight: 700;
+  box-shadow: none;
+  transform: translateY(1px);
 }
-.nav-link.active {
-  border-bottom-color: var(--accent);
+
+.header-special {
+  display: inline-block;
+  padding: 8px 12px;
+  font-weight: 700;
+  background: #E03B32;
+  color: #FFFFFF;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  transition: all 0.15s ease-in-out;
+}
+.header-special:hover,
+.header-special:focus {
+  background: #003B8C;
+  color: #FFFFFF;
+  box-shadow: none;
+  transform: translateY(1px);
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -41,7 +41,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
   <body>
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
-      <div class="container flex items-center justify-between py-4">
+      <div class="container relative flex items-center justify-between py-4">
         <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -49,8 +49,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           </svg>
         </button>
         <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+          <a href="/categories/" class="header-btn">Categories</a>
+          <a href="/all" class="header-btn">All Calculators</a>
+          <a href="/traditional-calculator/" class="header-special">Traditional Calculator</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- restyle header with categories and all calculators buttons plus a special traditional calculator button
- add dedicated button styles and heavier bottom border for clearer separation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8eff977988321972626987d8fea7e