### PR TITLE
Refresh site color scheme and interactions

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,20 +1,21 @@
 :root {
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    The base relies on white and soft greys to keep content legible,
+    while red drives primary actions, blue covers links and active
+    states, and a deep mustard highlights key notices.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --ink: #374151;
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b;
   --primary-ink: #ffffff;
+  --heading: #000000;
   --card: #ffffff;
   --border: #e5e7eb;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
@@ -34,7 +35,7 @@
   :root {
     /*
       Adopt a dark palette that remains comfortable on the eyes.  We
-      retain the same blue accent colour while brightening the ink and
+      retain the same red and blue accents while brightening the ink and
       softening the muted tones.  Shadows are strengthened slightly to
       preserve depth on dark surfaces.
     */
@@ -44,10 +45,11 @@
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --secondary: #0057b8;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
+    --heading: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
     --shadow: 0 2px 4px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
@@ -70,14 +72,20 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--heading);
 }
 a {
-  color: var(--primary);
+  color: var(--secondary);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--secondary);
+  text-decoration: underline;
+}
+a:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -112,16 +120,26 @@ body {
   transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
+.nav-link:focus,
+.nav-link.active {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--secondary);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
+.nav-link:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
+}
+.nav-link.traditional:hover,
+.nav-link.traditional:focus {
+  background: var(--primary);
+  filter: brightness(1.05);
 }
 @media (max-width: 640px) {
   footer .links {
@@ -194,11 +212,12 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
-  transform: translateY(-1px);
+.card:hover,
+.card:focus-within {
+  transform: translateY(-2px);
   box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+    0 4px 8px rgba(0, 0, 0, 0.1),
+    0 12px 24px rgba(0, 0, 0, 0.08);
   border-color: var(--accent);
 }
 .card h3 {
@@ -210,7 +229,8 @@ ul.grid li {
   white-space: normal;
   transition: color 0.12s ease;
 }
-.card:hover h3 {
+.card:hover h3,
+.card:focus-within h3 {
   color: var(--accent);
 }
 .card p {
@@ -241,7 +261,7 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--secondary);
   outline-offset: 1px;
 }
 .btn-primary {
@@ -254,8 +274,13 @@ ul.grid li {
   cursor: pointer;
   box-shadow: var(--shadow);
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;
@@ -274,5 +299,5 @@ footer .links a {
 }
 footer .links a:hover {
   text-decoration: underline;
-  color: var(--accent);
+  color: var(--secondary);
 }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,17 +1,18 @@
 :root{
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+  --bg:#f9fafb;
+  --surface:#ffffff;
+  --text:#374151;
+  --muted:#6b7280;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  --primary:#DC2626;
+  --secondary:#0057B8; /* Link and active blue */
+  --accent:#B8860B; /* Dark mustard accent */
+  --heading:#000000;
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
@@ -36,9 +37,10 @@
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #DC2626;
+    --secondary: #0057B8;
+    --accent: #B8860B;
+    --heading: #ffffff;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -93,7 +93,7 @@ const jsonLd = {
         <div id={`hint-${slug}-${i.name}`} class="hint">{i.hint ? i.hint : (i.units ? i.units : '')}</div>
       </div>
     ))}
-    <button type="button" data-action="calc" class="btn">Calculate</button>
+    <button type="button" data-action="calc" class="btn-primary">Calculate</button>
   </form>
 
   <div class="result" data-role="result" aria-live="polite"></div>
@@ -155,17 +155,6 @@ const jsonLd = {
     box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.1),
       inset -2px -2px 4px rgba(255, 255, 255, 0.6);
   }
-  .btn {
-    display: inline-block;
-    padding: 12px 16px;
-    border-radius: 12px;
-    border: 0;
-    background: var(--accent-red);
-    color: var(--primary-ink);
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .btn:hover{ filter:brightness(1.05); }
   .result {
     margin-top: 16px;
     font-size: 18px;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (
@@ -42,8 +42,8 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--heading)]">CalcSimpler.com</a>
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--secondary)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
     <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <a href="/" class="btn-primary">Go back home</a>
   </main>
 </BaseLayout>

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -6,7 +6,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">All Calculators</h1>
+    <h1 style="color: var(--heading)">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
   <AdBanner />

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -58,7 +58,7 @@ const { cat, list = [] } = Astro.props;
 
 <BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
+    <h1 style="text-transform:capitalize;color: var(--heading)">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -22,7 +22,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--heading)">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
 
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--heading)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -16,7 +16,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     placeholder when the list is empty.
   */}
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--heading)">
       Smart &amp; Fast<br />Calculators
     </h1>
     <p class="mt-3" style="color: var(--muted)">
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--heading)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -13,7 +13,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { mustard: "#B8860B" },
+        neutral: { ink: "#374151", muted: "#6B7280", heading: "#000000" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- overhaul color variables for neutral backgrounds, red primary buttons, blue links, and mustard accents
- deepen hover/focus states for navigation, cards, and buttons
- standardize page headings to new heading color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b902360b788321aec7c5115291640b