### PR TITLE
Add AI calculator with OpenAI backend

### DIFF
--- a/src/components/AiWidget.astro
+++ b/src/components/AiWidget.astro
@@ -1,0 +1,34 @@
+---
+---
+<section class="ai-widget mt-8">
+  <h2>Ask AI</h2>
+  <form class="mt-2 flex flex-col sm:flex-row gap-2">
+    <label class="sr-only">Question</label>
+    <input type="text" placeholder="Ask a question" class="flex-1 p-2 border rounded-md" required />
+    <button type="submit" class="btn">Ask</button>
+  </form>
+  <p data-role="answer" class="mt-2 text-sm"></p>
+</section>
+<script is:inline>
+  const root = document.currentScript.parentElement;
+  const form = root.querySelector('form');
+  const input = root.querySelector('input');
+  const out = root.querySelector('[data-role="answer"]');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = input.value.trim();
+    if (!q) return;
+    out.textContent = 'Thinking...';
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: q })
+      });
+      const data = await res.json();
+      out.textContent = data.answer || 'No answer available.';
+    } catch (err) {
+      out.textContent = 'Error fetching answer.';
+    }
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,6 +69,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             >Search</a
           >
           <a
+            href="/ai-calculator"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
+          <a
             href="/traditional-calculator/"
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
@@ -86,6 +91,7 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
         <a href="/categories/">Categories</a>
         <a href="/all">All Calculators</a>
         <a href="/search">Search</a>
+        <a href="/ai-calculator">AI Calculator</a>
         <a href="/sitemap.xml">Sitemap</a>
         <a href="/privacy">Privacy</a>
         <a href="/disclaimer">Disclaimer</a>

--- a/src/layouts/CalculatorLayout.astro
+++ b/src/layouts/CalculatorLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import AiWidget from '../components/AiWidget.astro';
 
 /**
  * Simplified calculator layout that wraps individual calculator pages with
@@ -10,5 +11,6 @@ const { title, description, canonical } = Astro.props;
 ---
 <BaseLayout {title} {description} {canonical}>
   <slot />
+  <AiWidget />
 </BaseLayout>
 

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
+---
+<BaseLayout title="AI Calculator" description="Ask questions and get quick answers from AI.">
+  <section class="hero container mx-auto max-w-3xl px-4">
+    <h1>AI Calculator</h1>
+    <p class="muted">Ask a question and get a concise answer.</p>
+    <AiWidget />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { question } = await request.json();
+    const prompt = String(question ?? '').slice(0, 500);
+    const apiKey = import.meta.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: 'Missing OpenAI key' }), { status: 500 });
+    }
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 100,
+        temperature: 0.7
+      })
+    });
+    const data = await resp.json();
+    const answer = data.choices?.[0]?.message?.content?.trim() || 'No answer';
+    return new Response(JSON.stringify({ answer }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'Failed to fetch' }), { status: 500 });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -18,7 +19,7 @@ const items = Object.values(modules).map((m) => ({
       class="w-full mt-4 p-2 border rounded-md"
     />
   </section>
-  <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="search-results">
+    <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="search-results">
     <h2 id="search-results" class="sr-only">Search results</h2>
     <div id="results" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
       {items.map((it) => (
@@ -30,8 +31,9 @@ const items = Object.values(modules).map((m) => ({
         </div>
       ))}
     </div>
-  </section>
-  <script is:inline>
+    </section>
+    <AiWidget />
+    <script is:inline>
     const input = document.getElementById('search-input');
     const cards = Array.from(document.querySelectorAll('#results > div'));
     function filter() {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -53,6 +53,7 @@ export async function GET({ site }: APIContext) {
     "/privacy",
     "/disclaimer",
     "/categories",
+    "/ai-calculator",
   ];
 
   type UrlItem = {


### PR DESCRIPTION
## Summary
- add `/api/ai` route forwarding questions to OpenAI Chat Completions
- create reusable AI widget and dedicated AI Calculator page
- surface AI widget beneath calculators, in search results, nav and sitemap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb35a89a04832192d93807e933229e