### PR TITLE
Add AI-powered calculator interface

### DIFF
--- a/src/components/AiWidget.astro
+++ b/src/components/AiWidget.astro
@@ -1,0 +1,54 @@
+---
+const { heading = 'Need another answer?' } = Astro.props;
+---
+<div class="ai-widget">
+  <h2>{heading}</h2>
+  <form id="ai-form" class="ai-form">
+    <input
+      id="ai-question"
+      type="text"
+      placeholder="Ask a question"
+      required
+    />
+    <button type="submit" class="btn">Ask AI</button>
+  </form>
+  <p id="ai-answer" class="ai-answer"></p>
+</div>
+
+<script>
+  const form = document.getElementById('ai-form');
+  const input = document.getElementById('ai-question');
+  const answerEl = document.getElementById('ai-answer');
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const question = input.value.trim();
+    if (!question) return;
+    answerEl.textContent = 'Thinking...';
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      });
+      const data = await res.json();
+      answerEl.textContent = data.answer || 'No answer available.';
+    } catch {
+      answerEl.textContent = 'Error retrieving answer.';
+    }
+  });
+</script>
+
+<style>
+  .ai-widget { margin-top: 2rem; }
+  .ai-form { display: flex; gap: 0.5rem; }
+  .ai-form input {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .ai-answer {
+    margin-top: 0.5rem;
+    color: var(--ink);
+  }
+</style>

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import AiWidget from './AiWidget.astro';
 import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
@@ -128,6 +129,8 @@ const jsonLd = {
     ))}
   </ul>
 </section>
+
+<AiWidget />
 
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
+---
+<BaseLayout title="AI Calculator" description="Ask questions and get concise answers.">
+  <section class="container mx-auto max-w-3xl px-4">
+    <h1 style="color: var(--ink)">AI Calculator</h1>
+    <p style="color: var(--muted)">Ask any question below to get a quick answer.</p>
+    <AiWidget heading="Ask the AI" />
+  </section>
+</BaseLayout>

--- a/src/pages/api/ai.ts
+++ b/src/pages/api/ai.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { question } = await request.json();
+    if (!question || typeof question !== "string") {
+      return new Response(JSON.stringify({ error: "Missing question" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const apiKey = import.meta.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: "Missing API key" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: question }],
+        max_tokens: 100,
+      }),
+    });
+    const data = await res.json();
+    const answer =
+      data?.choices?.[0]?.message?.content?.trim() ||
+      "Sorry, I couldn't find an answer.";
+    return new Response(JSON.stringify({ answer }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: "Failed to fetch answer" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiWidget from "../components/AiWidget.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -31,6 +32,7 @@ const items = Object.values(modules).map((m) => ({
       ))}
     </div>
   </section>
+  <AiWidget />
   <script is:inline>
     const input = document.getElementById('search-input');
     const cards = Array.from(document.querySelectorAll('#results > div'));

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -53,6 +53,7 @@ export async function GET({ site }: APIContext) {
     "/privacy",
     "/disclaimer",
     "/categories",
+    "/ai",
   ];
 
   type UrlItem = {


### PR DESCRIPTION
## Summary
- add `/api/ai` backend route to relay questions to OpenAI Chat Completions
- create reusable `<AiWidget>` component and dedicated AI Calculator page
- embed AI widget across calculators, search results, nav, and sitemap

## Testing
- `npm test`
- `npx prettier -w src/pages/api/ai.ts`

------
https://chatgpt.com/codex/tasks/task_b_68bb35a89a04832192d93807e933229e