### PR TITLE
Improve icons for category cards

### DIFF
--- a/public/icons/coding.svg
+++ b/public/icons/coding.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/><line x1="12" y1="2" x2="12" y2="22"/></svg>

--- a/public/icons/education.svg
+++ b/public/icons/education.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5V5a2 2 0 0 1 2-2h6"/><path d="M12 3h6a2 2 0 0 1 2 2v14.5"/><path d="M12 3v16.5"/></svg>

--- a/public/icons/home.svg
+++ b/public/icons/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10L12 3l9 7"/><path d="M5 22V12h14v10"/></svg>

--- a/public/icons/marketing.svg
+++ b/public/icons/marketing.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 11v4a2 2 0 0 0 2 2h3v-8H5a2 2 0 0 0-2 2z"/><path d="M13 15h3l5 2V7l-5 2h-3v6z"/></svg>

--- a/public/icons/science.svg
+++ b/public/icons/science.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 2h12"/><path d="M9 2v6l-4 8v6h14v-6l-4-8V2"/><line x1="6" y1="12" x2="18" y2="12"/></svg>

--- a/public/icons/travel.svg
+++ b/public/icons/travel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3l20 9-20 9 5-9-5-9z"/><path d="M7 12l3 5 4-8"/></svg>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -9,18 +9,18 @@ import AdBanner from '../../components/AdBanner.astro';
  * category lacks bespoke artwork.
  */
 const CATEGORIES = [
-  { slug: 'finance-business',        title: 'Finance & Business',        desc: 'Corporate finance, ROI, taxes',       icon: 'finance' },
-  { slug: 'personal-finance-loans',  title: 'Personal Finance & Loans',  desc: 'Budgeting and loan payments',          icon: 'business' },
+  { slug: 'finance-business',        title: 'Finance & Business',        desc: 'Corporate finance, ROI, taxes',       icon: 'business' },
+  { slug: 'personal-finance-loans',  title: 'Personal Finance & Loans',  desc: 'Budgeting and loan payments',          icon: 'finance' },
   { slug: 'health-fitness',          title: 'Health & Fitness',          desc: 'BMI and body metrics',                 icon: 'health' },
-  { slug: 'math-statistics',         title: 'Math & Statistics',         desc: 'Geometry, algebra and statistics',     icon: 'geometry' },
+  { slug: 'math-statistics',         title: 'Math & Statistics',         desc: 'Geometry, algebra and statistics',     icon: 'statistics' },
   { slug: 'conversions-units',       title: 'Conversions & Units',       desc: 'Unit and currency conversions',        icon: 'conversions' },
   { slug: 'date-time',               title: 'Date & Time',               desc: 'Schedules and durations',              icon: 'time-date' },
-  { slug: 'education-learning',      title: 'Education & Learning',      desc: 'Study tools and references',           icon: 'algebra' },
-  { slug: 'science-engineering',     title: 'Science & Engineering',     desc: 'Physics and engineering tools',        icon: 'statistics' },
-  { slug: 'technology-coding',       title: 'Technology & Coding',       desc: 'Computing and tech topics',            icon: 'algebra' },
-  { slug: 'home-diy',                title: 'Home & DIY',                desc: 'Household projects and DIY',           icon: 'business' },
-  { slug: 'lifestyle-travel',        title: 'Lifestyle & Travel',        desc: 'Everyday life and travel',             icon: 'statistics' },
-  { slug: 'web-marketing',           title: 'Web & Marketing',           desc: 'Online tools and marketing',           icon: 'finance' }
+  { slug: 'education-learning',      title: 'Education & Learning',      desc: 'Study tools and references',           icon: 'education' },
+  { slug: 'science-engineering',     title: 'Science & Engineering',     desc: 'Physics and engineering tools',        icon: 'science' },
+  { slug: 'technology-coding',       title: 'Technology & Coding',       desc: 'Computing and tech topics',            icon: 'coding' },
+  { slug: 'home-diy',                title: 'Home & DIY',                desc: 'Household projects and DIY',           icon: 'home' },
+  { slug: 'lifestyle-travel',        title: 'Lifestyle & Travel',        desc: 'Everyday life and travel',             icon: 'travel' },
+  { slug: 'web-marketing',           title: 'Web & Marketing',           desc: 'Online tools and marketing',           icon: 'marketing' }
 ];
 ---
 <BaseLayout title="Categories" description="Browse all calculator categories.">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,18 +9,18 @@ import AdBanner from '../components/AdBanner.astro';
  * where dedicated artwork is not available.
  */
 const CATEGORIES = [
-  { slug: 'finance-business',        title: 'Finance & Business',        desc: 'Corporate finance, ROI, taxes',       icon: 'finance' },
-  { slug: 'personal-finance-loans',  title: 'Personal Finance & Loans',  desc: 'Budgeting and loan payments',          icon: 'business' },
+  { slug: 'finance-business',        title: 'Finance & Business',        desc: 'Corporate finance, ROI, taxes',       icon: 'business' },
+  { slug: 'personal-finance-loans',  title: 'Personal Finance & Loans',  desc: 'Budgeting and loan payments',          icon: 'finance' },
   { slug: 'health-fitness',          title: 'Health & Fitness',          desc: 'BMI and body metrics',                 icon: 'health' },
-  { slug: 'math-statistics',         title: 'Math & Statistics',         desc: 'Geometry, algebra and statistics',     icon: 'geometry' },
+  { slug: 'math-statistics',         title: 'Math & Statistics',         desc: 'Geometry, algebra and statistics',     icon: 'statistics' },
   { slug: 'conversions-units',       title: 'Conversions & Units',       desc: 'Unit and currency conversions',        icon: 'conversions' },
   { slug: 'date-time',               title: 'Date & Time',               desc: 'Schedules and durations',              icon: 'time-date' },
-  { slug: 'education-learning',      title: 'Education & Learning',      desc: 'Study tools and references',           icon: 'algebra' },
-  { slug: 'science-engineering',     title: 'Science & Engineering',     desc: 'Physics and engineering tools',        icon: 'statistics' },
-  { slug: 'technology-coding',       title: 'Technology & Coding',       desc: 'Computing and tech topics',            icon: 'algebra' },
-  { slug: 'home-diy',                title: 'Home & DIY',                desc: 'Household projects and DIY',           icon: 'business' },
-  { slug: 'lifestyle-travel',        title: 'Lifestyle & Travel',        desc: 'Everyday life and travel',             icon: 'statistics' },
-  { slug: 'web-marketing',           title: 'Web & Marketing',           desc: 'Online tools and marketing',           icon: 'finance' }
+  { slug: 'education-learning',      title: 'Education & Learning',      desc: 'Study tools and references',           icon: 'education' },
+  { slug: 'science-engineering',     title: 'Science & Engineering',     desc: 'Physics and engineering tools',        icon: 'science' },
+  { slug: 'technology-coding',       title: 'Technology & Coding',       desc: 'Computing and tech topics',            icon: 'coding' },
+  { slug: 'home-diy',                title: 'Home & DIY',                desc: 'Household projects and DIY',           icon: 'home' },
+  { slug: 'lifestyle-travel',        title: 'Lifestyle & Travel',        desc: 'Everyday life and travel',             icon: 'travel' },
+  { slug: 'web-marketing',           title: 'Web & Marketing',           desc: 'Online tools and marketing',           icon: 'marketing' }
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">


### PR DESCRIPTION
## Summary
- add dedicated SVG icons for coding, education, home, marketing, science, and travel categories
- map all twelve category cards to distinct icons on home and categories pages

## Testing
- `npm test`
- `npx prettier --write src/pages/index.astro src/pages/categories/index.astro public/icons/coding.svg public/icons/education.svg public/icons/home.svg public/icons/marketing.svg public/icons/science.svg public/icons/travel.svg` *(fails: No parser could be inferred)*

------
https://chatgpt.com/codex/tasks/task_b_68bc82fb97808321b34468dbb94c7ccc