### PR TITLE
Refine menu and card hover styles

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -110,7 +110,7 @@ body {
   transition: font-size 0.2s ease;
 }
 .logo:hover {
-  font-size: 120%;
+  font-size: 150%;
   color: #000;
 }
 .nav-link {
@@ -218,8 +218,8 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(2px);
-  box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.2);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
   border-color: var(--border);
 }
 .card h3 {
@@ -297,16 +297,17 @@ footer .links a {
   display: inline-block;
   padding: 8px 12px;
   border-radius: 12px;
-  background: #b8860b;
-  color: #ffffff;
-  font-weight: 700;
+  background: #d1d5db;
+  color: #000000;
+  font-weight: 400;
   text-decoration: none;
   box-shadow: var(--shadow);
-  transition: background 0.2s, transform 0.2s;
+  transition: background 0.2s, color 0.2s, font-weight 0.2s, transform 0.2s;
 }
 footer .links a:hover,
 footer .links a:focus {
-  background: #000000;
+  background: #b8860b;
   color: #ffffff;
+  font-weight: 700;
   transform: translateY(1px);
 }


### PR DESCRIPTION
## Summary
- Tone down card hover depth
- Restyle footer buttons with gray base and mustard hover
- Enlarge logo text by 50% on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b917ac504c8321893d66cf70e5a65a