### PR TITLE
Refine navigation styles and card depth

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -110,7 +110,7 @@ body {
   transition: font-size 0.2s ease;
 }
 .logo:hover {
-  font-size: 120%;
+  font-size: 150%;
   color: #000;
 }
 .nav-link {
@@ -122,7 +122,11 @@ body {
   border-radius: 4px;
   box-shadow: var(--shadow);
   text-align: center;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s, transform 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s,
+    transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
@@ -140,7 +144,7 @@ body {
   background: #b91c1c;
   color: #ffffff;
   transform: translateY(1px);
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.active {
   background: #d1d5db;
@@ -218,8 +222,8 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(2px);
-  box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.2);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
   border-color: var(--border);
 }
 .card h3 {
@@ -228,7 +232,9 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  transition: background 0.12s ease, font-weight 0.12s ease;
+  transition:
+    background 0.12s ease,
+    font-weight 0.12s ease;
 }
 .card:hover h3 {
   background: #ffffff;
@@ -281,7 +287,7 @@ ul.grid li {
 .btn-primary:hover,
 .btn-primary:focus {
   transform: translateY(1px);
-  box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .faq summary {
   cursor: pointer;
@@ -297,16 +303,21 @@ footer .links a {
   display: inline-block;
   padding: 8px 12px;
   border-radius: 12px;
-  background: #b8860b;
-  color: #ffffff;
-  font-weight: 700;
+  background: #d1d5db;
+  color: #000000;
+  font-weight: 400;
   text-decoration: none;
   box-shadow: var(--shadow);
-  transition: background 0.2s, transform 0.2s;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    font-weight 0.2s,
+    transform 0.2s;
 }
 footer .links a:hover,
 footer .links a:focus {
-  background: #000000;
+  background: #b8860b;
   color: #ffffff;
+  font-weight: 700;
   transform: translateY(1px);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a href="https://calcsimpler.com" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- Dark mustard hover for footer buttons with white bold text, default light gray
- Logo links to CalcSimpler and grows 50% on hover
- Soften card hover shadow for subtler depth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b917ac504c8321893d66cf70e5a65a