### PR TITLE
feat: add modern logo

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="CalcSimpler logo">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0057b8"/>
+      <stop offset="100%" stop-color="#00a0ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#grad)"/>
+  <rect x="12" y="12" width="40" height="12" rx="2" fill="#ffffff" opacity="0.95"/>
+  <text x="32" y="21" font-family="sans-serif" font-size="10" font-weight="700" text-anchor="middle" fill="#0057b8">CS</text>
+  <g fill="#ffffff" opacity="0.95">
+    <rect x="12" y="30" width="12" height="12" rx="2"/>
+    <rect x="26" y="30" width="12" height="12" rx="2"/>
+    <rect x="40" y="30" width="12" height="12" rx="2"/>
+    <rect x="12" y="44" width="12" height="12" rx="2"/>
+    <rect x="26" y="44" width="12" height="12" rx="2"/>
+    <rect x="40" y="44" width="12" height="12" rx="2"/>
+  </g>
+</svg>

--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -82,10 +82,17 @@ body {
 }
 .logo {
   color: #000;
-  transition: font-size 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: transform 0.2s ease;
+}
+.logo img {
+  height: 32px;
+  width: 32px;
 }
 .logo:hover {
-  font-size: 150%;
+  transform: scale(1.05);
   color: #000;
 }
 .nav-link {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,10 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">
+          <img src="/logo.svg" alt="" />
+          <span>CalcSimpler</span>
+        </a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- add gradient SVG logo for CalcSimpler
- show logo in site header with text
- enhance logo styling with flex layout and hover scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bdae39b2948321b6755c293191ccea