### PR TITLE
feat: apply updated color scheme

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,15 +5,15 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
+  --bg: #f9fafb;
+  --surface: #f3f4f6;
+  --ink: #374151;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --action: #dc2626;
+  --accent: #b8860b;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -45,8 +45,8 @@
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
     --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --action: #dc2626;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +70,16 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: #000000;
 }
 a {
   color: var(--primary);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: #1e3a8a;
+  text-decoration: underline;
 }
 body {
   padding-top: 72px;
@@ -119,7 +121,7 @@ body {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--action);
   color: #fff;
   font-weight: 700;
 }
@@ -194,12 +196,15 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
-  transform: translateY(-1px);
+.card:hover,
+.card:focus {
+  transform: translateY(-2px);
   box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+    0 4px 6px rgba(0, 0, 0, 0.1),
+    0 12px 32px rgba(0, 0, 0, 0.08);
+  background: var(--accent);
   border-color: var(--accent);
+  color: #ffffff;
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -210,8 +215,10 @@ ul.grid li {
   white-space: normal;
   transition: color 0.12s ease;
 }
-.card:hover h3 {
-  color: var(--accent);
+.card:hover h3,
+.card:focus h3 {
+  color: #ffffff;
+  font-weight: 700;
 }
 .card p {
   color: var(--muted);
@@ -219,6 +226,11 @@ ul.grid li {
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
+  transition: color 0.12s ease;
+}
+.card:hover p,
+.card:focus p {
+  color: #ffffff;
 }
 .ad-slot {
   border: 1px dashed var(--border);
@@ -245,6 +257,23 @@ ul.grid li {
   outline-offset: 1px;
 }
 .btn-primary {
+  background: var(--action);
+  color: var(--primary-ink);
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+.btn-primary:hover,
+.btn-primary:focus {
+  background: #b91c1c;
+  outline: 2px solid #1e3a8a;
+  outline-offset: 2px;
+}
+
+.btn-secondary {
   background: var(--primary);
   color: var(--primary-ink);
   border: none;
@@ -254,8 +283,21 @@ ul.grid li {
   cursor: pointer;
   box-shadow: var(--shadow);
 }
-.btn-primary:hover {
-  filter: brightness(1.05);
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background: #1e3a8a;
+  outline: 2px solid #1e3a8a;
+  outline-offset: 2px;
+  color: #ffffff;
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,17 +1,17 @@
 :root{
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
+  --bg:#f9fafb;
+  --surface:#f3f4f6;
+  --text:#374151;
   --muted:#4b5563;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
   --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  --action:#DC2626;
+  --accent:#B8860B; /* Dark mustard accent */
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
@@ -37,8 +37,8 @@
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
     --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --action: #DC2626;
+    --accent: #B8860B;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -160,12 +160,18 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--action);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
+    box-shadow: var(--shadow);
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus {
+    background: #b91c1c;
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;
@@ -180,6 +186,8 @@ const jsonLd = {
   .result:not(:empty) {
     background: var(--accent);
     box-shadow: var(--shadow);
+    color: #ffffff;
+    font-weight: 700;
   }
   .examples,
   .faq,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Set the theme colour to match the primary brand colour.  This
          provides a consistent browser UI in both light and dark modes. -->
-    <meta name="theme-color" content="#0057B8">
+    <meta name="theme-color" content="#DC2626">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (
@@ -43,7 +43,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
         <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--primary)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="container mx-auto px-4 py-20 text-center" style="max-width:640px;">
     <h1 class="text-4xl font-bold mb-4">404 — Page not found</h1>
     <p class="mb-6 text-lg text-slate-600">We couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); background:var(--primary); color:var(--primary-ink); text-decoration:none;">Go back home</a>
+    <a href="/" class="btn-primary" style="padding:12px 20px; border-radius:var(--radius); text-decoration:none;">Go back home</a>
   </main>
 </BaseLayout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        secondary: "#0057B8",
+        accent: { mustard: "#B8860B" },
+        neutral: { ink: "#374151", muted: "#4B5563" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- adopt neutral backgrounds with dark text and black headings
- style red action buttons and blue link states
- add mustard accent hover for category cards and badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b90399d28083219ba5dca4c7ef27c9