### PR TITLE
feat: apply updated color palette

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,19 +1,20 @@
 :root {
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    The base relies on white and light grey to keep content legible,
+    while red drives primary actions, blue marks links and active
+    states, and yellow provides subtle highlights.
   */
   --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --surface: #f5f5f5;
+  --ink: #374151; /* Dark grey text */
+  --heading: #000000; /* Black headings */
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626; /* Red for primary actions */
+  --secondary: #0057b8; /* Blue for links and active states */
+  --accent: #facc15; /* Yellow accent */
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -41,12 +42,13 @@
     --bg: #0a0a0a;
     --surface: #1a1a1a;
     --ink: #f5f5f5;
+    --heading: #ffffff;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
+    --primary: #dc2626;
+    --secondary: #0057b8;
     --accent: #facc15;
-    --accent-red: #dc2626;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +72,18 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--heading);
 }
 a {
-  color: var(--primary);
+  color: var(--secondary);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--secondary);
+  text-decoration: underline;
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -104,22 +110,28 @@ body {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--secondary);
   background: var(--card);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
+.nav-link:focus,
+.nav-link.active {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--secondary);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
 }
@@ -244,6 +256,7 @@ ul.grid li {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
+.btn,
 .btn-primary {
   background: var(--primary);
   color: var(--primary-ink);
@@ -254,8 +267,34 @@ ul.grid li {
   cursor: pointer;
   box-shadow: var(--shadow);
 }
-.btn-primary:hover {
+.btn:hover,
+.btn:focus,
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+}
+.btn:focus,
+.btn-primary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+.btn-secondary:hover,
+.btn-secondary:focus {
+  filter: brightness(1.05);
+}
+.btn-secondary:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;
@@ -275,4 +314,13 @@ footer .links a {
 footer .links a:hover {
   text-decoration: underline;
   color: var(--accent);
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #000;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
 }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,20 +1,22 @@
-:root{
+:root {
   /* Base tokens for light mode.  These values define the default
-     backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+     backgrounds and accessible text colours used throughout the site. */
+  --bg: #ffffff;
+  --surface: #f5f5f5;
+  --text: #374151; /* Dark grey for body text */
+  --ink: #374151;
+  --heading: #000000; /* Black headings */
+  --muted: #6b7280;
   /* Neutral palette combining soft greys */
-  --neutral-sky:#e5e7eb;
-  --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
-  --ring:#0057B833;
-  --radius:12px;
-  --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
+  --neutral-sky: #e5e7eb;
+  --neutral-warm: #f5f5f4;
+  /* Semantic brand colours */
+  --primary: #dc2626; /* Red for primary actions */
+  --secondary: #0057b8; /* Blue for links and secondary buttons */
+  --accent: #facc15; /* Yellow accent for notices */
+  --ring: #0057b833;
+  --radius: 12px;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
 /*
@@ -31,15 +33,28 @@
     --bg: #0a0a0a;
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
-    /* Primary text becomes light for readability */
+    /* Body text becomes light for readability */
     --text: #f5f5f5;
+    --ink: #f5f5f5;
+    /* Headings in dark mode */
+    --heading: #ffffff;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
-    /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    /* Preserve brand colours and accents in dark mode */
+    --primary: #dc2626;
+    --secondary: #0057b8;
+    --accent: #facc15;
   }
 }
 
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -160,12 +160,17 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus { filter:brightness(1.05); }
+  .btn:focus {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,9 +15,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <meta name="description" content={description} />
     <link rel="canonical" href={href} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <!-- Set the theme colour to match the primary brand colour.  This
-         provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <!-- Set the theme colour to match the primary action colour (red).
+         This provides a consistent browser UI in both light and dark modes. -->
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
     <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <a href="/" class="btn" style="text-decoration:none;">Go back home</a>
   </main>
 </BaseLayout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,14 +4,15 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { yellow: "#FACC15" },
+        neutral: { heading: "#000000", text: "#374151", muted: "#6B7280" },
       },
       boxShadow: {
-        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"
-      }
-    }
+        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- switch site to neutral backgrounds with dark gray body text and black headings
- use red for primary buttons and blue for links and active states with visible focus styles
- add yellow accent badge style for notices

## Testing
- `npm test`
- `npx prettier public/styles/theme.css public/styles/tokens.css tailwind.config.cjs -w`

------
https://chatgpt.com/codex/tasks/task_b_68b8fb6fef78832188cf08f75186e881