### PR TITLE
feat: update site color scheme and hover effects

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -5,15 +5,16 @@
     legible, while blue and red provide primary emphasis and yellow
     adds secondary highlights.
   */
-  --bg: #ffffff;
+  --bg: #f7f7f7;
   --surface: #f2f2f2;
-  --ink: #000000;
+  --ink: #111111;
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
   --primary: #0057b8;
   --accent: #facc15;
   --accent-red: #dc2626;
+  --mustard-dark: #b8860b;
   --primary-ink: #ffffff;
   --card: #ffffff;
   --border: #e5e7eb;
@@ -48,6 +49,7 @@
     --accent: #facc15;
     --accent-red: #dc2626;
     --primary-ink: #ffffff;
+    --mustard-dark: #b8860b;
     --card: #1a1a1a;
     --border: #374151;
     --shadow: 0 2px 4px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
@@ -70,14 +72,16 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--primary);
+  color: #000;
+  margin-top: 3rem;
 }
 a {
-  color: var(--primary);
+  color: #d1d5db;
   text-decoration: none;
 }
 a:hover {
-  color: var(--accent-red);
+  color: #4b5563;
+  text-decoration: underline;
 }
 body {
   padding-top: 72px;
@@ -100,26 +104,35 @@ body {
 .header a {
   text-decoration: none;
 }
+.logo { color: #000; }
+.logo:hover {
+  font-size: 120%;
+  color: #000;
+}
 .nav-link {
   display: inline-block;
   padding: 8px 12px;
-  font-weight: 600;
-  color: var(--ink);
-  background: var(--card);
+  font-weight: 700;
+  color: #fff;
+  background: #0057b8;
   border-radius: 4px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
+  transition: background 0.2s, box-shadow 0.2s, color 0.2s, transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: #fff;
-  font-weight: 700;
-  background: #1e3a8a;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  color: #000;
+  background: #fff;
+  box-shadow: var(--shadow);
+  transform: translateY(1px);
+}
+.nav-link.active {
+  background: #d1d5db;
+  color: #000;
 }
 .nav-link.traditional {
-  background: #dc2626;
+  background: var(--accent-red);
   color: #fff;
   font-weight: 700;
 }
@@ -195,23 +208,22 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(-1px);
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.08),
-    0 10px 28px rgba(0, 0, 0, 0.06);
+  transform: translateY(1px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
   border-color: var(--accent);
 }
 .card h3 {
   margin: 2px 0 6px;
   font-size: 18px;
-  /* Allow long calculator names to wrap onto multiple lines without
-     overflowing the card. */
   word-wrap: break-word;
   white-space: normal;
-  transition: color 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 .card:hover h3 {
-  color: var(--accent);
+  background: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--ink);
 }
 .card p {
   color: var(--muted);
@@ -269,10 +281,16 @@ footer .links {
   flex-wrap: wrap;
 }
 footer .links a {
-  color: inherit;
+  color: #fff;
   text-decoration: none;
+  background: var(--mustard-dark);
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  font-weight: 700;
+  box-shadow: var(--shadow);
+  transition: background 0.2s;
 }
 footer .links a:hover {
-  text-decoration: underline;
-  color: var(--accent);
+  background: #000;
+  color: #fff;
 }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,9 +1,9 @@
 :root{
   /* Base tokens for light mode.  These values define the default
      backgrounds, surfaces and text colours used throughout the site. */
-  --bg:#ffffff;
+  --bg:#f7f7f7;
   --surface:#f2f2f2;
-  --text:#000000;
+  --text:#111111;
   --muted:#4b5563;
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
@@ -15,6 +15,7 @@
   --ring:#0057B833;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
+  --mustard-dark:#b8860b;
 }
 
 /*
@@ -39,6 +40,7 @@
     --primary: #0057B8;
     --accent: #FACC15;
     --accent-red: #DC2626;
+    --mustard-dark:#b8860b;
   }
 }
 

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -141,7 +141,7 @@ const jsonLd = {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
   }
-  h1 { margin: 0 0 8px; font-size: 28px; }
+  h1 { margin: 3rem 0 8px; font-size: 28px; }
   .muted { color: var(--muted); margin: 0 0 16px; }
   .field { margin: 14px 0; }
   .field label { display:block; margin: 0 0 6px; font-weight: 600; }
@@ -178,7 +178,9 @@ const jsonLd = {
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
   .result:not(:empty) {
-    background: var(--accent);
+    background: var(--mustard-dark);
+    color: #fff;
+    font-weight: 700;
     box-shadow: var(--shadow);
   }
   .examples,


### PR DESCRIPTION
## Summary
- restyle layout with light grey background, dark text, blue navigation buttons, and sinking cards
- add mustard result panel with hidden default state for calculators
- convert footer links into mustard buttons with black hover

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b9138618b88321a9cd4cec59883126