### PR TITLE
feat: add AI calculator interface across site

### DIFF
--- a/src/components/AiWidget.astro
+++ b/src/components/AiWidget.astro
@@ -1,0 +1,43 @@
+---
+---
+<div class="ai-widget">
+  <form id="ai-form" class="flex flex-col gap-2">
+    <textarea id="ai-question" rows="3" placeholder="Ask anything..." class="p-2 border rounded-md"></textarea>
+    <button type="submit" class="p-2 rounded-md bg-[var(--accent-red)] text-white">Ask AI</button>
+  </form>
+  <div id="ai-answer" class="mt-2"></div>
+</div>
+<script>
+const form = document.getElementById('ai-form');
+const question = document.getElementById('ai-question');
+const answer = document.getElementById('ai-answer');
+form?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const q = question.value.trim();
+  if (!q) return;
+  answer.textContent = 'Thinking...';
+  try {
+    const res = await fetch('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question: q })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      answer.textContent = data.answer || 'No answer available.';
+    } else {
+      answer.textContent = 'Error contacting AI.';
+    }
+  } catch (err) {
+    answer.textContent = 'Error contacting AI.';
+  }
+});
+</script>
+<style>
+.ai-widget textarea {
+  width: 100%;
+}
+.ai-widget button {
+  width: fit-content;
+}
+</style>

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import AiWidget from './AiWidget.astro';
 import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
@@ -97,6 +98,12 @@ const jsonLd = {
   </form>
 
   <div class="result" data-role="result" aria-live="polite"></div>
+
+  <div class="ai-helper mt-8">
+    <h2>Need something else?</h2>
+    <p class="muted">Ask our AI-powered calculator for a quick answer.</p>
+    <AiWidget />
+  </div>
 
   <script type="application/json" data-schema set:html={JSON.stringify(schema)}></script>
 </section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai-calculator/"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import AiWidget from '../components/AiWidget.astro';
+---
+<BaseLayout title="AI Calculator" description="Can't find a calculator? Ask our AI assistant for help.">
+  <section class="container mx-auto max-w-2xl px-4">
+    <h1 style="color: var(--ink)">AI Calculator</h1>
+    <p class="muted">Didn't find what you needed on CalcSimpler.com? Ask our AI-powered assistant.</p>
+    <AiWidget />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ask.ts
+++ b/src/pages/api/ask.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from 'astro';
+
+export const POST: APIRoute = async ({ request }) => {
+  const { question } = await request.json().catch(() => ({ }));
+  if (!question) {
+    return new Response(JSON.stringify({ error: 'Missing question' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  const apiKey = import.meta.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: 'Missing API key' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant that answers calculator questions concisely.' },
+          { role: 'user', content: question }
+        ],
+        max_tokens: 150
+      })
+    });
+    const data = await res.json();
+    const answer = data.choices?.[0]?.message?.content?.trim() || '';
+    return new Response(JSON.stringify({ answer }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'AI request failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -30,6 +31,11 @@ const items = Object.values(modules).map((m) => ({
         </div>
       ))}
     </div>
+  </section>
+  <section class="section container mx-auto max-w-5xl px-4 mt-8">
+    <h2>Need something else?</h2>
+    <p class="muted">Ask our AI-powered calculator.</p>
+    <AiWidget />
   </section>
   <script is:inline>
     const input = document.getElementById('search-input');


### PR DESCRIPTION
## Summary
- add AI Calculator page and API endpoint using OpenAI
- insert AI assistant widget after calculator results and on search page
- expose AI Calculator from site navigation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bb2ec6a42c832198540c6f6a0d4738