### PR TITLE
feat: update site color scheme

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,15 +5,16 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --ink: #4b5563;
+  --heading: #000000;
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -40,13 +41,14 @@
     */
     --bg: #0a0a0a;
     --surface: #1a1a1a;
-    --ink: #f5f5f5;
+    --ink: #d1d5db;
+    --heading: #ffffff;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --secondary: #3b82f6;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +72,16 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--heading);
 }
 a {
-  color: var(--primary);
-  text-decoration: none;
+  color: var(--secondary);
+  text-decoration: underline;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--accent);
+  text-decoration-thickness: 2px;
 }
 body {
   padding-top: 72px;
@@ -104,22 +108,27 @@ body {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--secondary);
   background: var(--card);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s,
+    transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--secondary);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--primary);
   color: #fff;
   font-weight: 700;
 }
@@ -253,9 +262,18 @@ ul.grid li {
   font-weight: 600;
   cursor: pointer;
   box-shadow: var(--shadow);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    filter 0.12s ease;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.2),
+    0 10px 15px rgba(0, 0, 0, 0.1);
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,20 +1,21 @@
-:root{
+:root {
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --text: #4b5563;
+  --heading: #000000;
+  --muted: #6b7280;
   /* Neutral palette combining soft greys */
-  --neutral-sky:#e5e7eb;
-  --neutral-warm:#f5f5f4;
+  --neutral-sky: #e5e7eb;
+  --neutral-warm: #f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
-  --ring:#0057B833;
-  --radius:12px;
-  --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b; /* Dark mustard accent */
+  --ring: #0057b833;
+  --radius: 12px;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
 /*
@@ -32,14 +33,25 @@
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
     /* Primary text becomes light for readability */
-    --text: #f5f5f5;
+    --text: #d1d5db;
+    --heading: #ffffff;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
-    /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    /* Preserve brand colours and accents in dark mode */
+    --primary: #dc2626;
+    --secondary: #3b82f6;
+    --accent: #b8860b;
   }
 }
 
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -160,12 +160,22 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: transform 0.12s ease, box-shadow 0.12s ease,
+      filter 0.12s ease;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus {
+    filter: brightness(1.05);
+    transform: translateY(-1px);
+    box-shadow:
+      0 4px 6px rgba(0, 0, 0, 0.2),
+      0 10px 15px rgba(0, 0, 0, 0.1);
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,14 +4,15 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { mustard: "#B8860B", blue: "#0057B8" },
+        neutral: { heading: "#000000", text: "#4B5563" },
       },
       boxShadow: {
-        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"
-      }
-    }
+        brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- align design tokens with neutral background, dark text, and black headings
- use red for primary actions, blue for links, and mustard for accents across light and dark themes
- add depth-enhanced hover/focus states for nav links and buttons

## Testing
- `npm test`
- `npx prettier public/styles/theme.css public/styles/tokens.css src/components/Calculator.astro tailwind.config.cjs -w` *(fails: No parser could be inferred for file "/workspace/niche-calculator-network/src/components/Calculator.astro".)*
- `npx prettier public/styles/theme.css public/styles/tokens.css tailwind.config.cjs -w`


------
https://chatgpt.com/codex/tasks/task_b_68b902360b788321aec7c5115291640b