### PR TITLE
feat: red card style and vivid success icon

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -182,11 +182,11 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: var(--card);
-  border: 1px solid var(--border);
+  background: #dc2626;
+  border: 1px solid #b91c1c;
   border-radius: var(--radius);
   padding: 16px;
-  box-shadow: var(--shadow);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3), 0 8px 16px rgba(0, 0, 0, 0.25);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -194,8 +194,8 @@ ul.grid li {
 }
 .card:hover {
   transform: translateY(1px);
-  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
-  border-color: var(--border);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2);
+  border-color: #b91c1c;
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -203,20 +203,23 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  transition: background 0.12s ease, font-weight 0.12s ease;
+  color: #ffffff;
+  font-weight: 700;
 }
 .card:hover h3 {
-  background: #ffffff;
+  color: #ffffff;
   font-weight: 700;
-  text-decoration: none;
-  color: var(--ink);
 }
 .card p {
-  color: var(--muted);
+  color: #ffffff;
   font-size: 14px;
+  font-weight: 700;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
+}
+.card img {
+  filter: brightness(0) invert(1);
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -207,7 +207,7 @@ const jsonLd = {
     font-weight: 700;
   }
   .result .icon {
-    font-size: 1.2em;
+    font-size: 1.6em;
   }
   .examples,
   .faq,
@@ -302,7 +302,7 @@ const jsonLd = {
     }
 
     function showMessage(type, msg) {
-      const icon = type === 'error' ? '⚠️' : '✔️';
+      const icon = type === 'error' ? '⚠️' : '✅';
       resultEl.innerHTML = `<span class="icon" aria-hidden="true">${icon}</span><span>${msg}</span>`;
       resultEl.dataset.state = type;
       resultEl.setAttribute('role', type === 'error' ? 'alert' : 'status');


### PR DESCRIPTION
## Summary
- make category and calculator cards bold with red backgrounds and strong shadows
- display card icons and text in white
- use larger, more colorful success icon in calculator results

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b979a7fc5483219336a561a45be553