### PR TITLE
Add AI assistant section and integrate across pages

### DIFF
--- a/src/components/AiAssistant.astro
+++ b/src/components/AiAssistant.astro
@@ -1,0 +1,36 @@
+---
+// Reusable AI calculator section
+---
+<section class="ai-calc my-8 p-4 border rounded" data-ai-calc aria-labelledby="ai-calc-heading">
+  <h2 id="ai-calc-heading" class="text-xl font-bold mb-2" style="color: var(--ink)">¿No encontraste lo que necesitabas en Calcsimpler.com?</h2>
+  <p class="mb-4" style="color: var(--muted)">Pregunta a nuestra calculadora con IA:</p>
+  <form class="flex flex-col gap-4">
+    <label for="ai-query" class="sr-only">Pregunta</label>
+    <input id="ai-query" name="query" type="text" class="p-2 border rounded-md" placeholder="Escribe tu pregunta..." required />
+    <button type="submit" class="p-2 rounded bg-blue-600 text-white hover:bg-blue-700">Enviar</button>
+  </form>
+  <div class="ai-result mt-4 text-lg font-semibold" style="color: var(--ink)"></div>
+</section>
+<script>
+(() => {
+  const root = document.currentScript.parentElement;
+  const form = root.querySelector('form');
+  const input = root.querySelector('input[name="query"]');
+  const resultEl = root.querySelector('.ai-result');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    resultEl.textContent = 'Pensando...';
+    try {
+      const resp = await fetch('/api/ai-calculator', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: input.value })
+      });
+      const data = await resp.json();
+      resultEl.textContent = data.result || data.error || 'Error';
+    } catch (err) {
+      resultEl.textContent = 'Error';
+    }
+  });
+})();
+</script>

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -4,6 +4,7 @@
   - Sin JSON.parse necesario (aunque se mantiene opcional).
 */
 import AdBanner from './AdBanner.astro';
+import AiAssistant from './AiAssistant.astro';
 import allCalcs from '../../data/calculators.json';
 const { schema } = Astro.props;
 const title = schema?.title ?? 'Calculator';
@@ -97,6 +98,8 @@ const jsonLd = {
   </form>
 
   <div class="result" data-role="result" aria-live="polite"></div>
+
+  <AiAssistant />
 
   <script type="application/json" data-schema set:html={JSON.stringify(schema)}></script>
 </section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,11 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/traditional-calculator') && 'active'].filter(Boolean).join(' ')}
             >Traditional Calculator</a
           >
+          <a
+            href="/ai-calculator/"
+            class={['nav-link', Astro.url.pathname.startsWith('/ai-calculator') && 'active'].filter(Boolean).join(' ')}
+            >AI Calculator</a
+          >
         </nav>
       </div>
     </header>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout title="Calculadora IA" description="Utiliza la potencia de la IA para resolver cualquier cálculo al instante.">
+  <section class="max-w-2xl mx-auto py-8">
+    <h1 class="text-3xl font-bold mb-4" style="color: var(--ink)">Calculadora IA</h1>
+    <p class="mb-6" style="color: var(--muted)">¡Bienvenido! Ingresa cualquier operación matemática y la inteligencia artificial te dará la respuesta.</p>
+    <form id="ai-form" class="flex flex-col gap-4">
+      <label for="query" class="sr-only">Operación</label>
+      <input id="query" name="query" type="text" class="p-2 border rounded-md" placeholder="Ej. (5*3)^2" required />
+      <button type="submit" class="p-2 rounded bg-blue-600 text-white hover:bg-blue-700">Calcular</button>
+    </form>
+    <div id="result" class="mt-4 text-lg font-semibold" style="color: var(--ink)"></div>
+  </section>
+  <script>
+    const form = document.getElementById('ai-form');
+    const input = document.getElementById('query');
+    const resultEl = document.getElementById('result');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      resultEl.textContent = 'Calculando...';
+      try {
+        const resp = await fetch('/api/ai-calculator', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: input.value }),
+        });
+        const data = await resp.json();
+        resultEl.textContent = data.result || data.error || 'Error';
+      } catch (err) {
+        resultEl.textContent = 'Error';
+      }
+    });
+  </script>
+</BaseLayout>

--- a/src/pages/ai-calculator.astro
+++ b/src/pages/ai-calculator.astro
@@ -1,35 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import AiAssistant from '../components/AiAssistant.astro';
 ---
-<BaseLayout title="Calculadora IA" description="Utiliza la potencia de la IA para resolver cualquier cálculo al instante.">
+<BaseLayout title="Calculadora IA" description="¿No encontraste lo que necesitabas en Calcsimpler.com? Pregunta a nuestra IA.">
   <section class="max-w-2xl mx-auto py-8">
     <h1 class="text-3xl font-bold mb-4" style="color: var(--ink)">Calculadora IA</h1>
-    <p class="mb-6" style="color: var(--muted)">¡Bienvenido! Ingresa cualquier operación matemática y la inteligencia artificial te dará la respuesta.</p>
-    <form id="ai-form" class="flex flex-col gap-4">
-      <label for="query" class="sr-only">Operación</label>
-      <input id="query" name="query" type="text" class="p-2 border rounded-md" placeholder="Ej. (5*3)^2" required />
-      <button type="submit" class="p-2 rounded bg-blue-600 text-white hover:bg-blue-700">Calcular</button>
-    </form>
-    <div id="result" class="mt-4 text-lg font-semibold" style="color: var(--ink)"></div>
+    <p class="mb-6" style="color: var(--muted)">¿No encontraste lo que necesitabas en Calcsimpler.com? Envía tu pregunta y nuestra IA te ayudará con una respuesta concisa.</p>
+    <AiAssistant />
   </section>
-  <script>
-    const form = document.getElementById('ai-form');
-    const input = document.getElementById('query');
-    const resultEl = document.getElementById('result');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      resultEl.textContent = 'Calculando...';
-      try {
-        const resp = await fetch('/api/ai-calculator', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ query: input.value }),
-        });
-        const data = await resp.json();
-        resultEl.textContent = data.result || data.error || 'Error';
-      } catch (err) {
-        resultEl.textContent = 'Error';
-      }
-    });
-  </script>
 </BaseLayout>

--- a/src/pages/api/ai-calculator.ts
+++ b/src/pages/api/ai-calculator.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { query } = await request.json();
+    const apiKey = process.env.OPENAI_API_KEY;
+    let result = "";
+    if (apiKey) {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-3.5-turbo",
+          messages: [
+            {
+              role: "system",
+              content:
+                "Eres una calculadora. Resuelve la operación y devuelve solo el resultado.",
+            },
+            { role: "user", content: query },
+          ],
+        }),
+      });
+      const data = await res.json();
+      result = data.choices?.[0]?.message?.content?.trim() ?? "";
+    } else {
+      try {
+        // eslint-disable-next-line no-new-func
+        result = String(Function(`"use strict";return (${query})`)());
+      } catch {
+        result = "Error";
+      }
+    }
+    return new Response(JSON.stringify({ result }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: err.message ?? "Error" }), {
+      status: 500,
+    });
+  }
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AiAssistant from "../components/AiAssistant.astro";
 const modules = import.meta.glob("./calculators/*.mdx", { eager: true });
 const items = Object.values(modules).map((m) => ({
   url: m.url,
@@ -31,6 +32,7 @@ const items = Object.values(modules).map((m) => ({
       ))}
     </div>
   </section>
+  <AiAssistant />
   <script is:inline>
     const input = document.getElementById('search-input');
     const cards = Array.from(document.querySelectorAll('#results > div'));


### PR DESCRIPTION
## Summary
- add reusable AI Assistant section with friendly invitation and OpenAI-backed form
- show AI Assistant below results on every calculator and on the search page
- simplify AI calculator page to use the new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bd95647b288321a9d8d7b2142b3565