### PR TITLE
Actualizar estilos de navegación y tarjetas

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -218,8 +218,8 @@ ul.grid li {
     border-color 0.12s ease;
 }
 .card:hover {
-  transform: translateY(2px);
-  box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.2);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
   border-color: var(--border);
 }
 .card h3 {
@@ -297,16 +297,17 @@ footer .links a {
   display: inline-block;
   padding: 8px 12px;
   border-radius: 12px;
-  background: #b8860b;
-  color: #ffffff;
-  font-weight: 700;
+  background: #e5e5e5;
+  color: #000000;
+  font-weight: 400;
   text-decoration: none;
   box-shadow: var(--shadow);
-  transition: background 0.2s, transform 0.2s;
+  transition: background 0.2s, color 0.2s, font-weight 0.2s, transform 0.2s;
 }
 footer .links a:hover,
 footer .links a:focus {
-  background: #000000;
+  background: #b8860b;
   color: #ffffff;
+  font-weight: 700;
   transform: translateY(1px);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,12 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a
+          href="/"
+          aria-label="CalcSimpler"
+          class="logo mr-2.5 text-xl font-bold text-[var(--ink)] transition-transform duration-200 hover:scale-150"
+          >CalcSimpler.com</a
+        >
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- Ajusta botones del menú inferior con nuevo color base gris y hover mostaza
- Reduce profundidad de tarjetas de categorías y calculadoras
- Añade efecto hover al logo del menú superior con aumento de tamaño

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b917ac504c8321893d66cf70e5a65a