### PR TITLE
style: improve header separation and logo spacing

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -95,7 +95,7 @@ body {
   background: var(--card);
   border-bottom: 1px solid var(--border);
   z-index: 50;
-  box-shadow: var(--shadow);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 .header a {
   text-decoration: none;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a href="/" aria-label="CalcSimpler" class="logo text-xl font-bold text-[var(--ink)] mr-4">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- add subtle bottom shadow to header for clearer separation
- add right margin to CalcSimpler.com logo link to prevent crowding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8f7ed6c548321a155bdcf73c032dc