### PR TITLE
Apply new accessible color scheme

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,19 +1,20 @@
 :root {
   /*
-    Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    Neutral foundation with vibrant accents.
+    A light grey background and white surfaces keep content legible,
+    while red drives primary actions and blue covers links and secondary
+    elements. A dark mustard accent highlights notices.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --bg: #f8f9fa;
+  --surface: #ffffff;
+  --ink: #374151;
+  --headline: #000000;
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -40,13 +41,13 @@
     */
     --bg: #0a0a0a;
     --surface: #1a1a1a;
-    --ink: #f5f5f5;
+    --ink: #e5e7eb;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --secondary: #0057b8;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +71,19 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--headline);
 }
 a {
-  color: var(--primary);
+  color: var(--secondary);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+a:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -109,19 +115,31 @@ body {
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--secondary);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
+.nav-link:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
+}
+.nav-link.traditional:hover,
+.nav-link.traditional:focus {
+  background: var(--primary);
+  color: #fff;
 }
 @media (max-width: 640px) {
   footer .links {
@@ -194,12 +212,17 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
-  transform: translateY(-1px);
+.card:hover,
+.card:focus {
+  transform: translateY(-2px);
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.08),
     0 10px 28px rgba(0, 0, 0, 0.06);
   border-color: var(--accent);
+}
+.card:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -210,7 +233,8 @@ ul.grid li {
   white-space: normal;
   transition: color 0.12s ease;
 }
-.card:hover h3 {
+.card:hover h3,
+.card:focus h3 {
   color: var(--accent);
 }
 .card p {
@@ -241,7 +265,7 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--secondary);
   outline-offset: 1px;
 }
 .btn-primary {
@@ -256,6 +280,27 @@ ul.grid li {
 }
 .btn-primary:hover {
   filter: brightness(1.05);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--primary-ink);
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+.btn-secondary:hover {
+  filter: brightness(1.05);
+}
+.btn-secondary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,20 +1,21 @@
-:root{
+:root {
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+  --bg: #f8f9fa;
+  --surface: #ffffff;
+  --text: #374151;
+  --headline: #000000;
+  --muted: #6b7280;
   /* Neutral palette combining soft greys */
-  --neutral-sky:#e5e7eb;
-  --neutral-warm:#f5f5f4;
+  --neutral-sky: #e5e7eb;
+  --neutral-warm: #f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
-  --ring:#0057B833;
-  --radius:12px;
-  --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b; /* Mustard accent */
+  --ring: #0057b833;
+  --radius: 12px;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
 /*
@@ -32,14 +33,24 @@
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
     /* Primary text becomes light for readability */
-    --text: #f5f5f5;
+    --text: #e5e7eb;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #dc2626;
+    --secondary: #0057b8;
+    --accent: #b8860b;
   }
 }
 
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -160,12 +160,19 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover {
+    filter: brightness(1.05);
+  }
+  .btn:focus {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (
@@ -42,8 +42,8 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--headline)]">CalcSimpler.com</a>
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--secondary)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,8 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Page not found" description="The page you were looking for does not exist.">
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
-    <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
-    <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <h1 class="text-4xl font-bold mb-4 text-[var(--headline)]">404 — Page not found</h1>
+    <p class="mb-6 text-lg text-[var(--muted)]">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
+    <a href="/" class="btn-primary" style="padding:12px 20px;">Go back home</a>
   </main>
 </BaseLayout>

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -6,7 +6,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">All Calculators</h1>
+    <h1 style="color: var(--headline)">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
   <AdBanner />

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -58,7 +58,7 @@ const { cat, list = [] } = Astro.props;
 
 <BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
+    <h1 style="text-transform:capitalize;color: var(--headline)">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -22,7 +22,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--headline)">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
 
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--headline)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/education.astro
+++ b/src/pages/education.astro
@@ -12,20 +12,20 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
     <main class="container mx-auto px-4 py-10">
-      <h1 class="text-3xl font-bold">{title}</h1>
+      <h1 class="text-3xl font-bold text-[var(--headline)]">{title}</h1>
       <AdBanner />
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="block rounded-xl border border-[var(--border)] p-4 hover:border-[var(--secondary)] hover:shadow-sm transition">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--headline)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--ink)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/everyday.astro
+++ b/src/pages/everyday.astro
@@ -9,20 +9,20 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
     <main class="container mx-auto px-4 py-10">
-      <h1 class="text-3xl font-bold">{title}</h1>
+      <h1 class="text-3xl font-bold text-[var(--headline)]">{title}</h1>
       <AdBanner />
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="block rounded-xl border border-[var(--border)] p-4 hover:border-[var(--secondary)] hover:shadow-sm transition">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--headline)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--ink)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -16,7 +16,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     placeholder when the list is empty.
   */}
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--headline)">
       Smart &amp; Fast<br />Calculators
     </h1>
     <p class="mt-3" style="color: var(--muted)">
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--headline)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -13,7 +13,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/science.astro
+++ b/src/pages/science.astro
@@ -11,20 +11,20 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title}>
     <main class="container mx-auto px-4 py-10">
-      <h1 class="text-3xl font-bold">{title}</h1>
+      <h1 class="text-3xl font-bold text-[var(--headline)]">{title}</h1>
       <AdBanner />
       {list.length ? (
       <div class="grid gap-4 mt-6 sm:grid-cols-2 lg:grid-cols-3">
         {list.map((it) => (
-          <a href={it.url} class="block rounded-xl border border-slate-200 p-4 hover:border-blue-500 hover:shadow-sm transition">
-            <div class="text-sm text-slate-500">{it.fm.cluster || ''}</div>
-            <div class="text-lg font-semibold text-slate-900">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
-            <div class="text-slate-600">{it.fm.description || ''}</div>
+          <a href={it.url} class="block rounded-xl border border-[var(--border)] p-4 hover:border-[var(--secondary)] hover:shadow-sm transition">
+            <div class="text-sm text-[var(--muted)]">{it.fm.cluster || ''}</div>
+            <div class="text-lg font-semibold text-[var(--headline)]">{it.fm.title || it.url.replace('/calculators/','').replace('.mdx','')}</div>
+            <div class="text-[var(--ink)]">{it.fm.description || ''}</div>
           </a>
         ))}
       </div>
     ) : (
-      <p class="text-slate-500"><em>No calculators available in this category.</em></p>
+      <p class="text-[var(--muted)]"><em>No calculators available in this category.</em></p>
     )}
   </main>
 </BaseLayout>

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--headline)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,14 +4,15 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { mustard: "#B8860B", blue: "#0057B8" },
+        neutral: { ink: "#374151", muted: "#6B7280" },
       },
       boxShadow: {
-        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"
-      }
-    }
+        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- Introduce neutral light background, dark text and black headings with updated palette
- Style links, buttons and navigation with red primary actions and blue secondary states, including focus outlines
- Add depth on hover/focus for category and calculator cards for clearer interaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b8ffd45c508321ac53c462112f71b5