### PR TITLE
Refine color palette and calculator results

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,15 +5,15 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
-  --surface: #f2f2f2;
-  --ink: #000000;
+  --bg: #f7f7f7;
+  --surface: #ffffff;
+  --ink: #1a1a1a;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
-  --accent-red: #dc2626;
+  --primary: #dc2626; /* Red for primary actions */
+  --link: #0057b8; /* Blue for links and secondary actions */
+  --accent: #b8860b; /* Dark mustard yellow */
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -44,9 +44,9 @@
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
+    --primary: #dc2626;
+    --link: #0057b8;
+    --accent: #b8860b;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
@@ -70,14 +70,22 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: #000000;
+}
+h1 {
+  margin-top: 2em;
 }
 a {
-  color: var(--primary);
+  color: var(--link);
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+a:focus {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -112,15 +120,20 @@ body {
   transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
+.nav-link:focus,
+.nav-link.active {
   color: #fff;
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--link);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
+.nav-link:focus {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
 .nav-link.traditional {
-  background: #dc2626;
-  color: #fff;
+  background: var(--primary);
+  color: var(--primary-ink);
   font-weight: 700;
 }
 @media (max-width: 640px) {
@@ -194,7 +207,8 @@ ul.grid li {
     box-shadow 0.12s ease,
     border-color 0.12s ease;
 }
-.card:hover {
+.card:hover,
+.card:focus {
   transform: translateY(-1px);
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.08),
@@ -210,7 +224,8 @@ ul.grid li {
   white-space: normal;
   transition: color 0.12s ease;
 }
-.card:hover h3 {
+.card:hover h3,
+.card:focus h3 {
   color: var(--accent);
 }
 .card p {
@@ -241,7 +256,7 @@ ul.grid li {
   background: #fff;
 }
 .input:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--link);
   outline-offset: 1px;
 }
 .btn-primary {
@@ -254,8 +269,13 @@ ul.grid li {
   cursor: pointer;
   box-shadow: var(--shadow);
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus {
   filter: brightness(1.05);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,17 +1,17 @@
 :root{
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
-  --surface:#f2f2f2;
-  --text:#000000;
+  --bg:#f7f7f7; /* Ultra light grey background */
+  --surface:#ffffff; /* White surfaces/cards */
+  --text:#1a1a1a; /* Very dark grey text */
   --muted:#4b5563;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
-  --accent-red:#DC2626;
+  /* Primary and secondary colours */
+  --primary:#dc2626; /* Red for primary actions */
+  --link:#0057B8; /* Blue for links and secondary actions */
+  --accent:#b8860b; /* Dark mustard yellow accent */
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
@@ -36,9 +36,9 @@
     /* Muted text uses a mid‑tone grey */
     --muted: #9ca3af;
     /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
+    --primary: #dc2626;
+    --link: #0057B8;
+    --accent: #b8860b;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,7 +141,7 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 2em 0 8px; font-size: 28px; color: #000; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
   .field label { display:block; margin: 0 0 6px; font-weight: 600; }
@@ -160,25 +160,36 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
     font-weight: 600;
     cursor: pointer;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus {
+    filter:brightness(1.05);
+  }
+  .btn:focus {
+    outline: 2px solid var(--link);
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;
-    font-weight: 600;
-    color: var(--ink);
+    font-weight: 700;
+    color: var(--bg);
     background: var(--bg);
     border-radius: var(--radius);
     box-shadow: none;
     padding: 12px;
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
+  .result:empty {
+    padding: 0;
+  }
   .result:not(:empty) {
     background: var(--accent);
+    color: #fff;
     box-shadow: var(--shadow);
   }
   .examples,

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -6,7 +6,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">All Calculators</h1>
+    <h1 class="text-black">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
   <AdBanner />

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -58,7 +58,7 @@ const { cat, list = [] } = Astro.props;
 
 <BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
+    <h1 style="text-transform:capitalize;color:#000">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -22,7 +22,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold text-black">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
 
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-black group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/disclaimer.astro
+++ b/src/pages/disclaimer.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Disclaimer" description="Educational information only.">
-  <h1 style="margin-top:0"><strong>DISCLAIMER</strong></h1>
+  <h1><strong>DISCLAIMER</strong></h1>
 <br>
 
   <p>

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -16,7 +16,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     placeholder when the list is empty.
   */}
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight text-black">
       Smart &amp; Fast<br />Calculators
     </h1>
     <p class="mt-3" style="color: var(--muted)">
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold text-black group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -13,7 +13,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Privacy Policy" description="Privacy policy for this site.">
-  <h1 style="margin-top:0"><strong>PRIVACY POLICY</strong></h1>
+  <h1><strong>PRIVACY POLICY</strong></h1>
 
 
 <br>

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 class="text-black">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        link: "#0057B8",
+        accent: { mustard: "#B8860B" },
+        neutral: { ink: "#1A1A1A", muted: "#4B5563", light: "#F7F7F7" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- Adopt light gray backgrounds, dark text, and black headings across the site
- Add red primary buttons, blue link states, and mustard accents with improved hover/focus styles
- Show calculator results in bold white on mustard background with depth

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b909e709748321944dc5078359c2e9