### PR TITLE
feat: remove dark mode

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -22,37 +22,7 @@
   --space: 14px;
   --maxw: 1120px;
 }
-/*
-  When the user prefers a dark colour scheme we override the global
-  variables with a complementary dark palette.  Colours are chosen
-  to provide sufficient contrast on dark backgrounds while maintaining
-  the same hue relationships as the light theme.  Cards and headers
-  remain distinct from the background and the primary accent colour
-  stays constant across both modes.
-*/
-@media (prefers-color-scheme: dark) {
-  :root {
-    /*
-      Adopt a dark palette that remains comfortable on the eyes.  We
-      retain the same blue accent colour while brightening the ink and
-      softening the muted tones.  Shadows are strengthened slightly to
-      preserve depth on dark surfaces.
-    */
-    --bg: #0a0a0a;
-    --surface: #1a1a1a;
-    --ink: #f5f5f5;
-    --muted: #9ca3af;
-    --neutral-sky: #1a1a1a;
-    --neutral-warm: #262626;
-    --primary: #0057b8;
-    --accent: #facc15;
-    --accent-red: #dc2626;
-    --primary-ink: #ffffff;
-    --card: #1a1a1a;
-    --border: #374151;
-    --shadow: 0 2px 4px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
-  }
-}
+
 html,
 body {
   background: var(--bg);

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -17,29 +17,4 @@
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
 }
 
-/*
-  Define a dark palette for users who prefer dark mode via the
-  `prefers‑color‑scheme` media query.  The dark colours mirror the
-  semantic roles used in light mode (background, surface, text and
-  muted text) but with darker hues for a comfortable low‑light
-  experience.  The accent colour remains the same across both
-  palettes to maintain brand consistency.
-*/
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* Dark background for page body */
-    --bg: #0a0a0a;
-    /* Darker surface for cards and containers */
-    --surface: #1a1a1a;
-    /* Primary text becomes light for readability */
-    --text: #f5f5f5;
-    /* Muted text uses a mid‑tone grey */
-    --muted: #9ca3af;
-    /* Preserve brand colour and accents in dark mode */
-    --primary: #0057B8;
-    --accent: #FACC15;
-    --accent-red: #DC2626;
-  }
-}
-
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}

--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <div class="container mx-auto max-w-5xl px-4 pb-10">
-  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 dark:border-slate-600 grid place-items-center text-slate-500">
+  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
     Ad — 728 × 90 reserved
   </div>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,8 +15,8 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <meta name="description" content={description} />
     <link rel="canonical" href={href} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <!-- Set the theme colour to match the primary brand colour.  This
-         provides a consistent browser UI in both light and dark modes. -->
+    <!-- Set the theme colour to match the primary brand colour.
+         This provides a consistent browser UI in light mode. -->
     <meta name="theme-color" content="#0057B8">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />

--- a/src/pages/traditional-calculator.astro
+++ b/src/pages/traditional-calculator.astro
@@ -4,76 +4,76 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout title="Traditional Calculator" description="Perform basic arithmetic operations with this traditional calculator.">
   <div class="max-w-sm mx-auto mt-8">
-    <div id="calc" class="bg-white dark:bg-slate-800 p-4 rounded-lg shadow-lg">
+    <div id="calc" class="bg-white p-4 rounded-lg shadow-lg">
       <input
         id="display"
-        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100"
+        class="w-full mb-2 p-3 border rounded text-right text-2xl bg-gray-100 text-slate-900"
         readonly
       />
       <div class="grid grid-cols-4 gap-2">
         <button
           data-value="7"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >7</button>
         <button
           data-value="8"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >8</button>
         <button
           data-value="9"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >9</button>
         <button
           data-value="/"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >÷</button>
         <button
           data-value="4"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >4</button>
         <button
           data-value="5"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >5</button>
         <button
           data-value="6"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >6</button>
         <button
           data-value="*"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >×</button>
         <button
           data-value="1"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >1</button>
         <button
           data-value="2"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >2</button>
         <button
           data-value="3"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >3</button>
         <button
           data-value="-"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >−</button>
         <button
           data-value="0"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >0</button>
         <button
           data-value="."
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >.</button>
         <button
           data-value="="
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >=</button>
         <button
           data-value="+"
-          class="p-2 rounded border bg-gray-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 transition-colors font-semibold"
+          class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold"
         >+</button>
         <button
           data-value="C"


### PR DESCRIPTION
## Summary
- drop dark theme styles and tokens
- simplify components and pages to light mode only
- clarify theme color comment

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b91c208b048321b8d9e544dea42b2b