### PR TITLE
feat: redesign CalcSimpler logo

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <defs><linearGradient id="g" x1="0" x2="1"><stop offset="0" stop-color="#1d4ed8"/><stop offset="1" stop-color="#60a5fa"/></linearGradient></defs>
-  <rect width="64" height="64" rx="12" fill="url(#g)"/>
-  <path d="M18 44V20h16a10 10 0 110 20H18zm16-6a6 6 0 100-12H26v12h8z" fill="#fff"/>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#grad)"/>
+  <rect x="16" y="16" width="32" height="32" rx="6" fill="#ffffff" opacity="0.95"/>
+  <path d="M24 26h16M24 34h16M20 30h24" stroke="#6366f1" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" fill="none">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="60" rx="12" fill="url(#grad)"/>
+  <rect x="20" y="15" width="30" height="30" rx="6" fill="#ffffff" opacity="0.95"/>
+  <path d="M30 25h10M30 35h10M25 30h20" stroke="#6366f1" stroke-width="2" stroke-linecap="round"/>
+  <text x="70" y="38" font-size="24" font-family="'Inter', sans-serif" font-weight="600" fill="#ffffff">CalcSimpler</text>
+</svg>

--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -81,12 +81,11 @@ body {
   text-decoration: none;
 }
 .logo {
-  color: #000;
-  transition: font-size 0.2s ease;
+  display: inline-block;
+  transition: transform 0.2s ease;
 }
 .logo:hover {
-  font-size: 150%;
-  color: #000;
+  transform: scale(1.1);
 }
 .nav-link {
   display: inline-block;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <a href="#main" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">Skip to content</a>
     <header class="header" role="banner">
       <div class="container flex items-center justify-between py-4">
-        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5 text-xl font-bold text-[var(--ink)]">CalcSimpler.com</a>
+        <a href="/" aria-label="CalcSimpler" class="logo mr-2.5">
+          <img src="/logo.svg" alt="CalcSimpler logo" class="h-10 w-auto" />
+        </a>
         <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- add vibrant logo and matching favicon
- replace text header with image logo
- refine hover animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bdae39b2948321b6755c293191ccea