### PR TITLE
feat: add search page and navigation link

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,6 +64,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             >Categories</a
           >
           <a
+            href="/search/"
+            class={['nav-link', Astro.url.pathname.startsWith('/search') && 'active'].filter(Boolean).join(' ')}
+            >Search</a
+          >
+          <a
             href="/traditional-calculator/"
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
@@ -80,6 +85,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
         <a href="/">Home</a>
         <a href="/categories/">Categories</a>
         <a href="/all">All Calculators</a>
+        <a href="/search/">Search</a>
         <a href="/sitemap.xml">Sitemap</a>
         <a href="/privacy">Privacy</a>
         <a href="/disclaimer">Disclaimer</a>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,60 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import AdBanner from "../components/AdBanner.astro";
+const modules = import.meta.glob("../pages/calculators/*.mdx", { eager: true });
+const items = Object.values(modules).map((m) => ({
+  url: m.url,
+  title: m.frontmatter.title || m.url.replace('/calculators/','').replace('.mdx',''),
+  description: m.frontmatter.intro || m.frontmatter.description || ''
+}));
+---
+<BaseLayout title="Search" description="Search calculators by title or description.">
+  <section class="hero container mx-auto max-w-5xl px-4">
+    <h1 style="color: var(--ink)">Search</h1>
+    <p style="color: var(--muted)">Find calculators by title or description.</p>
+    <input
+      id="search"
+      type="search"
+      placeholder="Search calculators..."
+      class="mt-4 w-full rounded-md border border-[var(--border)] p-2"
+      aria-label="Search calculators"
+    />
+  </section>
+  <AdBanner />
+  <section class="section container mx-auto max-w-5xl px-4">
+    <h2 class="sr-only">Search results</h2>
+    <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+  </section>
+  <script is:inline>
+    const items = {JSON.stringify(items).replace(/</g, '\u003c')};
+    const input = document.getElementById('search');
+    const results = document.getElementById('results');
+
+    function render(list) {
+      results.innerHTML = list
+        .map(
+          (it) => `
+        <div>
+          <a class="card" href="${it.url}">
+            <h3>${it.title}</h3>
+            <p>${it.description}</p>
+          </a>
+        </div>
+      `
+        )
+        .join('');
+    }
+
+    render(items);
+
+    input.addEventListener('input', () => {
+      const q = input.value.toLowerCase();
+      const filtered = items.filter(
+        (it) =>
+          it.title.toLowerCase().includes(q) ||
+          it.description.toLowerCase().includes(q)
+      );
+      render(filtered);
+    });
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add Search link to header and footer navigation
- introduce search page to filter calculators by title or description on the client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb24d305d8832184cd4c76cd6615c2