### PR TITLE
Add AI calculator page and backend OpenAI endpoint

### DIFF
--- a/src/components/AiWidget.astro
+++ b/src/components/AiWidget.astro
@@ -1,0 +1,33 @@
+---
+const { promptLabel = 'Ask a question' } = Astro.props;
+---
+<div class="ai-widget mt-6">
+  <form id="ai-form" class="flex gap-2">
+    <label for="ai-question" class="sr-only">{promptLabel}</label>
+    <input id="ai-question" type="text" required class="flex-1 p-2 border rounded" placeholder={promptLabel} />
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Ask AI</button>
+  </form>
+  <p id="ai-answer" class="mt-2 text-sm"></p>
+</div>
+<script is:inline>
+  const form = document.getElementById('ai-form');
+  const input = document.getElementById('ai-question');
+  const answer = document.getElementById('ai-answer');
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = input.value.trim();
+    if (!q) return;
+    answer.textContent = 'Thinking...';
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: q })
+      });
+      const data = await res.json();
+      answer.textContent = data.answer ?? 'No answer available.';
+    } catch (err) {
+      answer.textContent = 'Error fetching answer.';
+    }
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,16 +63,21 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
             >Categories</a
           >
-          <a
-            href="/search"
-            class={['nav-link', Astro.url.pathname.startsWith('/search') && 'active'].filter(Boolean).join(' ')}
-            >Search</a
-          >
-          <a
-            href="/traditional-calculator/"
-            class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
-            >Traditional Calculator</a
-          >
+            <a
+              href="/search"
+              class={['nav-link', Astro.url.pathname.startsWith('/search') && 'active'].filter(Boolean).join(' ')}
+              >Search</a
+            >
+            <a
+              href="/ai-calculator"
+              class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+              >AI Calculator</a
+            >
+            <a
+              href="/traditional-calculator/"
+              class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
+              >Traditional Calculator</a
+            >
         </nav>
       </div>
     </header>

--- a/src/layouts/CalculatorLayout.astro
+++ b/src/layouts/CalculatorLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import AiWidget from '../components/AiWidget.astro';
 
 /**
  * Simplified calculator layout that wraps individual calculator pages with
@@ -8,7 +9,8 @@ import BaseLayout from './BaseLayout.astro';
  */
 const { title, description, canonical } = Astro.props;
 ---
-<BaseLayout {title} {description} {canonical}>
-  <slot />
-</BaseLayout>
+  <BaseLayout {title} {description} {canonical}>
+    <slot />
+    <AiWidget />
+  </BaseLayout>
 

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
+---
+<BaseLayout title="AI Calculator" description="Ask any question and get a quick answer.">
+  <section class="container mx-auto max-w-3xl px-4">
+    <h1>AI Calculator</h1>
+    <p class="text-gray-600">Can't find a calculator? Ask our AI below.</p>
+    <AiWidget />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  const { question } = await request.json().catch(() => ({ question: "" }));
+  if (!question) {
+    return new Response(JSON.stringify({ error: "Missing question" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const apiKey = import.meta.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "Missing API key" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  try {
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: question }],
+        max_tokens: 100,
+        temperature: 0.7,
+      }),
+    });
+    const data = await res.json();
+    const answer = data?.choices?.[0]?.message?.content?.trim() ?? "";
+    return new Response(JSON.stringify({ answer }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: "Failed to fetch answer" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -18,9 +19,9 @@ const items = Object.values(modules).map((m) => ({
       class="w-full mt-4 p-2 border rounded-md"
     />
   </section>
-  <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="search-results">
-    <h2 id="search-results" class="sr-only">Search results</h2>
-    <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+    <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="search-results">
+      <h2 id="search-results" class="sr-only">Search results</h2>
+      <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
       {items.map((it) => (
         <div data-title={it.title.toLowerCase()} data-description={it.description.toLowerCase()}>
           <a class="card" href={it.url}>
@@ -29,10 +30,13 @@ const items = Object.values(modules).map((m) => ({
           </a>
         </div>
       ))}
-    </div>
-  </section>
-  <script is:inline>
-    const input = document.getElementById('search-input');
+      </div>
+    </section>
+    <section class="container mx-auto max-w-5xl px-4">
+      <AiWidget />
+    </section>
+    <script is:inline>
+      const input = document.getElementById('search-input');
     const cards = Array.from(document.querySelectorAll('#results > div'));
     function filter() {
       const q = input.value.trim().toLowerCase();

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -53,6 +53,7 @@ export async function GET({ site }: APIContext) {
     "/privacy",
     "/disclaimer",
     "/categories",
+    "/ai-calculator",
   ];
 
   type UrlItem = {


### PR DESCRIPTION
## Summary
- add `/api/ai` endpoint that relays questions to OpenAI and returns concise answers
- create reusable AI widget and dedicated AI calculator page
- link AI calculator in nav, embed widget on calculator and search pages, and include page in sitemap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bb35a89a04832192d93807e933229e