### PR TITLE
style: refine color palette and button states

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -1,20 +1,21 @@
 :root {
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
-    The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    The base relies on light neutrals with dark grey text for legibility.
+    Red drives primary actions while blue handles links and secondary
+    emphasis. A deep mustard yellow is reserved for subtle highlights.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
-  --muted: #4b5563;
+  --bg: #f9fafb;
+  --surface: #ffffff;
+  --ink: #374151;
+  --muted: #6b7280;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626;
+  --secondary: #0057b8;
+  --accent: #b8860b;
   --primary-ink: #ffffff;
+  --headline: #000000;
   --card: #ffffff;
   --border: #e5e7eb;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
@@ -40,14 +41,15 @@
     */
     --bg: #0a0a0a;
     --surface: #1a1a1a;
-    --ink: #f5f5f5;
+    --ink: #e5e7eb;
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --secondary: #0057b8;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
+    --headline: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
     --shadow: 0 2px 4px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
@@ -70,14 +72,21 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--headline);
 }
 a {
-  color: var(--primary);
-  text-decoration: none;
+  color: var(--secondary);
+  text-decoration: underline;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--secondary);
+  filter: brightness(1.2);
+  text-decoration: underline;
+}
+a:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -109,7 +118,7 @@ body {
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition: background 0.2s, box-shadow 0.2s, color 0.2s, transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
@@ -117,6 +126,9 @@ body {
   font-weight: 700;
   background: #1e3a8a;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .nav-link.traditional {
   background: #dc2626;
@@ -194,12 +206,17 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
+.card:hover,
+.card:focus {
   transform: translateY(-1px);
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.08),
     0 10px 28px rgba(0, 0, 0, 0.06);
   border-color: var(--accent);
+}
+.card:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -236,26 +253,57 @@ ul.grid li {
 .input {
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius);
   padding: 10px 12px;
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--secondary);
   outline-offset: 1px;
 }
 .btn-primary {
   background: var(--primary);
   color: var(--primary-ink);
   border: none;
-  border-radius: 12px;
+  border-radius: var(--radius);
   padding: 12px 16px;
   font-weight: 600;
   cursor: pointer;
   box-shadow: var(--shadow);
+  text-decoration: none;
+  transition: filter 0.2s, transform 0.2s, box-shadow 0.2s;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--primary-ink);
+  border: none;
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  text-decoration: none;
+  transition: filter 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.btn-secondary:hover,
+.btn-secondary:focus {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+}
+.btn-secondary:focus {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,19 +1,19 @@
 :root{
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
-  --muted:#4b5563;
+  --bg:#f9fafb;
+  --surface:#ffffff;
+  --text:#374151;
+  --muted:#6b7280;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  --primary:#DC2626;
+  --secondary:#0057B8;
+  --accent:#B8860B; /* Mustard accent */
   --ring:#0057B833;
-  --radius:12px;
+  --radius:14px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
 }
 
@@ -32,13 +32,13 @@
     /* Darker surface for cards and containers */
     --surface: #1a1a1a;
     /* Primary text becomes light for readability */
-    --text: #f5f5f5;
+    --text: #e5e7eb;
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #DC2626;
+    --secondary: #0057B8;
+    --accent: #B8860B;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -93,7 +93,7 @@ const jsonLd = {
         <div id={`hint-${slug}-${i.name}`} class="hint">{i.hint ? i.hint : (i.units ? i.units : '')}</div>
       </div>
     ))}
-    <button type="button" data-action="calc" class="btn">Calculate</button>
+    <button type="button" data-action="calc" class="btn-primary">Calculate</button>
   </form>
 
   <div class="result" data-role="result" aria-live="polite"></div>
@@ -149,23 +149,18 @@ const jsonLd = {
     width: 100%;
     padding: 10px 12px;
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--card);
     color: var(--ink);
     box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.1),
       inset -2px -2px 4px rgba(255, 255, 255, 0.6);
   }
-  .btn {
-    display: inline-block;
-    padding: 12px 16px;
-    border-radius: 12px;
-    border: 0;
-    background: var(--accent-red);
-    color: var(--primary-ink);
-    font-weight: 600;
-    cursor: pointer;
+  .field input[type=number]:focus,
+  .field input:focus,
+  .field select:focus {
+    outline: 2px solid var(--secondary);
+    outline-offset: 1px;
   }
-  .btn:hover{ filter:brightness(1.05); }
   .result {
     margin-top: 16px;
     font-size: 18px;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
     <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <a href="/" class="btn-secondary">Go back home</a>
   </main>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- apply neutral background with dark gray text and black headings
- introduce red primary buttons, blue links/secondary buttons, and mustard accents
- add hover/focus depth for navigation and cards; update calculator and 404 buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b902360b788321aec7c5115291640b