### PR TITLE
Add AI calculator page and widget

### DIFF
--- a/src/components/AiWidget.astro
+++ b/src/components/AiWidget.astro
@@ -1,0 +1,54 @@
+---
+---
+<section class="ai-widget mt-8">
+  <h2 class="text-xl font-semibold mb-2">Can't find what you need?</h2>
+  <p class="text-sm text-[var(--muted)] mb-4">Ask our AI for help with any calculation question.</p>
+  <form id="ai-form" class="flex flex-col sm:flex-row gap-2" onsubmit="return false">
+    <input
+      id="ai-question"
+      type="text"
+      placeholder="Ask a question"
+      class="flex-1 p-2 border rounded"
+    />
+    <button id="ai-submit" class="px-4 py-2 rounded bg-[var(--accent-red)] text-[var(--primary-ink)]">Ask AI</button>
+  </form>
+  <div id="ai-answer" class="mt-2 text-[var(--ink)]"></div>
+</section>
+
+<script is:inline>
+  const form = document.getElementById('ai-form');
+  const input = document.getElementById('ai-question');
+  const answer = document.getElementById('ai-answer');
+  const btn = document.getElementById('ai-submit');
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = input.value.trim();
+    if (!q) return;
+    answer.textContent = 'Thinking...';
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: q })
+      });
+      const data = await res.json();
+      answer.textContent = data.answer || 'No answer available.';
+    } catch (err) {
+      answer.textContent = 'Error fetching answer.';
+    } finally {
+      btn.disabled = false;
+    }
+  });
+</script>
+
+<style>
+  .ai-widget {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+  }
+  #ai-answer {
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import AiWidget from './AiWidget.astro';
 import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
@@ -100,6 +101,8 @@ const jsonLd = {
 
   <script type="application/json" data-schema set:html={JSON.stringify(schema)}></script>
 </section>
+
+<AiWidget />
 
 <section class="examples">
   <h2>Examples</h2>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai-calculator/"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import AiWidget from '../components/AiWidget.astro';
+---
+<BaseLayout title="AI Calculator" description="Ask our AI any calculation question.">
+  <section class="max-w-xl mx-auto mt-8">
+    <h1 class="text-2xl font-bold mb-4">AI Calculator</h1>
+    <p class="mb-4 text-[var(--muted)]">Can't find what you need on CalcSimpler.com? Ask our AI for a quick answer.</p>
+    <AiWidget />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { question } = await request.json();
+    if (!question) {
+      return new Response(JSON.stringify({ error: "Missing question" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const apiKey = import.meta.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: "Missing OpenAI key" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a helpful assistant that answers calculation questions concisely.",
+          },
+          { role: "user", content: question },
+        ],
+        max_tokens: 200,
+        temperature: 0.2,
+      }),
+    });
+    const data = await res.json();
+    const answer = data?.choices?.[0]?.message?.content?.trim() || "";
+    return new Response(JSON.stringify({ answer }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: "Request failed" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -30,6 +31,7 @@ const items = Object.values(modules).map((m) => ({
         </div>
       ))}
     </div>
+    <AiWidget />
   </section>
   <script is:inline>
     const input = document.getElementById('search-input');


### PR DESCRIPTION
## Summary
- add AI calculator page with simple question interface
- forward questions to OpenAI Chat Completions via new API route
- surface AI widget across calculators, search page, and top navigation

## Testing
- `npm test`
- `npx prettier src/components/AiWidget.astro src/pages/ai-calculator.astro src/layouts/BaseLayout.astro src/components/Calculator.astro src/pages/search.astro src/pages/api/ai.ts -w` *(fails: No parser could be inferred for file)*

------
https://chatgpt.com/codex/tasks/task_b_68bb2ec6a42c832198540c6f6a0d4738