### PR TITLE
feat: refresh site color scheme and hover interactions

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,14 +5,15 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
+  --bg: #f9f9f9;
   --surface: #f2f2f2;
-  --ink: #000000;
+  --ink: #1a1a1a;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
+  --primary: #dc2626;
+  --accent: #d4a017;
+  --accent-dark: #b8860b;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
   --card: #ffffff;
@@ -21,6 +22,8 @@
   --radius: 14px;
   --space: 14px;
   --maxw: 1120px;
+  --blue: #1e3a8a;
+  --heading: #000000;
 }
 /*
   When the user prefers a dark colour scheme we override the global
@@ -44,13 +47,16 @@
     --muted: #9ca3af;
     --neutral-sky: #1a1a1a;
     --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
+    --primary: #dc2626;
+    --accent: #d4a017;
+    --accent-dark: #b8860b;
     --accent-red: #dc2626;
     --primary-ink: #ffffff;
     --card: #1a1a1a;
     --border: #374151;
     --shadow: 0 2px 4px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
+    --blue: #1e3a8a;
+    --heading: #ffffff;
   }
 }
 html,
@@ -70,17 +76,24 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: var(--heading) !important;
 }
 a {
-  color: var(--primary);
+  color: var(--accent);
   text-decoration: none;
+  font-weight: 600;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: var(--accent-dark);
+  text-decoration: underline;
 }
 body {
   padding-top: 72px;
+}
+
+main h1 {
+  margin-top: 48px !important;
 }
 .container {
   max-width: var(--maxw);
@@ -100,11 +113,17 @@ body {
 .header a {
   text-decoration: none;
 }
+.logo {
+  transition: font-size 0.2s ease;
+}
+.logo:hover {
+  font-size: 1.5rem;
+}
 .nav-link {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--accent);
   background: var(--card);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -112,15 +131,16 @@ body {
   transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 .nav-link:hover,
-.nav-link:focus {
-  color: #fff;
+.nav-link:focus,
+.nav-link.active {
+  color: var(--primary-ink);
   font-weight: 700;
-  background: #1e3a8a;
+  background: var(--accent-dark);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .nav-link.traditional {
-  background: #dc2626;
-  color: #fff;
+  background: var(--primary);
+  color: var(--primary-ink);
   font-weight: 700;
 }
 @media (max-width: 640px) {
@@ -178,10 +198,6 @@ ul.grid li {
   list-style: none;
 }
 .card {
-  /* Make cards fill the available width of their grid cell and stack
-     text vertically.  Using display:block ensures that anchor tags
-     expand to the full width of their parent container, preventing
-     content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
   background: var(--card);
@@ -195,23 +211,24 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(-1px);
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3);
   border-color: var(--accent);
 }
 .card h3 {
   margin: 2px 0 6px;
   font-size: 18px;
-  /* Allow long calculator names to wrap onto multiple lines without
-     overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
-  transition: color 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease;
+  display: inline-block;
+  padding: 2px 4px;
+  border-radius: 4px;
 }
 .card:hover h3 {
-  color: var(--accent);
+  background: var(--blue);
+  color: #fff;
+  font-weight: 700;
 }
 .card p {
   color: var(--muted);
@@ -250,12 +267,16 @@ ul.grid li {
   border: none;
   border-radius: 12px;
   padding: 12px 16px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   box-shadow: var(--shadow);
 }
 .btn-primary:hover {
-  filter: brightness(1.05);
+  filter: brightness(0.9);
+}
+.btn-primary:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .faq summary {
   cursor: pointer;

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,10 +141,10 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 48px 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
-  .field label { display:block; margin: 0 0 6px; font-weight: 600; }
+  .field label { display:block; margin: 0 0 6px; font-weight: 700; }
   .field input[type=number], .field input, .field select {
     width: 100%;
     padding: 10px 12px;
@@ -160,25 +160,28 @@ const jsonLd = {
     padding: 12px 16px;
     border-radius: 12px;
     border: 0;
-    background: var(--accent-red);
+    background: var(--primary);
     color: var(--primary-ink);
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
+    transition: filter 0.2s ease;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover { filter: brightness(0.9); }
+  .btn:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   .result {
     margin-top: 16px;
     font-size: 18px;
-    font-weight: 600;
-    color: var(--ink);
+    font-weight: 700;
+    color: var(--bg);
     background: var(--bg);
     border-radius: var(--radius);
     box-shadow: none;
     padding: 12px;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
+    transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   }
   .result:not(:empty) {
-    background: var(--accent);
+    background: var(--accent-dark);
+    color: #fff;
     box-shadow: var(--shadow);
   }
   .examples,

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        primary: "#DC2626",
+        mustard: { DEFAULT: "#D4A017", dark: "#B8860B" },
+        neutral: { light: "#F9F9F9", dark: "#1A1A1A", ink: "#000000", muted: "#4B5563" },
+        blue: "#1E3A8A"
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- adopt light grey backgrounds, dark text, black headings, and mustard/red accent palette
- add hover depth on category/calculator cards and enlarge site logo on hover
- style calculator result panel in bold white on dark mustard with hidden default state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b90ef7b51c83219867ba66787b9a27