### PR TITLE
Add AI assistant calculator and integrate across site

### DIFF
--- a/src/components/AIAssistant.astro
+++ b/src/components/AIAssistant.astro
@@ -1,0 +1,35 @@
+---
+const { heading = "Need a different calculation?", prompt = "Ask our AI-powered calculator:" } = Astro.props;
+const uid = Math.random().toString(36).slice(2);
+---
+<section class="ai-assistant mt-8">
+  <h2>{heading}</h2>
+  <p class="muted">{prompt}</p>
+  <form id={`ai-form-${uid}`} class="mt-4">
+    <textarea id={`ai-question-${uid}`} class="w-full p-2 border rounded-md" rows="3" placeholder="Type your question"></textarea>
+    <button type="submit" class="btn mt-2">Ask AI</button>
+  </form>
+  <div id={`ai-answer-${uid}`} class="mt-2"></div>
+  <script is:inline>
+    const form = document.getElementById('ai-form-${uid}');
+    const input = document.getElementById('ai-question-${uid}');
+    const out = document.getElementById('ai-answer-${uid}');
+    form?.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const q = input.value.trim();
+      if (!q) return;
+      out.textContent = 'Thinking...';
+      try {
+        const res = await fetch('/api/ai', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question: q })
+        });
+        const data = await res.json();
+        out.textContent = data.answer || 'No answer available.';
+      } catch (err) {
+        out.textContent = 'Error fetching answer.';
+      }
+    });
+  </script>
+</section>

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import AIAssistant from './AIAssistant.astro';
 import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
@@ -100,6 +101,8 @@ const jsonLd = {
 
   <script type="application/json" data-schema set:html={JSON.stringify(schema)}></script>
 </section>
+
+<AIAssistant />
 
 <section class="examples">
   <h2>Examples</h2>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai-calculator/"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import AIAssistant from "../components/AIAssistant.astro";
+---
+<BaseLayout title="AI Calculator" description="Ask the AI for help with any calculation.">
+  <section class="container mx-auto max-w-3xl px-4">
+    <h1>AI Calculator</h1>
+    <p class="muted">Didn't find the calculator you needed on CalcSimpler.com? Ask below.</p>
+    <AIAssistant heading="Ask the AI" prompt="Describe your calculation question:" />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { question } = await request.json();
+    if (!question) {
+      return new Response(JSON.stringify({ error: 'Missing question' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    const key = import.meta.env.OPENAI_API_KEY;
+    if (!key) {
+      return new Response(JSON.stringify({ error: 'API key not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: question }],
+        max_tokens: 100
+      })
+    });
+    const data = await resp.json();
+    const answer = data.choices?.[0]?.message?.content?.trim() || '';
+    return new Response(JSON.stringify({ answer }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'AI request failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AIAssistant from "../components/AIAssistant.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -31,6 +32,9 @@ const items = Object.values(modules).map((m) => ({
       ))}
     </div>
   </section>
+  <div class="container mx-auto max-w-5xl px-4 mt-8">
+    <AIAssistant />
+  </div>
   <script is:inline>
     const input = document.getElementById('search-input');
     const cards = Array.from(document.querySelectorAll('#results > div'));

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -53,6 +53,7 @@ export async function GET({ site }: APIContext) {
     "/privacy",
     "/disclaimer",
     "/categories",
+    "/ai-calculator",
   ];
 
   type UrlItem = {


### PR DESCRIPTION
## Summary
- Add AI-powered assistant component and standalone AI calculator page
- Forward questions to OpenAI through new API route
- Link AI calculator in main navigation and embed assistant in calculators and search page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb2ec6a42c832198540c6f6a0d4738