### PR TITLE
feat: aplicar nueva paleta neutra y estilos interactivos

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,14 +5,14 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
+  --bg: #f7f7f7;
   --surface: #f2f2f2;
-  --ink: #000000;
+  --ink: #1a1a1a;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
+  --primary: #dc2626;
+  --accent: #b58900;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
   --card: #ffffff;
@@ -70,14 +70,20 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: #000;
+}
+h1 {
+  margin-top: 3em;
 }
 a {
-  color: var(--primary);
+  color: #9ca3af;
   text-decoration: none;
+  font-weight: 600;
 }
-a:hover {
-  color: var(--accent-red);
+a:hover,
+a:focus {
+  color: #6b7280;
+  text-decoration: underline;
 }
 body {
   padding-top: 72px;
@@ -103,25 +109,45 @@ body {
 .nav-link {
   display: inline-block;
   padding: 8px 12px;
-  font-weight: 600;
-  color: var(--ink);
-  background: var(--card);
-  border-radius: 4px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  font-weight: 700;
+  color: #fff;
+  background: #1e3a8a;
+  border-radius: 6px;
+  box-shadow: var(--shadow);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s,
+    transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: #fff;
-  font-weight: 700;
-  background: #1e3a8a;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  color: #000;
+  background: #fff;
+  transform: translateY(2px);
+  box-shadow: var(--shadow);
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--accent-red);
   color: #fff;
-  font-weight: 700;
+}
+.nav-link.active {
+  background: #d1d5db;
+  color: #1f2937;
+}
+.nav-link.traditional.active {
+  background: #d1d5db;
+  color: #1f2937;
+}
+.logo {
+  color: #000;
+  transition: transform 0.2s;
+}
+.logo:hover,
+.logo:focus {
+  color: #000;
+  transform: scale(1.2);
 }
 @media (max-width: 640px) {
   footer .links {
@@ -195,10 +221,8 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(-1px);
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
   border-color: var(--accent);
 }
 .card h3 {
@@ -208,10 +232,17 @@ ul.grid li {
      overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
-  transition: color 0.12s ease;
+  transition:
+    color 0.12s ease,
+    background 0.12s ease;
+  display: inline-block;
+  padding: 2px 4px;
 }
 .card:hover h3 {
-  color: var(--accent);
+  background: #fff;
+  color: #000;
+  font-weight: 700;
+  text-decoration: none;
 }
 .card p {
   color: var(--muted);
@@ -269,10 +300,20 @@ footer .links {
   flex-wrap: wrap;
 }
 footer .links a {
-  color: inherit;
+  color: #fff;
+  background: var(--accent);
+  padding: 6px 10px;
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  font-weight: 700;
   text-decoration: none;
+  transition:
+    background 0.2s,
+    transform 0.2s;
 }
-footer .links a:hover {
-  text-decoration: underline;
-  color: var(--accent);
+footer .links a:hover,
+footer .links a:focus {
+  background: #000;
+  color: #fff;
+  transform: translateY(2px);
 }

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,7 +141,7 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 3em 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
   .field label { display:block; margin: 0 0 6px; font-weight: 600; }
@@ -162,10 +162,18 @@ const jsonLd = {
     border: 0;
     background: var(--accent-red);
     color: var(--primary-ink);
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: background 0.2s, transform 0.2s;
   }
-  .btn:hover{ filter:brightness(1.05); }
+  .btn:hover,
+  .btn:focus {
+    filter: brightness(1.05);
+    transform: translateY(2px);
+    outline: 2px solid #6b7280;
+    outline-offset: 2px;
+  }
   .result {
     margin-top: 16px;
     font-size: 18px;
@@ -175,10 +183,12 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: none;
     padding: 12px;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
+    transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   }
   .result:not(:empty) {
     background: var(--accent);
+    color: #fff;
+    font-weight: 700;
     box-shadow: var(--shadow);
   }
   .examples,


### PR DESCRIPTION
## Summary
- redefine color scheme to light gray background, dark text and black headings
- add blue nav buttons with hover depth and logo scale
- show calculator results in bold white on mustard background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9138618b88321a9cd4cec59883126