### PR TITLE
Add office-focused calculators across all categories

### DIFF
--- a/data/calculators_extra.json
+++ b/data/calculators_extra.json
@@ -317,4 +317,462 @@
     ],
     "expression": "(distance*consumption/100)*price"
   }
+,
+  {
+    "slug": "mb-to-gb-converter",
+    "title": "MB to GB Converter",
+    "cluster": "Conversions",
+    "intro": "Convert megabytes to gigabytes for quick storage planning.",
+    "inputs": [
+      { "name": "mb", "hint": "Megabytes (MB)" }
+    ],
+    "expression": "mb/1024",
+    "examples": [
+      { "description": "2048 MB ⇒ 2 GB" },
+      { "description": "5120 MB ⇒ 5 GB" }
+    ],
+    "faqs": [
+      { "question": "Is it binary?", "answer": "Yes, 1 GB = 1024 MB." },
+      { "question": "Can I use decimals?", "answer": "Yes, decimals are allowed." }
+    ]
+  },
+  {
+    "slug": "percentage-to-decimal",
+    "title": "Percentage to Decimal Converter",
+    "cluster": "Conversions",
+    "intro": "Quickly turn a percentage into a decimal for spreadsheets and formulas.",
+    "inputs": [
+      { "name": "percent", "hint": "Percentage (%)" }
+    ],
+    "expression": "percent/100",
+    "examples": [
+      { "description": "25% ⇒ 0.25" },
+      { "description": "150% ⇒ 1.5" }
+    ],
+    "faqs": [
+      { "question": "Why divide by 100?", "answer": "Percent means per hundred." },
+      { "question": "Negative values?", "answer": "Yes, negatives work too." }
+    ]
+  },
+  {
+    "slug": "decimal-to-percentage",
+    "title": "Decimal to Percentage Converter",
+    "cluster": "Conversions",
+    "intro": "Convert decimals to percentages for reports and presentations.",
+    "inputs": [
+      { "name": "decimal", "hint": "Decimal" }
+    ],
+    "expression": "decimal*100",
+    "examples": [
+      { "description": "0.85 ⇒ 85%" },
+      { "description": "1.2 ⇒ 120%" }
+    ],
+    "faqs": [
+      { "question": "How is conversion done?", "answer": "Multiply by 100." },
+      { "question": "Percent sign added?", "answer": "Result is numeric percent." }
+    ]
+  },
+  {
+    "slug": "meeting-time-percentage",
+    "title": "Meeting Time Percentage",
+    "cluster": "Date & Time",
+    "intro": "See how much of your workday is spent in meetings.",
+    "inputs": [
+      { "name": "meeting", "hint": "Meeting time (min)" },
+      { "name": "workday", "hint": "Workday length (min)" }
+    ],
+    "expression": "(meeting/workday)*100",
+    "examples": [
+      { "description": "90 min of 480 ⇒ 18.75%" },
+      { "description": "30 min of 300 ⇒ 10%" }
+    ],
+    "faqs": [
+      { "question": "Typical workday?", "answer": "Many offices use 480 minutes." },
+      { "question": "Multiple meetings?", "answer": "Sum minutes before entering." }
+    ]
+  },
+  {
+    "slug": "break-time-planner",
+    "title": "Break Time Planner",
+    "cluster": "Date & Time",
+    "intro": "Plan how many minutes of break you should take in a workday.",
+    "inputs": [
+      { "name": "hours", "hint": "Hours worked" }
+    ],
+    "expression": "(hours/2)*15",
+    "examples": [
+      { "description": "8 h ⇒ 60 min" },
+      { "description": "5 h ⇒ 37.5 min" }
+    ],
+    "faqs": [
+      { "question": "What guideline?", "answer": "15 minutes per 2 hours of work." },
+      { "question": "Adjustable?", "answer": "Modify formula for your policy." }
+    ]
+  },
+  {
+    "slug": "work-hours-to-days",
+    "title": "Work Hours to Days Converter",
+    "cluster": "Date & Time",
+    "intro": "Translate hours of effort into standard workdays.",
+    "inputs": [
+      { "name": "hours", "hint": "Total hours" },
+      { "name": "day", "hint": "Hours per workday" }
+    ],
+    "expression": "hours/day",
+    "examples": [
+      { "description": "40 h at 8 ⇒ 5 days" },
+      { "description": "60 h at 7.5 ⇒ 8 days" }
+    ],
+    "faqs": [
+      { "question": "Standard day?", "answer": "Often 8 hours." },
+      { "question": "Include breaks?", "answer": "Enter net work hours." }
+    ]
+  },
+  {
+    "slug": "hourly-to-annual-salary",
+    "title": "Hourly to Annual Salary",
+    "cluster": "Finance",
+    "intro": "Convert an hourly wage into an annual salary for budgeting.",
+    "inputs": [
+      { "name": "rate", "hint": "Hourly rate ($)" },
+      { "name": "hours", "hint": "Hours per week" },
+      { "name": "weeks", "hint": "Weeks per year" }
+    ],
+    "expression": "rate*hours*weeks",
+    "examples": [
+      { "description": "$25,40h,52w ⇒ $52000" },
+      { "description": "$30,35h,48w ⇒ $50400" }
+    ],
+    "faqs": [
+      { "question": "Include overtime?", "answer": "Add it to weekly hours." },
+      { "question": "Unpaid leave?", "answer": "Reduce weeks per year." }
+    ]
+  },
+  {
+    "slug": "budget-variance-percentage",
+    "title": "Budget Variance Percentage",
+    "cluster": "Finance",
+    "intro": "Find the percentage difference between actual and budgeted costs.",
+    "inputs": [
+      { "name": "actual", "hint": "Actual amount ($)" },
+      { "name": "budget", "hint": "Budgeted amount ($)" }
+    ],
+    "expression": "((actual-budget)/budget)*100",
+    "examples": [
+      { "description": "$1200 vs $1000 ⇒ 20%" },
+      { "description": "$900 vs $1000 ⇒ -10%" }
+    ],
+    "faqs": [
+      { "question": "Negative result?", "answer": "Means under budget." },
+      { "question": "Use for revenue?", "answer": "Yes, any target vs actual." }
+    ]
+  },
+  {
+    "slug": "gross-up-calculator",
+    "title": "Gross-Up Calculator",
+    "cluster": "Finance",
+    "intro": "Determine the pre-tax amount required to provide a specific net payment.",
+    "inputs": [
+      { "name": "net", "hint": "Net amount ($)" },
+      { "name": "tax", "hint": "Tax rate (%)" }
+    ],
+    "expression": "net/(1-tax/100)",
+    "examples": [
+      { "description": "$1000 net at 30% ⇒ $1428.57" },
+      { "description": "$500 net at 25% ⇒ $666.67" }
+    ],
+    "faqs": [
+      { "question": "Multiple taxes?", "answer": "Combine rates before entering." },
+      { "question": "Tax 0%?", "answer": "Gross equals net." }
+    ]
+  },
+  {
+    "slug": "standing-time-percentage",
+    "title": "Standing Time Percentage",
+    "cluster": "Health",
+    "intro": "Track the share of your day spent standing versus sitting.",
+    "inputs": [
+      { "name": "standing", "hint": "Standing time (min)" },
+      { "name": "total", "hint": "Total awake time (min)" }
+    ],
+    "expression": "(standing/total)*100",
+    "examples": [
+      { "description": "120 of 960 ⇒ 12.5%" },
+      { "description": "240 of 600 ⇒ 40%" }
+    ],
+    "faqs": [
+      { "question": "Why track?", "answer": "Standing reduces sedentary risk." },
+      { "question": "Awake time?", "answer": "Hours you're not sleeping." }
+    ]
+  },
+  {
+    "slug": "caffeine-limit-by-weight",
+    "title": "Caffeine Limit by Weight",
+    "cluster": "Health",
+    "intro": "Estimate a moderate daily caffeine limit based on body weight.",
+    "inputs": [
+      { "name": "weight", "hint": "Weight (kg)" }
+    ],
+    "expression": "weight*3",
+    "examples": [
+      { "description": "70 kg ⇒ 210 mg" },
+      { "description": "90 kg ⇒ 270 mg" }
+    ],
+    "faqs": [
+      { "question": "Why 3 mg/kg?", "answer": "Conservative guideline." },
+      { "question": "Medical advice?", "answer": "No, consult a professional." }
+    ]
+  },
+  {
+    "slug": "screen-break-frequency",
+    "title": "Screen Break Frequency",
+    "cluster": "Health",
+    "intro": "Count how many 20-second eye breaks to take every 20 minutes of screen time.",
+    "inputs": [
+      { "name": "hours", "hint": "Screen time (hours)" }
+    ],
+    "expression": "(hours*60)/20",
+    "examples": [
+      { "description": "6 h ⇒ 18 breaks" },
+      { "description": "3 h ⇒ 9 breaks" }
+    ],
+    "faqs": [
+      { "question": "What is 20-20-20?", "answer": "Every 20 minutes look 20 feet away for 20 seconds." },
+      { "question": "Short sessions?", "answer": "Enter total daily hours." }
+    ]
+  },
+  {
+    "slug": "box-volume-calculator",
+    "title": "Box Volume Calculator",
+    "cluster": "Home & DIY",
+    "intro": "Find the capacity of a box from its length, width, and height.",
+    "inputs": [
+      { "name": "length", "hint": "Length (m)" },
+      { "name": "width", "hint": "Width (m)" },
+      { "name": "height", "hint": "Height (m)" }
+    ],
+    "expression": "length*width*height",
+    "examples": [
+      { "description": "0.5×0.4×0.3 ⇒ 0.06 m³" },
+      { "description": "1×0.5×0.5 ⇒ 0.25 m³" }
+    ],
+    "faqs": [
+      { "question": "Use cm?", "answer": "Convert to meters first." },
+      { "question": "Exact?", "answer": "Assumes perfect box." }
+    ]
+  },
+  {
+    "slug": "curtain-width-calculator",
+    "title": "Curtain Width Calculator",
+    "cluster": "Home & DIY",
+    "intro": "Determine total curtain width needed using a fullness ratio.",
+    "inputs": [
+      { "name": "window", "hint": "Window width (cm)" },
+      { "name": "fullness", "hint": "Fullness ratio" }
+    ],
+    "expression": "window*fullness",
+    "examples": [
+      { "description": "150 cm at 2× ⇒ 300 cm" },
+      { "description": "120 cm at 1.5× ⇒ 180 cm" }
+    ],
+    "faqs": [
+      { "question": "Fullness?", "answer": "Multiplier for gathers." },
+      { "question": "Overlap?", "answer": "Add extra width if needed." }
+    ]
+  },
+  {
+    "slug": "led-savings-calculator",
+    "title": "LED Savings Calculator",
+    "cluster": "Home & DIY",
+    "intro": "Estimate energy cost savings by replacing incandescent bulbs with LEDs.",
+    "inputs": [
+      { "name": "old", "hint": "Incandescent wattage" },
+      { "name": "new", "hint": "LED wattage" },
+      { "name": "hours", "hint": "Hours per day" },
+      { "name": "rate", "hint": "Electricity rate ($/kWh)" }
+    ],
+    "expression": "((old-new)*hours*30/1000)*rate",
+    "examples": [
+      { "description": "60→9W,5h,$0.15 ⇒ $6.84" },
+      { "description": "75→10W,3h,$0.20 ⇒ $11.70" }
+    ],
+    "faqs": [
+      { "question": "Why 30 days?", "answer": "Assumes monthly usage." },
+      { "question": "Bulb cost included?", "answer": "No, only energy savings." }
+    ]
+  },
+  {
+    "slug": "weighted-average-calculator",
+    "title": "Weighted Average Calculator",
+    "cluster": "Math",
+    "intro": "Find the weighted average of up to three data points.",
+    "inputs": [
+      { "name": "v1", "hint": "Value 1" },
+      { "name": "w1", "hint": "Weight 1" },
+      { "name": "v2", "hint": "Value 2" },
+      { "name": "w2", "hint": "Weight 2" },
+      { "name": "v3", "hint": "Value 3" },
+      { "name": "w3", "hint": "Weight 3" }
+    ],
+    "expression": "(v1*w1+v2*w2+v3*w3)/(w1+w2+w3)",
+    "examples": [
+      { "description": "80,90,75 with 1,2,1 ⇒ 83.75" },
+      { "description": "10,20,30 with 1,1,1 ⇒ 20" }
+    ],
+    "faqs": [
+      { "question": "Skip values?", "answer": "Use zero for unused inputs." },
+      { "question": "Equal weights?", "answer": "Set all weights to 1." }
+    ]
+  },
+  {
+    "slug": "standard-deviation-3-numbers",
+    "title": "Standard Deviation (3 Numbers)",
+    "cluster": "Math",
+    "intro": "Compute the sample standard deviation for three data points.",
+    "inputs": [
+      { "name": "a", "hint": "Value A" },
+      { "name": "b", "hint": "Value B" },
+      { "name": "c", "hint": "Value C" }
+    ],
+    "expression": "(((a-((a+b+c)/3))^2+(b-((a+b+c)/3))^2+(c-((a+b+c)/3))^2)/2)^0.5",
+    "examples": [
+      { "description": "10,12,15 ⇒ 2.52" },
+      { "description": "5,5,5 ⇒ 0" }
+    ],
+    "faqs": [
+      { "question": "Why divide by 2?", "answer": "n-1 for sample deviation." },
+      { "question": "More numbers?", "answer": "This tool uses three inputs." }
+    ]
+  },
+  {
+    "slug": "part-of-total-percentage",
+    "title": "Part of Total Percentage",
+    "cluster": "Math",
+    "intro": "Calculate what percentage a value represents of a whole.",
+    "inputs": [
+      { "name": "part", "hint": "Part" },
+      { "name": "total", "hint": "Total" }
+    ],
+    "expression": "(part/total)*100",
+    "examples": [
+      { "description": "30 of 200 ⇒ 15%" },
+      { "description": "50 of 80 ⇒ 62.5%" }
+    ],
+    "faqs": [
+      { "question": "Over 100%?", "answer": "Occurs if part > total." },
+      { "question": "Total 0?", "answer": "Calculation undefined." }
+    ]
+  },
+  {
+    "slug": "psu-load-percentage",
+    "title": "PSU Load Percentage",
+    "cluster": "Technology",
+    "intro": "Check how much of a power supply's capacity your system draws.",
+    "inputs": [
+      { "name": "load", "hint": "System load (W)" },
+      { "name": "capacity", "hint": "PSU capacity (W)" }
+    ],
+    "expression": "(load/capacity)*100",
+    "examples": [
+      { "description": "300 W on 500 W ⇒ 60%" },
+      { "description": "450 W on 600 W ⇒ 75%" }
+    ],
+    "faqs": [
+      { "question": "Why keep under 80%?", "answer": "For headroom and efficiency." },
+      { "question": "Overload?", "answer": "Result over 100% means overload." }
+    ]
+  },
+  {
+    "slug": "cloud-storage-cost",
+    "title": "Cloud Storage Cost",
+    "cluster": "Technology",
+    "intro": "Find the monthly bill for storing data in the cloud.",
+    "inputs": [
+      { "name": "data", "hint": "Data stored (GB)" },
+      { "name": "rate", "hint": "Price per GB ($)" }
+    ],
+    "expression": "data*rate",
+    "examples": [
+      { "description": "100 GB at $0.02 ⇒ $2" },
+      { "description": "250 GB at $0.015 ⇒ $3.75" }
+    ],
+    "faqs": [
+      { "question": "Include egress?", "answer": "No, storage only." },
+      { "question": "Free tier?", "answer": "Subtract free allowance first." }
+    ]
+  },
+  {
+    "slug": "printer-cost-per-page",
+    "title": "Printer Cost per Page",
+    "cluster": "Technology",
+    "intro": "Determine how much each printed page costs based on cartridge price and yield.",
+    "inputs": [
+      { "name": "price", "hint": "Cartridge price ($)" },
+      { "name": "yield", "hint": "Yield (pages)" }
+    ],
+    "expression": "price/yield",
+    "examples": [
+      { "description": "$40 and 2000 pages ⇒ $0.02" },
+      { "description": "$25 and 500 pages ⇒ $0.05" }
+    ],
+    "faqs": [
+      { "question": "Paper cost?", "answer": "Not included." },
+      { "question": "Yield exact?", "answer": "Manufacturer estimate only." }
+    ]
+  },
+  {
+    "slug": "ream-duration-calculator",
+    "title": "Ream Duration Calculator",
+    "cluster": "Other",
+    "intro": "See how many days a paper ream covers based on daily printing.",
+    "inputs": [
+      { "name": "pages", "hint": "Pages printed per day" }
+    ],
+    "expression": "500/pages",
+    "examples": [
+      { "description": "100 pages/day ⇒ 5 days" },
+      { "description": "25 pages/day ⇒ 20 days" }
+    ],
+    "faqs": [
+      { "question": "Half ream?", "answer": "Adjust the 500 figure." },
+      { "question": "Double-sided?", "answer": "Count each side separately." }
+    ]
+  },
+  {
+    "slug": "printing-carbon-footprint",
+    "title": "Printing Carbon Footprint",
+    "cluster": "Other",
+    "intro": "Approximate CO₂ emissions using 0.0044 kg per printed page.",
+    "inputs": [
+      { "name": "pages", "hint": "Pages printed" }
+    ],
+    "expression": "pages*0.0044",
+    "examples": [
+      { "description": "500 pages ⇒ 2.2 kg CO₂" },
+      { "description": "100 pages ⇒ 0.44 kg CO₂" }
+    ],
+    "faqs": [
+      { "question": "Source factor?", "answer": "Average emission per page." },
+      { "question": "Double-sided?", "answer": "Count each side." }
+    ]
+  },
+  {
+    "slug": "space-per-employee",
+    "title": "Space per Employee",
+    "cluster": "Other",
+    "intro": "Calculate floor area allocated to each employee.",
+    "inputs": [
+      { "name": "area", "hint": "Total area (m²)" },
+      { "name": "people", "hint": "Number of employees" }
+    ],
+    "expression": "area/people",
+    "examples": [
+      { "description": "200 m² & 10 ⇒ 20 m²/person" },
+      { "description": "90 m² & 15 ⇒ 6 m²/person" }
+    ],
+    "faqs": [
+      { "question": "Recommended area?", "answer": "Often 10–15 m² per person." },
+      { "question": "Include common areas?", "answer": "Include usable space." }
+    ]
+  }
 ]

--- a/src/pages/calculators/box-volume-calculator.mdx
+++ b/src/pages/calculators/box-volume-calculator.mdx
@@ -1,0 +1,34 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Box Volume Calculator"
+description: "Compute volume of a rectangular box."
+updated: "2025-10-24"
+cluster: "Home & DIY"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "box-volume-calculator",
+  title: "Box Volume Calculator",
+  locale: "en",
+  intro: "Find the capacity of a box from its length, width, and height.",
+  unit: "m³",
+  cluster: "Home & DIY",
+  inputs: [
+    { name: "length", label: "Length (m)", type: "number", step: "any", placeholder: "0.5" },
+    { name: "width", label: "Width (m)", type: "number", step: "any", placeholder: "0.4" },
+    { name: "height", label: "Height (m)", type: "number", step: "any", placeholder: "0.3" }
+  ],
+  expression: "length * width * height",
+  examples: [
+    { description: "0.5×0.4×0.3 m ⇒ 0.06 m³" },
+    { description: "1×0.5×0.5 m ⇒ 0.25 m³" }
+  ],
+  faqs: [
+    { question: "Can I use centimeters?", answer: "Convert dimensions to meters first." },
+    { question: "Is the result exact?", answer: "It assumes perfectly rectangular sides." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/break-time-planner.mdx
+++ b/src/pages/calculators/break-time-planner.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Break Time Planner"
+description: "Estimate break minutes using the 15-min per 2 hours guideline."
+updated: "2025-10-24"
+cluster: "Date & Time"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "break-time-planner",
+  title: "Break Time Planner",
+  locale: "en",
+  intro: "Plan how many minutes of break you should take in a workday.",
+  unit: "minutes",
+  cluster: "Date & Time",
+  inputs: [
+    { name: "hours", label: "Hours worked", type: "number", step: "any", placeholder: "8" }
+  ],
+  expression: "(hours / 2) * 15",
+  examples: [
+    { description: "8 h ⇒ 60 min of break" },
+    { description: "5 h ⇒ 37.5 min of break" }
+  ],
+  faqs: [
+    { question: "What guideline is used?", answer: "A common recommendation is 15 minutes per 2 hours of work." },
+    { question: "Can I adjust it?", answer: "Yes, modify the formula if your policy differs." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/budget-variance-percentage.mdx
+++ b/src/pages/calculators/budget-variance-percentage.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Budget Variance Percentage"
+description: "Compare actual spending against budgeted amounts."
+updated: "2025-10-24"
+cluster: "Finance"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "budget-variance-percentage",
+  title: "Budget Variance Percentage",
+  locale: "en",
+  intro: "Find the percentage difference between actual and budgeted costs.",
+  unit: "%",
+  cluster: "Finance",
+  inputs: [
+    { name: "actual", label: "Actual amount ($)", type: "number", step: "any", placeholder: "1200" },
+    { name: "budget", label: "Budgeted amount ($)", type: "number", step: "any", placeholder: "1000" }
+  ],
+  expression: "((actual - budget) / budget) * 100",
+  examples: [
+    { description: "$1200 vs $1000 ⇒ 20% over budget" },
+    { description: "$900 vs $1000 ⇒ -10% under budget" }
+  ],
+  faqs: [
+    { question: "What does a negative result mean?", answer: "It indicates spending was below budget." },
+    { question: "Can I compare revenue?", answer: "Yes, use the same formula for any target vs actual value." }
+  ],
+  disclaimer: "For informational purposes only, not financial advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/caffeine-limit-by-weight.mdx
+++ b/src/pages/calculators/caffeine-limit-by-weight.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Caffeine Limit by Weight"
+description: "Estimate a safe daily caffeine limit using 3 mg/kg guideline."
+updated: "2025-10-24"
+cluster: "Health"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "caffeine-limit-by-weight",
+  title: "Caffeine Limit by Weight",
+  locale: "en",
+  intro: "Estimate a moderate daily caffeine limit based on body weight.",
+  unit: "mg",
+  cluster: "Health",
+  inputs: [
+    { name: "weight", label: "Weight (kg)", type: "number", step: "any", placeholder: "70" }
+  ],
+  expression: "weight * 3",
+  examples: [
+    { description: "70 kg ⇒ 210 mg" },
+    { description: "90 kg ⇒ 270 mg" }
+  ],
+  faqs: [
+    { question: "Why 3 mg/kg?", answer: "It's a conservative guideline for moderate caffeine intake." },
+    { question: "Is this medical advice?", answer: "No, consult a professional for personal recommendations." }
+  ],
+  disclaimer: "For informational purposes only, not medical advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/cloud-storage-cost.mdx
+++ b/src/pages/calculators/cloud-storage-cost.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Cloud Storage Cost"
+description: "Estimate monthly cost of cloud storage usage."
+updated: "2025-10-24"
+cluster: "Technology"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "cloud-storage-cost",
+  title: "Cloud Storage Cost",
+  locale: "en",
+  intro: "Find the monthly bill for storing data in the cloud.",
+  unit: "USD/month",
+  cluster: "Technology",
+  inputs: [
+    { name: "data", label: "Data stored (GB)", type: "number", step: "any", placeholder: "100" },
+    { name: "rate", label: "Price per GB ($)", type: "number", step: "any", placeholder: "0.02" }
+  ],
+  expression: "data * rate",
+  examples: [
+    { description: "100 GB at $0.02 ⇒ $2/month" },
+    { description: "250 GB at $0.015 ⇒ $3.75/month" }
+  ],
+  faqs: [
+    { question: "Does this include egress fees?", answer: "No, it only accounts for storage cost." },
+    { question: "What about free tiers?", answer: "Subtract any free allowance before entering data." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/curtain-width-calculator.mdx
+++ b/src/pages/calculators/curtain-width-calculator.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Curtain Width Calculator"
+description: "Calculate curtain width from window size and fullness."
+updated: "2025-10-24"
+cluster: "Home & DIY"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "curtain-width-calculator",
+  title: "Curtain Width Calculator",
+  locale: "en",
+  intro: "Determine total curtain width needed using a fullness ratio.",
+  unit: "cm",
+  cluster: "Home & DIY",
+  inputs: [
+    { name: "window", label: "Window width (cm)", type: "number", step: "any", placeholder: "150" },
+    { name: "fullness", label: "Fullness ratio", type: "number", step: "any", placeholder: "2" }
+  ],
+  expression: "window * fullness",
+  examples: [
+    { description: "150 cm window with 2× fullness ⇒ 300 cm" },
+    { description: "120 cm window with 1.5× fullness ⇒ 180 cm" }
+  ],
+  faqs: [
+    { question: "What is fullness?", answer: "A multiplier to add gathers; 2× is common." },
+    { question: "Does this include overlap?", answer: "Add extra width if panels need to overlap." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/decimal-to-percentage.mdx
+++ b/src/pages/calculators/decimal-to-percentage.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Decimal to Percentage Converter"
+description: "Convert a decimal number into a percentage."
+updated: "2025-10-24"
+cluster: "Conversions"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "decimal-to-percentage",
+  title: "Decimal to Percentage Converter",
+  locale: "en",
+  intro: "Convert decimals to percentages for reports and presentations.",
+  unit: "%",
+  cluster: "Conversions",
+  inputs: [
+    { name: "decimal", label: "Decimal", type: "number", step: "any", placeholder: "0.85" }
+  ],
+  expression: "decimal * 100",
+  examples: [
+    { description: "0.85 ⇒ 85%" },
+    { description: "1.2 ⇒ 120%" }
+  ],
+  faqs: [
+    { question: "How is the conversion done?", answer: "Multiply the decimal by 100 to get a percentage." },
+    { question: "Does it add a percent sign?", answer: "The result is a numeric value representing percent." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/gross-up-calculator.mdx
+++ b/src/pages/calculators/gross-up-calculator.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Gross-Up Calculator"
+description: "Calculate gross payment needed to cover taxes on a net amount."
+updated: "2025-10-24"
+cluster: "Finance"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "gross-up-calculator",
+  title: "Gross-Up Calculator",
+  locale: "en",
+  intro: "Determine the pre-tax amount required to provide a specific net payment.",
+  unit: "USD",
+  cluster: "Finance",
+  inputs: [
+    { name: "net", label: "Net amount ($)", type: "number", step: "any", placeholder: "1000" },
+    { name: "tax", label: "Tax rate (%)", type: "number", step: "any", placeholder: "30" }
+  ],
+  expression: "net / (1 - tax/100)",
+  examples: [
+    { description: "$1000 net with 30% tax ⇒ $1428.57 gross" },
+    { description: "$500 net with 25% tax ⇒ $666.67 gross" }
+  ],
+  faqs: [
+    { question: "Does it handle multiple taxes?", answer: "Combine rates into a single percentage before entering." },
+    { question: "What if tax is 0?", answer: "Then gross equals net." }
+  ],
+  disclaimer: "For informational purposes only, not financial advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/hourly-to-annual-salary.mdx
+++ b/src/pages/calculators/hourly-to-annual-salary.mdx
@@ -1,0 +1,34 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Hourly to Annual Salary"
+description: "Estimate yearly salary from an hourly rate."
+updated: "2025-10-24"
+cluster: "Finance"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "hourly-to-annual-salary",
+  title: "Hourly to Annual Salary",
+  locale: "en",
+  intro: "Convert an hourly wage into an annual salary for budgeting.",
+  unit: "USD/year",
+  cluster: "Finance",
+  inputs: [
+    { name: "rate", label: "Hourly rate ($)", type: "number", step: "any", placeholder: "25" },
+    { name: "hours", label: "Hours per week", type: "number", step: "any", placeholder: "40" },
+    { name: "weeks", label: "Weeks per year", type: "number", step: "any", placeholder: "52" }
+  ],
+  expression: "rate * hours * weeks",
+  examples: [
+    { description: "$25/hr, 40h/week, 52 weeks ⇒ $52,000/year" },
+    { description: "$30/hr, 35h/week, 48 weeks ⇒ $50,400/year" }
+  ],
+  faqs: [
+    { question: "Does it include overtime?", answer: "Only if you include overtime hours in the weekly input." },
+    { question: "What about unpaid leave?", answer: "Adjust the weeks per year to account for unpaid time off." }
+  ],
+  disclaimer: "For informational purposes only, not financial advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/led-savings-calculator.mdx
+++ b/src/pages/calculators/led-savings-calculator.mdx
@@ -1,0 +1,35 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "LED Savings Calculator"
+description: "Estimate monthly savings when switching from incandescent to LED."
+updated: "2025-10-24"
+cluster: "Home & DIY"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "led-savings-calculator",
+  title: "LED Savings Calculator",
+  locale: "en",
+  intro: "Estimate energy cost savings by replacing incandescent bulbs with LEDs.",
+  unit: "USD/month",
+  cluster: "Home & DIY",
+  inputs: [
+    { name: "old", label: "Incandescent wattage", type: "number", step: "any", placeholder: "60" },
+    { name: "new", label: "LED wattage", type: "number", step: "any", placeholder: "9" },
+    { name: "hours", label: "Hours per day", type: "number", step: "any", placeholder: "5" },
+    { name: "rate", label: "Electricity rate ($/kWh)", type: "number", step: "any", placeholder: "0.15" }
+  ],
+  expression: "((old - new) * hours * 30 / 1000) * rate",
+  examples: [
+    { description: "60W→9W, 5h/day, $0.15/kWh ⇒ $6.84/mo saved" },
+    { description: "75W→10W, 3h/day, $0.20/kWh ⇒ $11.70/mo saved" }
+  ],
+  faqs: [
+    { question: "Why multiply by 30?", answer: "It approximates a 30-day month." },
+    { question: "Does bulb cost matter?", answer: "This focuses only on energy savings." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/mb-to-gb-converter.mdx
+++ b/src/pages/calculators/mb-to-gb-converter.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "MB to GB Converter"
+description: "Convert megabytes to gigabytes."
+updated: "2025-10-24"
+cluster: "Conversions"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "mb-to-gb-converter",
+  title: "MB to GB Converter",
+  locale: "en",
+  intro: "Convert megabytes to gigabytes for quick storage planning.",
+  unit: "GB",
+  cluster: "Conversions",
+  inputs: [
+    { name: "mb", label: "Megabytes (MB)", type: "number", step: "any", placeholder: "2048" }
+  ],
+  expression: "mb / 1024",
+  examples: [
+    { description: "2048 MB ⇒ 2 GB" },
+    { description: "5120 MB ⇒ 5 GB" }
+  ],
+  faqs: [
+    { question: "Is it using binary units?", answer: "Yes, it divides by 1024 to convert MB to GB." },
+    { question: "Can I use decimals?", answer: "Yes, enter any numeric value." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/meeting-time-percentage.mdx
+++ b/src/pages/calculators/meeting-time-percentage.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Meeting Time Percentage"
+description: "Meeting minutes as a share of the workday."
+updated: "2025-10-24"
+cluster: "Date & Time"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "meeting-time-percentage",
+  title: "Meeting Time Percentage",
+  locale: "en",
+  intro: "See how much of your workday is spent in meetings.",
+  unit: "%",
+  cluster: "Date & Time",
+  inputs: [
+    { name: "meeting", label: "Meeting time (minutes)", type: "number", step: "any", placeholder: "90" },
+    { name: "workday", label: "Workday length (minutes)", type: "number", step: "any", placeholder: "480" }
+  ],
+  expression: "(meeting / workday) * 100",
+  examples: [
+    { description: "90 min in 480 min ⇒ 18.75%" },
+    { description: "30 min in 300 min ⇒ 10%" }
+  ],
+  faqs: [
+    { question: "What is a typical workday length?", answer: "Many offices use 480 minutes (8 hours)." },
+    { question: "Can I analyze multiple meetings?", answer: "Sum the meeting minutes before entering." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/part-of-total-percentage.mdx
+++ b/src/pages/calculators/part-of-total-percentage.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Part of Total Percentage"
+description: "Find what percent a part is of a total."
+updated: "2025-10-24"
+cluster: "Math"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "part-of-total-percentage",
+  title: "Part of Total Percentage",
+  locale: "en",
+  intro: "Calculate what percentage a value represents of a whole.",
+  unit: "%",
+  cluster: "Math",
+  inputs: [
+    { name: "part", label: "Part", type: "number", step: "any", placeholder: "30" },
+    { name: "total", label: "Total", type: "number", step: "any", placeholder: "200" }
+  ],
+  expression: "(part / total) * 100",
+  examples: [
+    { description: "30 of 200 ⇒ 15%" },
+    { description: "50 of 80 ⇒ 62.5%" }
+  ],
+  faqs: [
+    { question: "Can the result exceed 100%?", answer: "Yes, if part is greater than total." },
+    { question: "What if total is 0?", answer: "The calculation is undefined." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/percentage-to-decimal.mdx
+++ b/src/pages/calculators/percentage-to-decimal.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Percentage to Decimal Converter"
+description: "Convert a percentage to its decimal form."
+updated: "2025-10-24"
+cluster: "Conversions"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "percentage-to-decimal",
+  title: "Percentage to Decimal Converter",
+  locale: "en",
+  intro: "Quickly turn a percentage into a decimal for spreadsheets and formulas.",
+  unit: "decimal",
+  cluster: "Conversions",
+  inputs: [
+    { name: "percent", label: "Percentage (%)", type: "number", step: "any", placeholder: "25" }
+  ],
+  expression: "percent / 100",
+  examples: [
+    { description: "25% ⇒ 0.25" },
+    { description: "150% ⇒ 1.5" }
+  ],
+  faqs: [
+    { question: "Why divide by 100?", answer: "Percent means per hundred, so dividing converts to decimal." },
+    { question: "Can it handle negative values?", answer: "Yes, negatives work the same way." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/printer-cost-per-page.mdx
+++ b/src/pages/calculators/printer-cost-per-page.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Printer Cost per Page"
+description: "Estimate cost per printed page from cartridge and yield."
+updated: "2025-10-24"
+cluster: "Technology"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "printer-cost-per-page",
+  title: "Printer Cost per Page",
+  locale: "en",
+  intro: "Determine how much each printed page costs based on cartridge price and yield.",
+  unit: "$\/page",
+  cluster: "Technology",
+  inputs: [
+    { name: "price", label: "Cartridge price ($)", type: "number", step: "any", placeholder: "40" },
+    { name: "yield", label: "Yield (pages)", type: "number", step: "any", placeholder: "2000" }
+  ],
+  expression: "price / yield",
+  examples: [
+    { description: "$40 cartridge, 2000 pages ⇒ $0.02/page" },
+    { description: "$25 cartridge, 500 pages ⇒ $0.05/page" }
+  ],
+  faqs: [
+    { question: "Does this include paper cost?", answer: "No, only cartridge cost is considered." },
+    { question: "What if yield is an estimate?", answer: "Results are approximate based on manufacturer yield." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/printing-carbon-footprint.mdx
+++ b/src/pages/calculators/printing-carbon-footprint.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Printing Carbon Footprint"
+description: "Estimate CO₂ emissions from paper printing."
+updated: "2025-10-24"
+cluster: "Other"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "printing-carbon-footprint",
+  title: "Printing Carbon Footprint",
+  locale: "en",
+  intro: "Approximate CO₂ emissions using 0.0044 kg per printed page.",
+  unit: "kg CO₂",
+  cluster: "Other",
+  inputs: [
+    { name: "pages", label: "Pages printed", type: "number", step: "any", placeholder: "500" }
+  ],
+  expression: "pages * 0.0044",
+  examples: [
+    { description: "500 pages ⇒ 2.2 kg CO₂" },
+    { description: "100 pages ⇒ 0.44 kg CO₂" }
+  ],
+  faqs: [
+    { question: "Where does 0.0044 come from?", answer: "It's an average emission factor per page." },
+    { question: "Does double-sided printing change it?", answer: "Yes, count each printed side separately." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/psu-load-percentage.mdx
+++ b/src/pages/calculators/psu-load-percentage.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "PSU Load Percentage"
+description: "Power supply usage as a percentage of capacity."
+updated: "2025-10-24"
+cluster: "Technology"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "psu-load-percentage",
+  title: "PSU Load Percentage",
+  locale: "en",
+  intro: "Check how much of a power supply's capacity your system draws.",
+  unit: "%",
+  cluster: "Technology",
+  inputs: [
+    { name: "load", label: "System load (W)", type: "number", step: "any", placeholder: "300" },
+    { name: "capacity", label: "PSU capacity (W)", type: "number", step: "any", placeholder: "500" }
+  ],
+  expression: "(load / capacity) * 100",
+  examples: [
+    { description: "300 W load on 500 W PSU ⇒ 60%" },
+    { description: "450 W load on 600 W PSU ⇒ 75%" }
+  ],
+  faqs: [
+    { question: "Why keep load under 80%?", answer: "It allows headroom and better efficiency." },
+    { question: "Can capacity be lower than load?", answer: "The result will exceed 100%, indicating overload." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/ream-duration-calculator.mdx
+++ b/src/pages/calculators/ream-duration-calculator.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Ream Duration Calculator"
+description: "Estimate how long a 500-sheet ream will last."
+updated: "2025-10-24"
+cluster: "Other"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "ream-duration-calculator",
+  title: "Ream Duration Calculator",
+  locale: "en",
+  intro: "See how many days a paper ream covers based on daily printing.",
+  unit: "days",
+  cluster: "Other",
+  inputs: [
+    { name: "pages", label: "Pages printed per day", type: "number", step: "any", placeholder: "100" }
+  ],
+  expression: "500 / pages",
+  examples: [
+    { description: "100 pages/day ⇒ 5 days" },
+    { description: "25 pages/day ⇒ 20 days" }
+  ],
+  faqs: [
+    { question: "What if I use half a ream?", answer: "Adjust the 500 figure accordingly." },
+    { question: "Does it account for double-sided printing?", answer: "No, count each printed side as a page." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/screen-break-frequency.mdx
+++ b/src/pages/calculators/screen-break-frequency.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Screen Break Frequency"
+description: "Number of 20-20-20 breaks for given screen hours."
+updated: "2025-10-24"
+cluster: "Health"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "screen-break-frequency",
+  title: "Screen Break Frequency",
+  locale: "en",
+  intro: "Count how many 20-second eye breaks to take every 20 minutes of screen time.",
+  unit: "breaks",
+  cluster: "Health",
+  inputs: [
+    { name: "hours", label: "Screen time (hours)", type: "number", step: "any", placeholder: "6" }
+  ],
+  expression: "(hours * 60) / 20",
+  examples: [
+    { description: "6 h ⇒ 18 breaks" },
+    { description: "3 h ⇒ 9 breaks" }
+  ],
+  faqs: [
+    { question: "What is the 20-20-20 rule?", answer: "Every 20 minutes, look 20 feet away for 20 seconds." },
+    { question: "Do short sessions add up?", answer: "Yes, enter total screen hours for the day." }
+  ],
+  disclaimer: "For informational purposes only, not medical advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/space-per-employee.mdx
+++ b/src/pages/calculators/space-per-employee.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Space per Employee"
+description: "Office area available per person."
+updated: "2025-10-24"
+cluster: "Other"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "space-per-employee",
+  title: "Space per Employee",
+  locale: "en",
+  intro: "Calculate floor area allocated to each employee.",
+  unit: "m²/person",
+  cluster: "Other",
+  inputs: [
+    { name: "area", label: "Total area (m²)", type: "number", step: "any", placeholder: "200" },
+    { name: "people", label: "Number of employees", type: "number", step: "any", placeholder: "10" }
+  ],
+  expression: "area / people",
+  examples: [
+    { description: "200 m² for 10 people ⇒ 20 m²/person" },
+    { description: "90 m² for 15 people ⇒ 6 m²/person" }
+  ],
+  faqs: [
+    { question: "Is there a recommended area?", answer: "Many offices aim for 10–15 m² per person." },
+    { question: "Does this include common areas?", answer: "Include any space employees can use." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/standard-deviation-3-numbers.mdx
+++ b/src/pages/calculators/standard-deviation-3-numbers.mdx
@@ -1,0 +1,34 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Standard Deviation (3 Numbers)"
+description: "Sample standard deviation of three values."
+updated: "2025-10-24"
+cluster: "Math"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "standard-deviation-3-numbers",
+  title: "Standard Deviation (3 Numbers)",
+  locale: "en",
+  intro: "Compute the sample standard deviation for three data points.",
+  unit: "value",
+  cluster: "Math",
+  inputs: [
+    { name: "a", label: "Value A", type: "number", step: "any", placeholder: "10" },
+    { name: "b", label: "Value B", type: "number", step: "any", placeholder: "12" },
+    { name: "c", label: "Value C", type: "number", step: "any", placeholder: "15" }
+  ],
+  expression: "(( (a - ((a+b+c)/3))^2 + (b - ((a+b+c)/3))^2 + (c - ((a+b+c)/3))^2 ) / 2) ^ 0.5",
+  examples: [
+    { description: "10,12,15 ⇒ 2.52" },
+    { description: "5,5,5 ⇒ 0" }
+  ],
+  faqs: [
+    { question: "Why divide by 2?", answer: "For sample standard deviation with n-1 degrees of freedom." },
+    { question: "Can I use more numbers?", answer: "This version handles exactly three values." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/standing-time-percentage.mdx
+++ b/src/pages/calculators/standing-time-percentage.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Standing Time Percentage"
+description: "How much of the day you spend standing."
+updated: "2025-10-24"
+cluster: "Health"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "standing-time-percentage",
+  title: "Standing Time Percentage",
+  locale: "en",
+  intro: "Track the share of your day spent standing versus sitting.",
+  unit: "%",
+  cluster: "Health",
+  inputs: [
+    { name: "standing", label: "Standing time (minutes)", type: "number", step: "any", placeholder: "120" },
+    { name: "total", label: "Total awake time (minutes)", type: "number", step: "any", placeholder: "960" }
+  ],
+  expression: "(standing / total) * 100",
+  examples: [
+    { description: "120 min standing in 960 min ⇒ 12.5%" },
+    { description: "240 min standing in 600 min ⇒ 40%" }
+  ],
+  faqs: [
+    { question: "Why track standing time?", answer: "Regular standing can reduce sedentary health risks." },
+    { question: "What is total awake time?", answer: "Hours you're not sleeping during the day." }
+  ],
+  disclaimer: "For informational purposes only, not medical advice.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/weighted-average-calculator.mdx
+++ b/src/pages/calculators/weighted-average-calculator.mdx
@@ -1,0 +1,37 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Weighted Average Calculator"
+description: "Compute weighted average for up to three values."
+updated: "2025-10-24"
+cluster: "Math"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "weighted-average-calculator",
+  title: "Weighted Average Calculator",
+  locale: "en",
+  intro: "Find the weighted average of up to three data points.",
+  unit: "value",
+  cluster: "Math",
+  inputs: [
+    { name: "v1", label: "Value 1", type: "number", step: "any", placeholder: "80" },
+    { name: "w1", label: "Weight 1", type: "number", step: "any", placeholder: "1" },
+    { name: "v2", label: "Value 2", type: "number", step: "any", placeholder: "90" },
+    { name: "w2", label: "Weight 2", type: "number", step: "any", placeholder: "2" },
+    { name: "v3", label: "Value 3", type: "number", step: "any", placeholder: "75" },
+    { name: "w3", label: "Weight 3", type: "number", step: "any", placeholder: "1" }
+  ],
+  expression: "(v1*w1 + v2*w2 + v3*w3) / (w1 + w2 + w3)",
+  examples: [
+    { description: "Scores 80,90,75 with weights 1,2,1 ⇒ 83.75" },
+    { description: "Values 10,20,30 with weights 1,1,1 ⇒ 20" }
+  ],
+  faqs: [
+    { question: "Can I leave some values blank?", answer: "Enter zero for unused values and weights." },
+    { question: "Are weights required?", answer: "Yes, use 1 for equal weighting." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/work-hours-to-days.mdx
+++ b/src/pages/calculators/work-hours-to-days.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Work Hours to Days Converter"
+description: "Convert total work hours into standard workdays."
+updated: "2025-10-24"
+cluster: "Date & Time"
+---
+import Calculator from "../../components/Calculator.astro";
+
+export const schema = {
+  slug: "work-hours-to-days",
+  title: "Work Hours to Days Converter",
+  locale: "en",
+  intro: "Translate hours of effort into 8-hour workdays.",
+  unit: "workdays",
+  cluster: "Date & Time",
+  inputs: [
+    { name: "hours", label: "Total hours", type: "number", step: "any", placeholder: "40" },
+    { name: "day", label: "Hours per workday", type: "number", step: "any", placeholder: "8" }
+  ],
+  expression: "hours / day",
+  examples: [
+    { description: "40 h at 8 h/day ⇒ 5 workdays" },
+    { description: "60 h at 7.5 h/day ⇒ 8 workdays" }
+  ],
+  faqs: [
+    { question: "What is a standard workday?", answer: "Many workplaces use 8 hours, but you can adjust the input." },
+    { question: "Does it account for breaks?", answer: "Breaks should be excluded from the hours entered." }
+  ],
+  disclaimer: "For informational purposes only.",
+};
+
+<Calculator schema={schema} />


### PR DESCRIPTION
## Summary
- add 24 new English calculators for office users spanning Conversions, Date & Time, Finance, Health, Home & DIY, Math, Technology, and Other categories
- register all new calculators in `calculators_extra.json` for manual workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ba2e91749c83218de4929a10062a12