### PR TITLE
fix: show description on category cards

### DIFF
--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -75,7 +75,7 @@ const { cat, list = [] } = Astro.props;
           <div>
             <a class="card" href={`/calculators/${c.slug}/`}>
               <h3>{c.title}</h3>
-              <p>{c.intro ?? ''}</p>
+              <p>{c.intro || c.description || ''}</p>
             </a>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- ensure category pages show a calculator's description when no intro is provided

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'node_modules/yargs-parser/build/lib/index.js')*

------
https://chatgpt.com/codex/tasks/task_b_68ba9a7459d08321b95726d6f579ddbd