### PR TITLE
feat: add AI calculator page and API

### DIFF
--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,44 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="AI Calculator" description="Friendly AI-powered calculator for any question.">
+  <div class="max-w-xl mx-auto mt-8 text-center">
+    <p class="mb-4 text-lg text-slate-900">
+      Hi there! If you couldn't find the right calculator on Calcsimpler.com, our friendly AI calculator is here to help.
+      Ask anything below and I'll do my best to give you a clear answer.
+    </p>
+    <textarea
+      id="question"
+      class="w-full p-3 border rounded mb-4 text-slate-900"
+      rows="4"
+      placeholder="e.g., What's 15% of 80?"
+    ></textarea>
+    <button
+      id="ask"
+      class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800 transition-colors"
+    >Ask the AI Calculator</button>
+    <div id="answer" class="mt-4 p-3 border rounded text-left text-slate-900"></div>
+  </div>
+
+  <script>
+    const questionEl = document.getElementById('question');
+    const answerEl = document.getElementById('answer');
+    document.getElementById('ask').addEventListener('click', async () => {
+      const question = questionEl.value.trim();
+      if (!question) return;
+      answerEl.textContent = 'Thinking...';
+      try {
+        const res = await fetch('/api/ai-calculator', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question })
+        });
+        const data = await res.json();
+        answerEl.textContent = data.answer || 'Sorry, I could not compute that.';
+      } catch (err) {
+        answerEl.textContent = 'Sorry, something went wrong.';
+      }
+    });
+  </script>
+</BaseLayout>

--- a/src/pages/api/ai-calculator.ts
+++ b/src/pages/api/ai-calculator.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  const { question } = await request.json();
+  const apiKey = import.meta.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "Missing OpenAI API key." }), {
+      status: 500,
+    });
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a helpful calculator that responds with concise answers.",
+          },
+          { role: "user", content: question },
+        ],
+      }),
+    });
+    const data = await response.json();
+    const answer =
+      data.choices?.[0]?.message?.content?.trim() || "Unable to compute.";
+    return new Response(JSON.stringify({ answer }), { status: 200 });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: "Request failed." }), {
+      status: 500,
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add AI calculator page with friendly message linking to Calcsimpler.com
- provide API route calling OpenAI chat completions

## Testing
- `npx prettier --write src/pages/api/ai-calculator.ts src/pages/ai-calculator.astro` *(fails: No parser could be inferred for file "/workspace/niche-calculator-network/src/pages/ai-calculator.astro".)*
- `npx prettier --write src/pages/api/ai-calculator.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb185363648321b32b95544115996c