### PR TITLE
Fix variable check for scientific notation

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -297,7 +297,7 @@ const jsonLd = {
       if (expr) {
         // ensure every symbol referenced in the expression is provided in vars
         const varNames = expr.match(/[A-Za-z_][A-Za-z0-9_]*/g) || [];
-        const unknown = varNames.filter(n => !(n in vars));
+        const unknown = varNames.filter(n => !(n in vars) && n.toLowerCase() !== 'e');
         if (unknown.length) {
           resultEl.textContent = 'Unknown variable: ' + unknown[0];
           return;


### PR DESCRIPTION
## Summary
- avoid flagging the `e` in scientific notation as an unknown variable

## Testing
- `npm test`
- `node -e "const expr='beards * 5e-9'; const varNames=expr.match(/[A-Za-z_][A-Za-z0-9_]*/g)||[]; const vars={beards:1}; const unknown=varNames.filter(n=>!(n in vars) && n.toLowerCase()!=='e'); console.log(unknown);"`

------
https://chatgpt.com/codex/tasks/task_b_68b91e3d32bc83218c46ba2c3aa3da4a