### PR TITLE
feat: apply new color scheme and hover interactions

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,14 +5,15 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
+  --bg: #f7f7f7;
   --surface: #f2f2f2;
-  --ink: #000000;
+  --ink: #1a1a1a;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
   --accent: #facc15;
+  --accent-dark: #b38b00;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
   --card: #ffffff;
@@ -46,6 +47,7 @@
     --neutral-warm: #262626;
     --primary: #0057b8;
     --accent: #facc15;
+    --accent-dark: #b38b00;
     --accent-red: #dc2626;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
@@ -70,14 +72,23 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: #000 !important;
+}
+h1 {
+  margin-top: 3em;
 }
 a {
-  color: var(--primary);
+  color: var(--accent);
+  font-weight: 500;
   text-decoration: none;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--accent-dark);
+  font-weight: 700;
+  text-decoration: underline;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 body {
   padding-top: 72px;
@@ -112,16 +123,26 @@ body {
   transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
-  color: #fff;
+.nav-link:focus,
+.nav-link.active {
+  background: var(--accent);
+  color: var(--ink);
   font-weight: 700;
-  background: #1e3a8a;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
 }
 .nav-link.traditional {
   background: #dc2626;
   color: #fff;
   font-weight: 700;
+}
+.nav-link.traditional:hover,
+.nav-link.traditional:focus {
+  background: #dc2626;
+  filter: brightness(1.1);
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
 }
 @media (max-width: 640px) {
   footer .links {
@@ -195,23 +216,30 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(-1px);
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), inset -2px -2px 4px rgba(255, 255, 255, 0.6);
   border-color: var(--accent);
+}
+.card:focus {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
 }
 .card h3 {
   margin: 2px 0 6px;
   font-size: 18px;
+  font-weight: 600;
   /* Allow long calculator names to wrap onto multiple lines without
      overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
-  transition: color 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease;
+  display: inline-block;
+  padding: 0 2px;
 }
 .card:hover h3 {
-  color: var(--accent);
+  background: var(--primary);
+  color: var(--primary-ink);
+  font-weight: 700;
 }
 .card p {
   color: var(--muted);
@@ -245,17 +273,21 @@ ul.grid li {
   outline-offset: 1px;
 }
 .btn-primary {
-  background: var(--primary);
-  color: var(--primary-ink);
+  background: var(--accent);
+  color: var(--ink);
   border: none;
   border-radius: 12px;
   padding: 12px 16px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   box-shadow: var(--shadow);
 }
 .btn-primary:hover {
   filter: brightness(1.05);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,7 +141,7 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 48px 0 8px; font-size: 28px; color:#000; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
   .field label { display:block; margin: 0 0 6px; font-weight: 600; }
@@ -162,14 +162,18 @@ const jsonLd = {
     border: 0;
     background: var(--accent-red);
     color: var(--primary-ink);
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
   }
   .btn:hover{ filter:brightness(1.05); }
+  .btn:focus{
+    outline:2px solid var(--accent-dark);
+    outline-offset:2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;
-    font-weight: 600;
+    font-weight: 700;
     color: var(--ink);
     background: var(--bg);
     border-radius: var(--radius);
@@ -178,7 +182,8 @@ const jsonLd = {
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
   .result:not(:empty) {
-    background: var(--accent);
+    background: var(--accent-dark);
+    color: #fff;
     box-shadow: var(--shadow);
   }
   .examples,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)] transition-all duration-200 hover:text-2xl">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -6,7 +6,7 @@ const items = Object.values(modules).map((m) => ({ url: m.url, fm: m.frontmatter
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
-    <h1 style="color: var(--ink)">All Calculators</h1>
+    <h1 style="color: #000">All Calculators</h1>
     <p style="color: var(--muted)">Explore every calculator available on the site.</p>
   </section>
   <AdBanner />

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -58,7 +58,7 @@ const { cat, list = [] } = Astro.props;
 
 <BaseLayout title={`${cat.title} calculators`} description={`Browse ${cat.title} calculators`}>
   <section class="hero container mx-auto max-w-5xl px-4 pt-10">
-    <h1 style="text-transform:capitalize;color: var(--ink)">{cat.title} Calculators</h1>
+    <h1 style="text-transform:capitalize;color: #000">{cat.title} Calculators</h1>
     <p style="color: var(--muted)">Explore calculators in this category.</p>
   </section>
 

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -22,7 +22,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-3xl sm:text-4xl font-bold" style="color: var(--ink)">Categories</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold" style="color: #000">Categories</h1>
     <p class="mt-2" style="color: var(--muted)">Browse all our calculators by topic.</p>
   </section>
 
@@ -32,7 +32,7 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`} class="card group">
+          <a href={`/categories/${cat.slug}/`} class="card">
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.
@@ -45,7 +45,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/conversions.astro
+++ b/src/pages/conversions.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "conversio
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/date-time.astro
+++ b/src/pages/date-time.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "date & ti
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/finance.astro
+++ b/src/pages/finance.astro
@@ -16,7 +16,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "finance")
     placeholder when the list is empty.
   */}
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "health");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/home-diy.astro
+++ b/src/pages/home-diy.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "home & di
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const CATEGORIES = [
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
   <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: #000">
       Smart &amp; Fast<br />Calculators
     </h1>
     <p class="mt-3" style="color: var(--muted)">
@@ -39,7 +39,7 @@ const CATEGORIES = [
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {CATEGORIES.map((cat) => (
         <li>
-          <a href={`/categories/${cat.slug}/`} class="card group" aria-label={`${cat.title} calculators`}>
+          <a href={`/categories/${cat.slug}/`} class="card" aria-label={`${cat.title} calculators`}>
             <div class="flex items-start gap-3">
               {/**
                * Provide meaningful alt text for icons to improve accessibility.
@@ -53,7 +53,7 @@ const CATEGORIES = [
                 loading="lazy"
               />
               <div>
-                <h3 class="text-lg font-semibold text-[var(--ink)] group-hover:underline group-hover:text-[var(--accent)] transition-colors">{cat.title}</h3>
+                <h3 class="text-lg font-semibold">{cat.title}</h3>
                 <p class="text-sm text-[var(--muted)]">{cat.desc}</p>
               </div>
             </div>

--- a/src/pages/math.astro
+++ b/src/pages/math.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "math");
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/other.astro
+++ b/src/pages/other.astro
@@ -13,7 +13,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === slug);
 ---
 <BaseLayout title={title} description="Browse everyday & misc calculators">
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />

--- a/src/pages/technology.astro
+++ b/src/pages/technology.astro
@@ -9,7 +9,7 @@ const list = items.filter(i => (i.fm.cluster || "").toLowerCase() === "technolog
 ---
 <BaseLayout title={title} description={`Browse ${slug} calculators`}>
     <section class="hero container mx-auto max-w-5xl px-4">
-      <h1 style="color: var(--ink)">{title}</h1>
+      <h1 style="color: #000">{title}</h1>
       <p style="color: var(--muted)">Explore calculators in this category.</p>
     </section>
     <AdBanner />


### PR DESCRIPTION
## Summary
- introduce neutral gray background with dark-gray text and black headings
- add mustard links, red primary buttons, and sinking card hover effects
- style calculator results with bold white text over dark mustard box

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_b_68b90ef7b51c83219867ba66787b9a27