### PR TITLE
Add sixteen new calculators across categories

### DIFF
--- a/src/pages/calculators/arithmetic-series-sum.mdx
+++ b/src/pages/calculators/arithmetic-series-sum.mdx
@@ -1,0 +1,37 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Arithmetic Series Sum"
+description: "Sum of the first n terms of an arithmetic sequence."
+updated: "2025-09-27"
+cluster: "Math"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "a1", "label": "First Term", "type": "number", "step": "any", "placeholder": "2" },
+    { "name": "d", "label": "Common Difference", "type": "number", "step": "any", "placeholder": "3" },
+    { "name": "n", "label": "Number of Terms", "type": "number", "step": "1", "min": 1, "placeholder": "5" }
+  ],
+  "slug": "arithmetic-series-sum",
+  "title": "Arithmetic Series Sum",
+  "locale": "en",
+  "unit": "number",
+  "expression": "n/2 * (2*a1 + (n-1)*d)",
+  "intro": "Calculate the total of the first n terms in an arithmetic sequence using its first term and common difference.",
+  "examples": [
+    { "description": "a1=2, d=3, n=5 ⇒ 40" },
+    { "description": "a1=1, d=1, n=10 ⇒ 55" },
+    { "description": "a1=5, d=2, n=4 ⇒ 26" }
+  ],
+  "faqs": [
+    { "question": "What is an arithmetic series?", "answer": "A sequence where each term increases by a constant difference." },
+    { "question": "Can n be non-integer?", "answer": "No, number of terms must be a whole number." },
+    { "question": "What if difference is negative?", "answer": "The formula works with negative differences as well." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Math"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/celsius-to-kelvin.mdx
+++ b/src/pages/calculators/celsius-to-kelvin.mdx
@@ -1,0 +1,41 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Celsius to Kelvin"
+description: "Convert temperatures from Celsius to Kelvin."
+updated: "2025-09-27"
+cluster: "Conversions"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    {
+      "name": "c",
+      "label": "Celsius (°C)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "25"
+    }
+  ],
+  "slug": "celsius-to-kelvin",
+  "title": "Celsius to Kelvin",
+  "locale": "en",
+  "unit": "K",
+  "expression": "c + 273.15",
+  "intro": "Easily convert temperatures from degrees Celsius to Kelvin for scientific calculations or everyday use.",
+  "examples": [
+    { "description": "0 °C ⇒ 273.15 K" },
+    { "description": "25 °C ⇒ 298.15 K" },
+    { "description": "-10 °C ⇒ 263.15 K" }
+  ],
+  "faqs": [
+    { "question": "Can it handle negative temperatures?", "answer": "Yes, input any Celsius value including negatives." },
+    { "question": "Are decimals supported?", "answer": "Yes, you can enter decimal temperatures." },
+    { "question": "What is absolute zero in Kelvin?", "answer": "Absolute zero is 0 K, equal to -273.15 °C." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Conversions"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/daylight-duration.mdx
+++ b/src/pages/calculators/daylight-duration.mdx
@@ -1,0 +1,48 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Daylight Duration"
+description: "Find total daylight hours from sunrise and sunset times."
+updated: "2025-09-27"
+cluster: "Date & Time"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    {
+      "name": "sunrise",
+      "label": "Sunrise (h)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "6"
+    },
+    {
+      "name": "sunset",
+      "label": "Sunset (h)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "18"
+    }
+  ],
+  "slug": "daylight-duration",
+  "title": "Daylight Duration",
+  "locale": "en",
+  "unit": "hours",
+  "expression": "sunset - sunrise",
+  "intro": "Determine the length of daylight by subtracting sunrise time from sunset time on a 24-hour clock.",
+  "examples": [
+    { "description": "Sunrise 6, Sunset 18 ⇒ 12 hours" },
+    { "description": "Sunrise 7.5, Sunset 20.25 ⇒ 12.75 hours" },
+    { "description": "Sunrise 5.25, Sunset 19.75 ⇒ 14.5 hours" }
+  ],
+  "faqs": [
+    { "question": "What time format is used?", "answer": "Enter times in decimal hours using a 24-hour clock." },
+    { "question": "Can it handle overnight sun?", "answer": "This calculator assumes sunrise occurs before sunset within the same day." },
+    { "question": "Are fractional hours allowed?", "answer": "Yes, use decimals for minutes (e.g., 7.5 for 7:30)." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Date & Time"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/dog-age-human-years.mdx
+++ b/src/pages/calculators/dog-age-human-years.mdx
@@ -1,0 +1,35 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Dog Age in Human Years"
+description: "Convert a dog's age to an equivalent human age."
+updated: "2025-09-27"
+cluster: "Other"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "dogYears", "label": "Dog Years", "type": "number", "step": "any", "placeholder": "3" }
+  ],
+  "slug": "dog-age-human-years",
+  "title": "Dog Age in Human Years",
+  "locale": "en",
+  "unit": "human years",
+  "expression": "dogYears * 7",
+  "intro": "Estimate your dog's age in human years using the common 7-to-1 ratio.",
+  "examples": [
+    { "description": "1 dog year ⇒ 7 human years" },
+    { "description": "5 dog years ⇒ 35 human years" },
+    { "description": "10 dog years ⇒ 70 human years" }
+  ],
+  "faqs": [
+    { "question": "Is the 7-year rule accurate?", "answer": "It's a simple approximation and varies by breed." },
+    { "question": "Can I use decimal ages?", "answer": "Yes, enter any age in years." },
+    { "question": "Does size affect the result?", "answer": "This method doesn't account for size or breed differences." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Other"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/fence-post-count.mdx
+++ b/src/pages/calculators/fence-post-count.mdx
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Fence Post Count"
+description: "Estimate number of posts needed for a straight fence."
+updated: "2025-09-27"
+cluster: "Home & DIY"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "length", "label": "Fence Length (ft)", "type": "number", "step": "any", "placeholder": "100" },
+    { "name": "spacing", "label": "Post Spacing (ft)", "type": "number", "step": "any", "placeholder": "8" }
+  ],
+  "slug": "fence-post-count",
+  "title": "Fence Post Count",
+  "locale": "en",
+  "unit": "posts",
+  "expression": "length / spacing + 1",
+  "intro": "Quickly approximate how many posts are needed to build a straight fence given total length and spacing between posts.",
+  "examples": [
+    { "description": "Length 100 ft, spacing 8 ft ⇒ 13.5 posts" },
+    { "description": "Length 50 ft, spacing 6 ft ⇒ 9.33 posts" },
+    { "description": "Length 200 ft, spacing 10 ft ⇒ 21 posts" }
+  ],
+  "faqs": [
+    { "question": "Should I round up the result?", "answer": "Yes, always round up to ensure enough posts." },
+    { "question": "Does it include corner posts?", "answer": "The formula adds one extra post for the end but doesn't account for gates or corners." },
+    { "question": "Can spacing be in meters?", "answer": "Convert to feet before using the calculator." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Home & DIY"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/inflation-adjusted-price.mdx
+++ b/src/pages/calculators/inflation-adjusted-price.mdx
@@ -1,0 +1,37 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Inflation Adjusted Price"
+description: "Estimate a future price after inflation."
+updated: "2025-09-27"
+cluster: "Finance"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "price", "label": "Current Price", "type": "number", "step": "any", "placeholder": "100" },
+    { "name": "rate", "label": "Annual Inflation (%)", "type": "number", "step": "any", "placeholder": "3" },
+    { "name": "years", "label": "Years", "type": "number", "step": "any", "placeholder": "5" }
+  ],
+  "slug": "inflation-adjusted-price",
+  "title": "Inflation Adjusted Price",
+  "locale": "en",
+  "unit": "same as price",
+  "expression": "price * (1 + rate/100) ^ years",
+  "intro": "Calculate how much a price today will cost in the future after applying annual inflation.",
+  "examples": [
+    { "description": "Price 100, 3% for 5 years ⇒ 115.93" },
+    { "description": "Price 50, 2% for 10 years ⇒ 60.95" },
+    { "description": "Price 20, 5% for 2 years ⇒ 22.05" }
+  ],
+  "faqs": [
+    { "question": "Is inflation compounded annually?", "answer": "Yes, the rate is applied once per year." },
+    { "question": "Can I use negative inflation?", "answer": "Yes, enter a negative rate for deflation." },
+    { "question": "What currency is used?", "answer": "The result uses the same currency as your input price." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Finance"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/kilograms-to-newtons.mdx
+++ b/src/pages/calculators/kilograms-to-newtons.mdx
@@ -1,0 +1,41 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Kilograms to Newtons"
+description: "Convert mass in kilograms to weight force in Newtons."
+updated: "2025-09-27"
+cluster: "Conversions"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    {
+      "name": "kg",
+      "label": "Mass (kg)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "10"
+    }
+  ],
+  "slug": "kilograms-to-newtons",
+  "title": "Kilograms to Newtons",
+  "locale": "en",
+  "unit": "N",
+  "expression": "kg * 9.80665",
+  "intro": "Calculate the weight force of an object in Newtons from its mass in kilograms assuming standard Earth gravity.",
+  "examples": [
+    { "description": "1 kg ⇒ 9.81 N" },
+    { "description": "5 kg ⇒ 49.03 N" },
+    { "description": "0.2 kg ⇒ 1.96 N" }
+  ],
+  "faqs": [
+    { "question": "What gravity constant is used?", "answer": "The calculator uses standard gravity of 9.80665 m/s²." },
+    { "question": "Can I input decimal masses?", "answer": "Yes, decimals are accepted." },
+    { "question": "Is this valid on other planets?", "answer": "No, the result is specific to Earth's gravity." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Conversions"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/lottery-expected-value.mdx
+++ b/src/pages/calculators/lottery-expected-value.mdx
@@ -1,0 +1,37 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Lottery Expected Value"
+description: "Calculate the expected monetary value of a lottery ticket."
+updated: "2025-09-27"
+cluster: "Other"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "prize", "label": "Prize Amount", "type": "number", "step": "any", "placeholder": "1000" },
+    { "name": "prob", "label": "Win Probability", "type": "number", "step": "any", "placeholder": "0.001" },
+    { "name": "cost", "label": "Ticket Cost", "type": "number", "step": "any", "placeholder": "2" }
+  ],
+  "slug": "lottery-expected-value",
+  "title": "Lottery Expected Value",
+  "locale": "en",
+  "unit": "same as prize",
+  "expression": "prize * prob - cost",
+  "intro": "Estimate the average gain or loss from buying a lottery ticket based on prize amount, odds, and ticket cost.",
+  "examples": [
+    { "description": "Prize 1000, prob 0.001, cost 2 ⇒ -1" },
+    { "description": "Prize 5000, prob 0.0005, cost 5 ⇒ -2.5" },
+    { "description": "Prize 100, prob 0.02, cost 1 ⇒ 1" }
+  ],
+  "faqs": [
+    { "question": "What is expected value?", "answer": "It's the average outcome if the lottery could be played many times." },
+    { "question": "Should probability be a decimal?", "answer": "Yes, enter odds as a decimal between 0 and 1." },
+    { "question": "Can expected value be negative?", "answer": "Yes, most lotteries have negative expected value." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Other"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/mean-arterial-pressure.mdx
+++ b/src/pages/calculators/mean-arterial-pressure.mdx
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Mean Arterial Pressure"
+description: "Estimate average arterial pressure using systolic and diastolic readings."
+updated: "2025-09-27"
+cluster: "Health"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "systolic", "label": "Systolic (mmHg)", "type": "number", "step": "any", "placeholder": "120" },
+    { "name": "diastolic", "label": "Diastolic (mmHg)", "type": "number", "step": "any", "placeholder": "80" }
+  ],
+  "slug": "mean-arterial-pressure",
+  "title": "Mean Arterial Pressure",
+  "locale": "en",
+  "unit": "mmHg",
+  "expression": "diastolic + (systolic - diastolic)/3",
+  "intro": "Calculate mean arterial pressure (MAP), an indicator of overall blood flow and pressure in the arteries.",
+  "examples": [
+    { "description": "120/80 ⇒ 93.33 mmHg" },
+    { "description": "110/70 ⇒ 83.33 mmHg" },
+    { "description": "140/90 ⇒ 106.67 mmHg" }
+  ],
+  "faqs": [
+    { "question": "Why use MAP?", "answer": "MAP helps gauge blood flow and perfusion to organs." },
+    { "question": "Are readings in mmHg?", "answer": "Yes, both inputs and result are in millimeters of mercury." },
+    { "question": "Does it replace professional advice?", "answer": "No, consult healthcare providers for medical guidance." }
+  ],
+  "disclaimer": "Educational purposes only. Not medical advice.",
+  "cluster": "Health"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/monthly-savings-required.mdx
+++ b/src/pages/calculators/monthly-savings-required.mdx
@@ -1,0 +1,37 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Monthly Savings Required"
+description: "Monthly deposit needed to reach a savings goal."
+updated: "2025-09-27"
+cluster: "Finance"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "goal", "label": "Savings Goal", "type": "number", "step": "any", "placeholder": "10000" },
+    { "name": "rate", "label": "Annual Interest (%)", "type": "number", "step": "any", "placeholder": "5" },
+    { "name": "years", "label": "Years", "type": "number", "step": "any", "placeholder": "5" }
+  ],
+  "slug": "monthly-savings-required",
+  "title": "Monthly Savings Required",
+  "locale": "en",
+  "unit": "per month",
+  "expression": "goal * (rate/100/12) / ((1 + rate/100/12)^(years*12) - 1)",
+  "intro": "Determine the monthly contribution needed to achieve a savings target given an annual interest rate.",
+  "examples": [
+    { "description": "Goal 10000, 5% for 5 years ⇒ 147.05 per month" },
+    { "description": "Goal 5000, 3% for 3 years ⇒ 132.91 per month" },
+    { "description": "Goal 20000, 4% for 10 years ⇒ 135.82 per month" }
+  ],
+  "faqs": [
+    { "question": "Is interest compounded monthly?", "answer": "Yes, the annual rate is converted to a monthly rate." },
+    { "question": "Can I use zero interest?", "answer": "Yes, the formula still works with a 0% rate." },
+    { "question": "Does it assume end-of-month deposits?", "answer": "Yes, contributions are assumed at the end of each month." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Finance"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/months-to-weeks.mdx
+++ b/src/pages/calculators/months-to-weeks.mdx
@@ -1,0 +1,41 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Months to Weeks"
+description: "Approximate weeks contained in a number of months."
+updated: "2025-09-27"
+cluster: "Date & Time"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    {
+      "name": "months",
+      "label": "Months",
+      "type": "number",
+      "step": "any",
+      "placeholder": "2"
+    }
+  ],
+  "slug": "months-to-weeks",
+  "title": "Months to Weeks",
+  "locale": "en",
+  "unit": "weeks",
+  "expression": "months * 4.34524",
+  "intro": "Convert months into an approximate number of weeks using the average of 4.34524 weeks per month.",
+  "examples": [
+    { "description": "1 month ⇒ 4.35 weeks" },
+    { "description": "6 months ⇒ 26.07 weeks" },
+    { "description": "0.5 month ⇒ 2.17 weeks" }
+  ],
+  "faqs": [
+    { "question": "What conversion factor is used?", "answer": "Each month is approximated as 4.34524 weeks." },
+    { "question": "Is this exact for all months?", "answer": "No, it's an average since months vary in length." },
+    { "question": "Can I convert fractional months?", "answer": "Yes, decimals are supported." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Date & Time"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/mulch-volume.mdx
+++ b/src/pages/calculators/mulch-volume.mdx
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Mulch Volume"
+description: "Calculate cubic yards of mulch needed for a project."
+updated: "2025-09-27"
+cluster: "Home & DIY"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "area", "label": "Area (ft²)", "type": "number", "step": "any", "placeholder": "500" },
+    { "name": "depth", "label": "Depth (in)", "type": "number", "step": "any", "placeholder": "3" }
+  ],
+  "slug": "mulch-volume",
+  "title": "Mulch Volume",
+  "locale": "en",
+  "unit": "yd³",
+  "expression": "(area * depth / 12) / 27",
+  "intro": "Estimate how many cubic yards of mulch are needed based on coverage area and desired depth.",
+  "examples": [
+    { "description": "Area 500 ft², depth 3 in ⇒ 4.63 yd³" },
+    { "description": "Area 200 ft², depth 2 in ⇒ 1.23 yd³" },
+    { "description": "Area 1000 ft², depth 4 in ⇒ 12.35 yd³" }
+  ],
+  "faqs": [
+    { "question": "Why divide by 27?", "answer": "There are 27 cubic feet in a cubic yard." },
+    { "question": "Can I use metric units?", "answer": "Convert to feet and inches first for accurate results." },
+    { "question": "Does it account for settling?", "answer": "No, consider ordering extra to account for compaction." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Home & DIY"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/ohms-law-voltage.mdx
+++ b/src/pages/calculators/ohms-law-voltage.mdx
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Ohm's Law Voltage"
+description: "Compute voltage from current and resistance using Ohm's Law."
+updated: "2025-09-27"
+cluster: "Technology"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "current", "label": "Current (A)", "type": "number", "step": "any", "placeholder": "2" },
+    { "name": "resistance", "label": "Resistance (Ω)", "type": "number", "step": "any", "placeholder": "5" }
+  ],
+  "slug": "ohms-law-voltage",
+  "title": "Ohm's Law Voltage",
+  "locale": "en",
+  "unit": "V",
+  "expression": "current * resistance",
+  "intro": "Apply Ohm's Law to find voltage when current and resistance are known.",
+  "examples": [
+    { "description": "2 A & 5 Ω ⇒ 10 V" },
+    { "description": "0.5 A & 100 Ω ⇒ 50 V" },
+    { "description": "1.2 A & 8 Ω ⇒ 9.6 V" }
+  ],
+  "faqs": [
+    { "question": "What is Ohm's Law?", "answer": "It relates voltage, current, and resistance: V = I × R." },
+    { "question": "Can inputs be decimal?", "answer": "Yes, decimals are accepted for both current and resistance." },
+    { "question": "Is temperature considered?", "answer": "No, resistance changes with temperature are not accounted for." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Technology"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/parallel-resistance.mdx
+++ b/src/pages/calculators/parallel-resistance.mdx
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Parallel Resistance"
+description: "Equivalent resistance of two resistors in parallel."
+updated: "2025-09-27"
+cluster: "Technology"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "r1", "label": "Resistor 1 (Ω)", "type": "number", "step": "any", "placeholder": "100" },
+    { "name": "r2", "label": "Resistor 2 (Ω)", "type": "number", "step": "any", "placeholder": "100" }
+  ],
+  "slug": "parallel-resistance",
+  "title": "Parallel Resistance",
+  "locale": "en",
+  "unit": "Ω",
+  "expression": "1 / (1/r1 + 1/r2)",
+  "intro": "Calculate the equivalent resistance for two resistors connected in parallel.",
+  "examples": [
+    { "description": "R1=100 Ω, R2=100 Ω ⇒ 50 Ω" },
+    { "description": "R1=200 Ω, R2=300 Ω ⇒ 120 Ω" },
+    { "description": "R1=10 Ω, R2=20 Ω ⇒ 6.67 Ω" }
+  ],
+  "faqs": [
+    { "question": "Can more than two resistors be used?", "answer": "This calculator is for exactly two resistors." },
+    { "question": "Are units important?", "answer": "Both inputs must be in the same unit, typically ohms." },
+    { "question": "Why does equivalent resistance decrease?", "answer": "Parallel paths allow more current, reducing total resistance." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Technology"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/sleep-cycle-count.mdx
+++ b/src/pages/calculators/sleep-cycle-count.mdx
@@ -1,0 +1,35 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Sleep Cycle Count"
+description: "Estimate the number of 90-minute sleep cycles in a sleep period."
+updated: "2025-09-27"
+cluster: "Health"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "hours", "label": "Total Sleep Hours", "type": "number", "step": "any", "placeholder": "7.5" }
+  ],
+  "slug": "sleep-cycle-count",
+  "title": "Sleep Cycle Count",
+  "locale": "en",
+  "unit": "cycles",
+  "expression": "hours / 1.5",
+  "intro": "Calculate how many complete 90-minute sleep cycles fit into your planned sleep time.",
+  "examples": [
+    { "description": "7.5 h ⇒ 5 cycles" },
+    { "description": "6 h ⇒ 4 cycles" },
+    { "description": "9 h ⇒ 6 cycles" }
+  ],
+  "faqs": [
+    { "question": "Why 1.5 hours per cycle?", "answer": "Each full sleep cycle averages around 90 minutes." },
+    { "question": "Can I use decimals?", "answer": "Yes, enter any sleep duration in hours." },
+    { "question": "Does it account for falling asleep time?", "answer": "No, it only divides total sleep duration by 1.5." }
+  ],
+  "disclaimer": "Educational purposes only. Not medical advice.",
+  "cluster": "Health"
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/triangular-number.mdx
+++ b/src/pages/calculators/triangular-number.mdx
@@ -1,0 +1,35 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Triangular Number"
+description: "Sum of the first n natural numbers."
+updated: "2025-09-27"
+cluster: "Math"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "inputs": [
+    { "name": "n", "label": "n", "type": "number", "step": "1", "min": 0, "placeholder": "5" }
+  ],
+  "slug": "triangular-number",
+  "title": "Triangular Number",
+  "locale": "en",
+  "unit": "number",
+  "expression": "n * (n + 1) / 2",
+  "intro": "Compute the nth triangular number, equal to the sum of all integers from 1 through n.",
+  "examples": [
+    { "description": "n=3 ⇒ 6" },
+    { "description": "n=5 ⇒ 15" },
+    { "description": "n=10 ⇒ 55" }
+  ],
+  "faqs": [
+    { "question": "What is a triangular number?", "answer": "It's the total of the natural numbers from 1 to n." },
+    { "question": "Can n be zero?", "answer": "Yes, n=0 gives a triangular number of 0." },
+    { "question": "Does it handle large n?", "answer": "Yes, but results grow quickly." }
+  ],
+  "disclaimer": "Educational purposes only. Not professional advice.",
+  "cluster": "Math"
+}
+
+<Calculator schema={schema} />


### PR DESCRIPTION
## Summary
- add conversions calculators for Celsius→Kelvin and kilograms→Newtons
- add date & time tools for months-to-weeks and daylight duration
- add finance tools for inflation adjustment and monthly savings planning
- add health utilities for mean arterial pressure and sleep cycle counts
- add home & DIY helpers for mulch volume and fence post counts
- add math aids for triangular numbers and arithmetic series sums
- add technology tools for Ohm's law voltage and parallel resistance
- add other calculators for dog age in human years and lottery expected value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ba6c163c4083219cb1e8935fc04309