### PR TITLE
feat: add client-side search

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,6 +64,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             >Categories</a
           >
           <a
+            href="/search"
+            class={['nav-link', Astro.url.pathname.startsWith('/search') && 'active'].filter(Boolean).join(' ')}
+            >Search</a
+          >
+          <a
             href="/traditional-calculator/"
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
@@ -79,6 +84,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
       <div class="links">
         <a href="/">Home</a>
         <a href="/categories/">Categories</a>
+        <a href="/search">Search</a>
         <a href="/all">All Calculators</a>
         <a href="/sitemap.xml">Sitemap</a>
         <a href="/privacy">Privacy</a>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+const data = await import('../../data/calculators.json');
+const calculators = (data.default ?? data).map((c) => ({
+  slug: c.slug,
+  title: c.title,
+  description: c.description || ''
+}));
+---
+<BaseLayout title="Search" description="Find calculators by title or description.">
+  <section class="hero container mx-auto max-w-5xl px-4">
+    <h1 style="color: var(--ink)">Search</h1>
+    <p style="color: var(--muted)">Find calculators by title or description.</p>
+    <input
+      id="search-input"
+      type="search"
+      placeholder="Search calculators..."
+      class="mt-4 w-full rounded border border-[var(--border)] p-2"
+    />
+  </section>
+  <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="results-title">
+    <h2 id="results-title" class="sr-only">Search results</h2>
+    <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4"></div>
+  </section>
+  <script is:inline>
+    const calculators = JSON.parse(decodeURIComponent('{encodeURIComponent(JSON.stringify(calculators))}'));
+    const input = document.getElementById('search-input');
+    const results = document.getElementById('results');
+    function render(list) {
+      results.innerHTML = '';
+      for (const c of list) {
+        const div = document.createElement('div');
+        div.innerHTML = `<a class="card" href="/calculators/${c.slug}/"><h3>${c.title}</h3><p>${c.description}</p></a>`;
+        results.appendChild(div.firstElementChild);
+      }
+    }
+    function filter(term) {
+      const q = term.toLowerCase();
+      return calculators.filter((c) =>
+        c.title.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
+      );
+    }
+    input.addEventListener('input', () => {
+      render(filter(input.value));
+    });
+    render(calculators);
+  </script>
+</BaseLayout>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -42,6 +42,7 @@ export async function GET({ site }: APIContext) {
   const staticPaths = [
     "/",
     "/all",
+    "/search",
     "/finance",
     "/health",
     "/math",


### PR DESCRIPTION
## Summary
- add search page to filter calculators client-side
- link search from main navigation and footer
- include search page in sitemap

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bb24d305d8832184cd4c76cd6615c2