### PR TITLE
feat: add categories button and restyle navigation

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -106,13 +106,31 @@ body {
   font-weight: 600;
   color: var(--ink);
   border-bottom: 2px solid transparent;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  border-radius: 4px;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    background-color 0.12s ease,
+    color 0.12s ease;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: var(--accent);
+  transform: translateY(-1px);
+  background: #1e3a8a;
+  color: #ffffff;
+  font-weight: 700;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
 }
 .nav-link.active {
   border-bottom-color: var(--accent);
+}
+
+.nav-link--traditional {
+  background: var(--accent-red);
+  color: #ffffff;
+  font-weight: 700;
 }
 @media (max-width: 640px) {
   footer .links {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,26 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none sm:justify-end"
+          aria-label="Primary"
+        >
+          <a
+            href="/all"
+            class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+            >All Calculators</a
+          >
+          <a
+            href="/categories/"
+            class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
+            >Categories</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class={['nav-link nav-link--traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- translate calculator links to English and add new Categories button
- style header buttons with shadows, red Traditional Calculator, and hover effects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8f3a7c5b083218d3705996fd07f43