### PR TITLE
Add site-wide search for calculators

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,6 +64,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             >Categories</a
           >
           <a
+            href="/search"
+            class={['nav-link', Astro.url.pathname.startsWith('/search') && 'active'].filter(Boolean).join(' ')}
+            >Search</a
+          >
+          <a
             href="/traditional-calculator/"
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
@@ -80,6 +85,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
         <a href="/">Home</a>
         <a href="/categories/">Categories</a>
         <a href="/all">All Calculators</a>
+        <a href="/search">Search</a>
         <a href="/sitemap.xml">Sitemap</a>
         <a href="/privacy">Privacy</a>
         <a href="/disclaimer">Disclaimer</a>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
+const items = Object.values(modules).map((m) => ({
+  url: m.url,
+  title: m.frontmatter?.title || m.url.replace('/calculators/','').replace('.mdx',''),
+  description: m.frontmatter?.intro || m.frontmatter?.description || ''
+}));
+---
+<BaseLayout title="Search" description="Search calculators by title or description.">
+  <section class="hero container mx-auto max-w-5xl px-4">
+    <h1 style="color: var(--ink)">Search</h1>
+    <p style="color: var(--muted)">Find a calculator by title or description.</p>
+    <input
+      id="search-input"
+      type="search"
+      placeholder="Search calculators"
+      class="w-full mt-4 p-2 border rounded-md"
+    />
+  </section>
+  <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="search-results">
+    <h2 id="search-results" class="sr-only">Search results</h2>
+    <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+      {items.map((it) => (
+        <div data-title={it.title.toLowerCase()} data-description={it.description.toLowerCase()}>
+          <a class="card" href={it.url}>
+            <h3>{it.title}</h3>
+            <p>{it.description}</p>
+          </a>
+        </div>
+      ))}
+    </div>
+  </section>
+  <script is:inline>
+    const input = document.getElementById('search-input');
+    const cards = Array.from(document.querySelectorAll('#results > div'));
+    function filter() {
+      const q = input.value.trim().toLowerCase();
+      cards.forEach((card) => {
+        const t = card.dataset.title;
+        const d = card.dataset.description;
+        const match = !q || t.includes(q) || d.includes(q);
+        card.style.display = match ? '' : 'none';
+      });
+    }
+    input.addEventListener('input', filter);
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add client-side search page for all calculators
- link search from primary nav and footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb24d305d8832184cd4c76cd6615c2