### PR TITLE
Revamp site color palette and interactive states

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,19 +1,20 @@
 :root {
   /*
-    Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    Neutral foundation with contrasting accents. Content sits on a
+    light canvas, dark grey text ensures readability and black headlines
+    provide maximum contrast. Blue highlights links, red marks primary
+    actions and a mustard tone draws attention to labels or notices.
   */
   --bg: #ffffff;
   --surface: #f2f2f2;
-  --ink: #000000;
+  --ink: #333333;
+  --headline: #000000;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --link: #0057b8;
+  --action: #dc2626;
+  --accent: #b88a00;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -40,13 +41,14 @@
     */
     --bg: #0a0a0a;
     --surface: #1a1a1a;
-    --ink: #f5f5f5;
+    --ink: #d1d5db;
+    --headline: #ffffff;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --link: #60a5fa;
+    --action: #f87171;
+    --accent: #b88a00;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +72,16 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--headline);
 }
 a {
-  color: var(--primary);
+  color: var(--link);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus-visible {
+  color: var(--link);
+  text-decoration: underline;
 }
 body {
   padding-top: 72px;
@@ -112,14 +116,14 @@ body {
   transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
+.nav-link:focus-visible {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--link);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--action);
   color: #fff;
   font-weight: 700;
 }
@@ -194,7 +198,8 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
+.card:hover,
+.card:focus-visible {
   transform: translateY(-1px);
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.08),
@@ -208,10 +213,38 @@ ul.grid li {
      overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
-  transition: color 0.12s ease;
 }
-.card:hover h3 {
+.label {
+  display: inline-block;
+  transition:
+    color 0.12s ease,
+    text-decoration 0.12s ease,
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.card:hover .label,
+.card:focus-visible .label {
   color: var(--accent);
+  text-decoration: underline;
+  transform: translateY(-1px);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.08),
+    0 10px 28px rgba(0, 0, 0, 0.06);
+}
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.badge:hover,
+.badge:focus-visible {
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.08),
+    0 6px 10px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
 }
 .card p {
   color: var(--muted);
@@ -241,11 +274,11 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--link);
   outline-offset: 1px;
 }
 .btn-primary {
-  background: var(--primary);
+  background: var(--action);
   color: var(--primary-ink);
   border: none;
   border-radius: 12px;
@@ -253,9 +286,15 @@ ul.grid li {
   font-weight: 600;
   cursor: pointer;
   box-shadow: var(--shadow);
+  transition: filter 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus-visible {
   filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.08),
+    0 6px 10px rgba(0, 0, 0, 0.06);
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -3,15 +3,16 @@
      backgrounds, surfaces and text colours used throughout the site. */
   --bg:#ffffff;
   --surface:#f2f2f2;
-  --text:#000000;
+  --text:#333333;
+  --headline:#000000;
   --muted:#4b5563;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  /* Primary action, link and accent colours */
+  --link:#0057B8;
+  --action:#DC2626;
+  --accent:#B88A00;
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
@@ -32,13 +33,14 @@
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
     /* Primary text becomes light for readability */
-    --text: #f5f5f5;
+    --text: #d1d5db;
+    --headline: #ffffff;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --link: #60a5fa;
+    --action: #f87171;
+    --accent: #B88A00;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -160,12 +160,13 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--action);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus-visible{ filter:brightness(1.05); }
   .result {
     margin-top: 16px;
     font-size: 18px;
@@ -180,6 +181,8 @@ const jsonLd = {
   .result:not(:empty) {
     background: var(--accent);
     box-shadow: var(--shadow);
+    color: var(--primary-ink);
+    font-weight: 700;
   }
   .examples,
   .faq,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
     <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--action); color:var(--primary-ink); text-decoration:none;">Go back home</a>
   </main>
 </BaseLayout>

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -17,7 +17,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
       {items.map((it) => (
         <div>
           <a class="card" href={it.url}>
-            <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+            <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
             <p>{it.fm.intro || it.fm.description || ''}</p>
           </a>
         </div>

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -74,7 +74,7 @@ const { cat, list = [] } = Astro.props;
         {list.map((c) => (
           <div>
             <a class="card" href={`/calculators/${c.slug}/`}>
-              <h3>{c.title}</h3>
+              <h3 class="label">{c.title}</h3>
               <p>{c.intro ?? ''}</p>
             </a>
           </div>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="label text-lg font-semibold text-[var(--ink)]">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -17,10 +17,10 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="card">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="label text-lg font-semibold text-[var(--ink)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>

--- a/src/pages/everyday.astro
+++ b/src/pages/everyday.astro
@@ -14,10 +14,10 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="card">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="label text-lg font-semibold text-[var(--ink)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -30,7 +30,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="label text-lg font-semibold text-[var(--ink)]">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -27,7 +27,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/src/pages/science.astro
+++ b/src/pages/science.astro
@@ -16,10 +16,10 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="card">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="label text-lg font-semibold text-[var(--ink)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--muted)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -23,7 +23,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
         {list.map((it) => (
           <div>
             <a class="card" href={it.url}>
-              <h3>{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
+              <h3 class="label">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</h3>
               <p>{it.fm.intro || it.fm.description || ''}</p>
             </a>
           </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        action: "#DC2626",
+        link: "#0057B8",
+        accent: { mustard: "#B88A00" },
+        neutral: { ink: "#333333", headline: "#000000", muted: "#4B5563" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- apply neutral theme with dark text, black headlines, red action buttons and blue links
- add mustard accent badges and hover depth for category/calculator labels
- ensure buttons and links have visible hover and focus states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b8ff887c1c8321ab2b5bda88127588