### PR TITLE
feat: red cards and better success icon

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -182,11 +182,12 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: var(--card);
-  border: 1px solid var(--border);
+  background: #dc2626;
+  border: 1px solid #dc2626;
   border-radius: var(--radius);
   padding: 16px;
   box-shadow: var(--shadow);
+  color: #ffffff;
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -195,7 +196,6 @@ ul.grid li {
 .card:hover {
   transform: translateY(1px);
   box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
-  border-color: var(--border);
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -204,19 +204,24 @@ ul.grid li {
   white-space: normal;
   padding: 2px 4px;
   transition: background 0.12s ease, font-weight 0.12s ease;
+  color: #ffffff;
+  font-weight: 700;
 }
 .card:hover h3 {
-  background: #ffffff;
-  font-weight: 700;
+  background: transparent;
   text-decoration: none;
-  color: var(--ink);
+  color: #ffffff;
 }
 .card p {
-  color: var(--muted);
+  color: #ffffff;
+  font-weight: 700;
   font-size: 14px;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
+}
+.card img {
+  filter: brightness(0) invert(1);
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -200,14 +200,19 @@ const jsonLd = {
     transition: background 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
   }
   .result:not(:empty) {
-    background: #b8860b;
     color: #ffffff;
     box-shadow: var(--shadow);
     opacity: 1;
     font-weight: 700;
   }
+  .result[data-state="success"] {
+    background: #16a34a;
+  }
+  .result[data-state="error"] {
+    background: #dc2626;
+  }
   .result .icon {
-    font-size: 1.2em;
+    font-size: 1.5em;
   }
   .examples,
   .faq,
@@ -302,7 +307,7 @@ const jsonLd = {
     }
 
     function showMessage(type, msg) {
-      const icon = type === 'error' ? '⚠️' : '✔️';
+      const icon = type === 'error' ? '⚠️' : '🎉';
       resultEl.innerHTML = `<span class="icon" aria-hidden="true">${icon}</span><span>${msg}</span>`;
       resultEl.dataset.state = type;
       resultEl.setAttribute('role', type === 'error' ? 'alert' : 'status');


### PR DESCRIPTION
## Summary
- style category and calculator cards with red background and white bold content
- enlarge and celebrate success results with a colorful icon and green background

## Testing
- `npm test` *(fails: npm not installed; apt-get 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b97766726c8321b53806792147c62e