### PR TITLE
style: refresh site color scheme

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -7,13 +7,15 @@
   */
   --bg: #ffffff;
   --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --ink: #4b5563; /* default text in dark gray */
+  --heading: #000000; /* headings in black */
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626; /* primary action red */
+  --link: #0057b8; /* link and secondary blue */
+  --link-hover: #1e3a8a;
+  --accent: #b8860b; /* dark mustard accent */
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -40,13 +42,15 @@
     */
     --bg: #0a0a0a;
     --surface: #1a1a1a;
-    --ink: #f5f5f5;
+    --ink: #e5e5e5;
+    --heading: #ffffff;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --link: #3b82f6;
+    --link-hover: #60a5fa;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +74,18 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--heading);
 }
 a {
-  color: var(--primary);
+  color: var(--link);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--link-hover);
+  text-decoration: underline;
+  outline: 2px solid var(--link-hover);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -115,11 +123,13 @@ body {
 .nav-link:focus {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--link-hover);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  outline: 2px solid var(--link-hover);
+  outline-offset: 2px;
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
 }
@@ -192,7 +202,8 @@ ul.grid li {
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
-    border-color 0.12s ease;
+    border-color 0.12s ease,
+    background 0.12s ease;
 }
 .card:hover {
   transform: translateY(-1px);
@@ -200,25 +211,26 @@ ul.grid li {
     0 2px 4px rgba(0, 0, 0, 0.08),
     0 10px 28px rgba(0, 0, 0, 0.06);
   border-color: var(--accent);
+  background: var(--accent);
 }
 .card h3 {
   margin: 2px 0 6px;
   font-size: 18px;
-  /* Allow long calculator names to wrap onto multiple lines without
-     overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
   transition: color 0.12s ease;
-}
-.card:hover h3 {
-  color: var(--accent);
+  color: var(--heading);
 }
 .card p {
   color: var(--muted);
   font-size: 14px;
-  /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
+}
+.card:hover h3,
+.card:hover p {
+  color: var(--primary-ink);
+  font-weight: 700;
 }
 .ad-slot {
   border: 1px dashed var(--border);
@@ -241,7 +253,7 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--link);
   outline-offset: 1px;
 }
 .btn-primary {
@@ -253,9 +265,13 @@ ul.grid li {
   font-weight: 600;
   cursor: pointer;
   box-shadow: var(--shadow);
+  transition: filter 0.2s ease, outline 0.2s ease;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+  outline: 2px solid var(--link-hover);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;
@@ -274,5 +290,5 @@ footer .links a {
 }
 footer .links a:hover {
   text-decoration: underline;
-  color: var(--accent);
+  color: var(--link-hover);
 }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -3,15 +3,16 @@
      backgrounds, surfaces and text colours used throughout the site. */
   --bg:#ffffff;
   --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+  --text:#4b5563; /* dark grey body text */
+  --heading:#000000; /* black headings */
+  --muted:#6b7280;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  /* Brand colours */
+  --primary:#DC2626; /* red for primary actions */
+  --link:#0057B8;    /* blue for links */
+  --accent:#B8860B;  /* dark mustard accent */
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
@@ -32,13 +33,14 @@
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
     /* Primary text becomes light for readability */
-    --text: #f5f5f5;
+    --text: #e5e5e5;
+    --heading: #ffffff;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #DC2626;
+    --link: #3B82F6;
+    --accent: #B8860B;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,7 +141,7 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 0 0 8px; font-size: 28px; color: var(--heading); }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
   .field label { display:block; margin: 0 0 6px; font-weight: 600; }
@@ -160,12 +160,19 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: filter 0.2s ease, outline 0.2s ease;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus {
+    filter: brightness(1.05);
+    outline: 2px solid var(--link-hover);
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;
@@ -180,6 +187,8 @@ const jsonLd = {
   .result:not(:empty) {
     background: var(--accent);
     box-shadow: var(--shadow);
+    color: var(--primary-ink);
+    font-weight: 700;
   }
   .examples,
   .faq,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (
@@ -43,7 +43,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
         <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--link)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -6,7 +6,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">All Calculators</h1>
+    <h1 style="color: var(--heading)">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
   <AdBanner />

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -58,7 +58,7 @@ const { cat, list = [] } = Astro.props;
 
 <BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
+    <h1 style="text-transform:capitalize;color: var(--heading)">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -22,7 +22,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--heading)">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
 
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--heading)] group-hover:underline transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -16,7 +16,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     placeholder when the list is empty.
   */}
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--heading)">
       Smart &amp; Fast<br />Calculators
     </h1>
     <p class="mt-3" style="color: var(--muted)">
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-[var(--heading)] group-hover:underline transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -13,7 +13,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: var(--heading)">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,13 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        // Primary actions use a bold red, while links and secondary
+        // elements rely on a complementary blue.  A dark mustard yellow
+        // provides an accent colour for warnings or highlighted labels.
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { mustard: "#B8860B" },
+        neutral: { title: "#000000", text: "#4B5563" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- apply neutral background with dark gray text and black headings
- use red for primary buttons and blue for links/secondary states
- highlight category cards and notices with dark mustard backgrounds and bold white text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b90399d28083219ba5dca4c7ef27c9