### PR TITLE
Add AI calculator page with API endpoint

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai-calculator/"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout title="Calculadora IA" description="Utiliza la potencia de la IA para resolver cualquier cálculo al instante.">
+  <section class="max-w-2xl mx-auto py-8">
+    <h1 class="text-3xl font-bold mb-4" style="color: var(--ink)">Calculadora IA</h1>
+    <p class="mb-6" style="color: var(--muted)">¡Bienvenido! Ingresa cualquier operación matemática y la inteligencia artificial te dará la respuesta.</p>
+    <form id="ai-form" class="flex flex-col gap-4">
+      <label for="query" class="sr-only">Operación</label>
+      <input id="query" name="query" type="text" class="p-2 border rounded-md" placeholder="Ej. (5*3)^2" required />
+      <button type="submit" class="p-2 rounded bg-blue-600 text-white hover:bg-blue-700">Calcular</button>
+    </form>
+    <div id="result" class="mt-4 text-lg font-semibold" style="color: var(--ink)"></div>
+  </section>
+  <script>
+    const form = document.getElementById('ai-form');
+    const input = document.getElementById('query');
+    const resultEl = document.getElementById('result');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      resultEl.textContent = 'Calculando...';
+      try {
+        const resp = await fetch('/api/ai-calculator', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: input.value }),
+        });
+        const data = await resp.json();
+        resultEl.textContent = data.result || data.error || 'Error';
+      } catch (err) {
+        resultEl.textContent = 'Error';
+      }
+    });
+  </script>
+</BaseLayout>

--- a/src/pages/api/ai-calculator.ts
+++ b/src/pages/api/ai-calculator.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { query } = await request.json();
+    const apiKey = process.env.OPENAI_API_KEY;
+    let result = "";
+    if (apiKey) {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-3.5-turbo",
+          messages: [
+            {
+              role: "system",
+              content:
+                "Eres una calculadora. Resuelve la operación y devuelve solo el resultado.",
+            },
+            { role: "user", content: query },
+          ],
+        }),
+      });
+      const data = await res.json();
+      result = data.choices?.[0]?.message?.content?.trim() ?? "";
+    } else {
+      try {
+        // eslint-disable-next-line no-new-func
+        result = String(Function(`"use strict";return (${query})`)());
+      } catch {
+        result = "Error";
+      }
+    }
+    return new Response(JSON.stringify({ result }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: err.message ?? "Error" }), {
+      status: 500,
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add AI calculator page with friendly form
- create serverless API route that uses OpenAI or local eval
- link new AI calculator from site navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd17df95288321a6793398f666d497