### PR TITLE
Refine navigation buttons and responsive layout

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -20,7 +20,7 @@
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
   --radius: 14px;
   --space: 14px;
-  --maxw: 1120px;
+  --maxw: 100%;
 }
 /*
   When the user prefers a dark colour scheme we override the global
@@ -83,6 +83,7 @@ body {
   padding-top: 72px;
 }
 .container {
+  width: 100%;
   max-width: var(--maxw);
   margin-inline: auto;
   padding-inline: 16px;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,9 +48,26 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <nav id="nav" class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex-col gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none" aria-label="Primary">
-          <a href="/traditional-calculator/" class={['nav-link', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}>Calculadora tradicional</a>
-          <a href="/all" class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}>Todas las calculadoras</a>
+        <nav
+          id="nav"
+          class="hidden absolute top-full right-0 mt-2 flex-col items-end gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-4 sm:border-0 sm:p-0 sm:shadow-none sm:justify-end"
+          aria-label="Primary"
+        >
+          <a
+            href="/all"
+            class="px-4 py-2 rounded shadow bg-[var(--card)] text-[var(--ink)] font-semibold whitespace-nowrap transition hover:shadow-lg hover:bg-blue-800 hover:text-white hover:font-bold"
+            >All Calculators</a
+          >
+          <a
+            href="/categories/"
+            class="px-4 py-2 rounded shadow bg-[var(--card)] text-[var(--ink)] font-semibold whitespace-nowrap transition hover:shadow-lg hover:bg-blue-800 hover:text-white hover:font-bold"
+            >Categories</a
+          >
+          <a
+            href="/traditional-calculator/"
+            class="px-4 py-2 rounded shadow bg-red-600 text-white font-bold whitespace-nowrap transition hover:shadow-lg hover:bg-blue-800 hover:text-white hover:font-bold"
+            >Traditional Calculator</a
+          >
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Translate header links to English and add new "Categories" button
- Style navigation buttons with shadows, right alignment, and red accent for Traditional Calculator
- Ensure full-width responsive layout via container width variable

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b8f52b55fc8321b60537b67635fdb3