### PR TITLE
Add twelve new calculators across categories

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -14328,4 +14328,209 @@
     ],
     "disclaimer": "For fun estimates only; not for official records."
   }
+,
+  {
+    "slug": "working-capital-ratio",
+    "title": "Working Capital Ratio Calculator",
+    "cluster": "finance",
+    "description": "Measure liquidity by dividing current assets by current liabilities.",
+    "inputs": [
+      { "name": "assets", "label": "Current Assets", "type": "number", "min": 0, "step": "any", "placeholder": "50000" },
+      { "name": "liabilities", "label": "Current Liabilities", "type": "number", "min": 0, "step": "any", "placeholder": "25000" }
+    ],
+    "expression": "assets / liabilities",
+    "examples": [
+      { "description": "50,000 assets and 25,000 liabilities ⇒ 2" }
+    ],
+    "faqs": [
+      { "question": "What does the ratio indicate?", "answer": "It shows short-term financial health." }
+    ]
+  },
+  {
+    "slug": "pmi-monthly-payment",
+    "title": "PMI Monthly Payment Calculator",
+    "cluster": "personal finance & loans",
+    "description": "Estimate monthly private mortgage insurance cost from loan amount and PMI rate.",
+    "inputs": [
+      { "name": "loan", "label": "Loan Amount", "type": "number", "min": 0, "step": "any", "placeholder": "200000" },
+      { "name": "rate", "label": "PMI Rate (%) per year", "type": "number", "min": 0, "step": "any", "placeholder": "0.5" }
+    ],
+    "expression": "(loan * rate/100) / 12",
+    "examples": [
+      { "description": "200,000 loan at 0.5% ⇒ 83.33" }
+    ],
+    "faqs": [
+      { "question": "When does PMI end?", "answer": "Usually when loan-to-value drops below 80%." }
+    ]
+  },
+  {
+    "slug": "pregnancy-due-date",
+    "title": "Pregnancy Due Date Calculator",
+    "cluster": "health",
+    "description": "Estimate expected due date 280 days from the last menstrual period.",
+    "inputs": [
+      { "name": "year", "label": "LMP Year", "type": "number", "min": 0, "step": "1", "placeholder": "2025" },
+      { "name": "month", "label": "LMP Month", "type": "number", "min": 1, "step": "1", "placeholder": "1" },
+      { "name": "day", "label": "LMP Day", "type": "number", "min": 1, "step": "1", "placeholder": "1" }
+    ],
+    "expression": "(new Date(year, month-1, day + 280)).toISOString().slice(0,10)",
+    "examples": [
+      { "description": "LMP 2025-01-01 ⇒ 2025-10-08" }
+    ],
+    "faqs": [
+      { "question": "How accurate is this?", "answer": "Actual delivery can vary by several weeks." }
+    ]
+  },
+  {
+    "slug": "mean-absolute-deviation",
+    "title": "Mean Absolute Deviation Calculator",
+    "cluster": "math",
+    "description": "Average distance of numbers from their mean.",
+    "inputs": [
+      { "name": "a", "label": "Number 1", "type": "number", "step": "any", "placeholder": "2" },
+      { "name": "b", "label": "Number 2", "type": "number", "step": "any", "placeholder": "4" },
+      { "name": "c", "label": "Number 3", "type": "number", "step": "any", "placeholder": "7" }
+    ],
+    "expression": "((Math.abs(a-((a+b+c)/3)) + Math.abs(b-((a+b+c)/3)) + Math.abs(c-((a+b+c)/3)))/3)",
+    "examples": [
+      { "description": "2, 4, 7 ⇒ 1.78" }
+    ],
+    "faqs": [
+      { "question": "What does MAD show?", "answer": "It indicates variability around the mean." }
+    ]
+  },
+  {
+    "slug": "mph-to-kph",
+    "title": "MPH to KPH Converter",
+    "cluster": "conversions",
+    "description": "Convert miles per hour to kilometers per hour.",
+    "inputs": [
+      { "name": "mph", "label": "Miles per hour", "type": "number", "min": 0, "step": "any", "placeholder": "60" }
+    ],
+    "expression": "mph * 1.60934",
+    "examples": [
+      { "description": "60 mph ⇒ 96.56 km/h" }
+    ],
+    "faqs": [
+      { "question": "Can it convert backward?", "answer": "Divide km/h by 1.60934 to get mph." }
+    ]
+  },
+  {
+    "slug": "unix-timestamp",
+    "title": "Unix Timestamp Calculator",
+    "cluster": "date & time",
+    "description": "Convert a calendar date to seconds since the Unix epoch.",
+    "inputs": [
+      { "name": "year", "label": "Year", "type": "number", "min": 0, "step": "1", "placeholder": "2025" },
+      { "name": "month", "label": "Month", "type": "number", "min": 1, "step": "1", "placeholder": "1" },
+      { "name": "day", "label": "Day", "type": "number", "min": 1, "step": "1", "placeholder": "1" }
+    ],
+    "expression": "Date.UTC(year, month-1, day)/1000",
+    "examples": [
+      { "description": "1970-01-01 ⇒ 0" }
+    ],
+    "faqs": [
+      { "question": "Does it account for time of day?", "answer": "No, it assumes midnight UTC." }
+    ]
+  },
+  {
+    "slug": "class-attendance-percentage",
+    "title": "Class Attendance Percentage Calculator",
+    "cluster": "education & learning",
+    "description": "Find the percentage of classes attended.",
+    "inputs": [
+      { "name": "attended", "label": "Classes Attended", "type": "number", "min": 0, "step": "1", "placeholder": "18" },
+      { "name": "total", "label": "Total Classes", "type": "number", "min": 1, "step": "1", "placeholder": "20" }
+    ],
+    "expression": "(attended / total) * 100",
+    "examples": [
+      { "description": "18 attended of 20 ⇒ 90%" }
+    ],
+    "faqs": [
+      { "question": "Can total be zero?", "answer": "Total classes must be greater than zero." }
+    ]
+  },
+  {
+    "slug": "spring-force",
+    "title": "Spring Force Calculator",
+    "cluster": "science & engineering",
+    "description": "Compute force using Hooke's Law (F = k × x).",
+    "inputs": [
+      { "name": "k", "label": "Spring Constant (N/m)", "type": "number", "min": 0, "step": "any", "placeholder": "200" },
+      { "name": "x", "label": "Displacement (m)", "type": "number", "step": "any", "placeholder": "0.1" }
+    ],
+    "expression": "k * x",
+    "examples": [
+      { "description": "k=200 N/m, x=0.1 m ⇒ 20 N" }
+    ],
+    "faqs": [
+      { "question": "Does direction matter?", "answer": "This returns magnitude; direction depends on compression or extension." }
+    ]
+  },
+  {
+    "slug": "hex-to-decimal",
+    "title": "Hex to Decimal Converter",
+    "cluster": "technology",
+    "description": "Convert a hexadecimal value to decimal.",
+    "inputs": [
+      { "name": "hex", "label": "Hex number", "type": "text", "placeholder": "FF" }
+    ],
+    "expression": "parseInt(hex, 16)",
+    "examples": [
+      { "description": "FF ⇒ 255" }
+    ],
+    "faqs": [
+      { "question": "Can I include 0x?", "answer": "No, enter the hex digits only." }
+    ]
+  },
+  {
+    "slug": "ceiling-fan-size",
+    "title": "Ceiling Fan Size Calculator",
+    "cluster": "home & diy",
+    "description": "Recommend fan blade span based on room area.",
+    "inputs": [
+      { "name": "area", "label": "Room Area (sq ft)", "type": "number", "min": 0, "step": "any", "placeholder": "150" }
+    ],
+    "expression": "area <= 75 ? 36 : area <= 144 ? 42 : area <= 225 ? 50 : area <= 400 ? 54 : 56",
+    "examples": [
+      { "description": "150 sq ft ⇒ 50 in" }
+    ],
+    "faqs": [
+      { "question": "What if my room is long and narrow?", "answer": "Consider multiple fans for large or odd-shaped rooms." }
+    ]
+  },
+  {
+    "slug": "map-scale-distance",
+    "title": "Map Scale Distance Calculator",
+    "cluster": "lifestyle & travel",
+    "description": "Find real-world distance from map measurement and scale.",
+    "inputs": [
+      { "name": "map", "label": "Map Distance (cm)", "type": "number", "min": 0, "step": "any", "placeholder": "5" },
+      { "name": "scale", "label": "Scale Denominator", "type": "number", "min": 1, "step": "any", "placeholder": "50000" }
+    ],
+    "expression": "(map * scale) / 100000",
+    "examples": [
+      { "description": "5 cm at 1:50,000 ⇒ 2.5 km" }
+    ],
+    "faqs": [
+      { "question": "Why divide by 100000?", "answer": "There are 100,000 centimeters in a kilometer." }
+    ]
+  },
+  {
+    "slug": "bounce-rate",
+    "title": "Bounce Rate Calculator",
+    "cluster": "web & marketing",
+    "description": "Determine the percentage of single-page visits on your site.",
+    "inputs": [
+      { "name": "bounces", "label": "Bounces", "type": "number", "min": 0, "step": "1", "placeholder": "25" },
+      { "name": "visits", "label": "Total Visits", "type": "number", "min": 1, "step": "1", "placeholder": "100" }
+    ],
+    "expression": "(bounces / visits) * 100",
+    "examples": [
+      { "description": "25 bounces out of 100 visits ⇒ 25%" }
+    ],
+    "faqs": [
+      { "question": "What is a bounce?", "answer": "A single-page session with no interaction." }
+    ]
+  }
 ]

--- a/src/pages/calculators/bounce-rate.mdx
+++ b/src/pages/calculators/bounce-rate.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Bounce Rate Calculator"
+description: "Determine the percentage of single-page visits on your site."
+updated: "2025-09-26"
+cluster: "Web & Marketing"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "bounce-rate",
+  title: "Bounce Rate Calculator",
+  locale: "en",
+  unit: "%",
+  intro: "Determine the percentage of single-page visits on your site.",
+  inputs: [
+    { name: "bounces", label: "Bounces", type: "number", step: "1", placeholder: "25" },
+    { name: "visits", label: "Total Visits", type: "number", step: "1", placeholder: "100" }
+  ],
+  expression: "(bounces / visits) * 100",
+  examples: [
+    { description: "25 bounces out of 100 visits ⇒ 25%" }
+  ],
+  faqs: [
+    { question: "What is a bounce?", answer: "A single-page session with no interaction." }
+  ],
+  disclaimer: "Use with analytics data for accuracy.",
+  cluster: "Web & Marketing"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/ceiling-fan-size.mdx
+++ b/src/pages/calculators/ceiling-fan-size.mdx
@@ -1,0 +1,31 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Ceiling Fan Size Calculator"
+description: "Recommend fan blade span based on room area."
+updated: "2025-09-26"
+cluster: "Home & DIY"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "ceiling-fan-size",
+  title: "Ceiling Fan Size Calculator",
+  locale: "en",
+  unit: "inches",
+  intro: "Recommend fan blade span based on room area.",
+  inputs: [
+    { name: "area", label: "Room Area (sq ft)", type: "number", step: "any", placeholder: "150" }
+  ],
+  expression: "area <= 75 ? 36 : area <= 144 ? 42 : area <= 225 ? 50 : area <= 400 ? 54 : 56",
+  examples: [
+    { description: "150 sq ft ⇒ 50 in" }
+  ],
+  faqs: [
+    { question: "What if my room is long and narrow?", answer: "Consider multiple fans for large or odd-shaped rooms." }
+  ],
+  disclaimer: "Guideline only; check manufacturer recommendations.",
+  cluster: "Home & DIY"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/class-attendance-percentage.mdx
+++ b/src/pages/calculators/class-attendance-percentage.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Class Attendance Percentage Calculator"
+description: "Find the percentage of classes attended."
+updated: "2025-09-26"
+cluster: "Education & Learning"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "class-attendance-percentage",
+  title: "Class Attendance Percentage Calculator",
+  locale: "en",
+  unit: "%",
+  intro: "Find the percentage of classes attended.",
+  inputs: [
+    { name: "attended", label: "Classes Attended", type: "number", step: "1", placeholder: "18" },
+    { name: "total", label: "Total Classes", type: "number", step: "1", placeholder: "20" }
+  ],
+  expression: "(attended / total) * 100",
+  examples: [
+    { description: "18 attended of 20 ⇒ 90%" }
+  ],
+  faqs: [
+    { question: "Can total be zero?", answer: "Total classes must be greater than zero." }
+  ],
+  disclaimer: "For planning purposes only.",
+  cluster: "Education & Learning"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/hex-to-decimal.mdx
+++ b/src/pages/calculators/hex-to-decimal.mdx
@@ -1,0 +1,31 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Hex to Decimal Converter"
+description: "Convert a hexadecimal value to decimal."
+updated: "2025-09-26"
+cluster: "Technology"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "hex-to-decimal",
+  title: "Hex to Decimal Converter",
+  locale: "en",
+  intro: "Translate a hexadecimal string into its decimal value.",
+  inputs: [
+    { name: "hex", label: "Hex number", type: "text", placeholder: "FF" }
+  ],
+  expression: "parseInt(hex, 16)",
+  examples: [
+    { description: "FF ⇒ 255" },
+    { description: "1A3 ⇒ 419" }
+  ],
+  faqs: [
+    { question: "Can I include 0x?", answer: "No, enter the hex digits only." }
+  ],
+  disclaimer: "For quick conversions.",
+  cluster: "Technology"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/map-scale-distance.mdx
+++ b/src/pages/calculators/map-scale-distance.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Map Scale Distance Calculator"
+description: "Find real-world distance from map measurement and scale."
+updated: "2025-09-26"
+cluster: "Lifestyle & Travel"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "map-scale-distance",
+  title: "Map Scale Distance Calculator",
+  locale: "en",
+  unit: "km",
+  intro: "Find real-world distance from map measurement and scale.",
+  inputs: [
+    { name: "map", label: "Map Distance (cm)", type: "number", step: "any", placeholder: "5" },
+    { name: "scale", label: "Scale Denominator", type: "number", step: "any", placeholder: "50000" }
+  ],
+  expression: "(map * scale) / 100000",
+  examples: [
+    { description: "5 cm at 1:50,000 ⇒ 2.5 km" }
+  ],
+  faqs: [
+    { question: "Why divide by 100000?", answer: "There are 100,000 centimeters in a kilometer." }
+  ],
+  disclaimer: "Assumes map scale is accurate.",
+  cluster: "Lifestyle & Travel"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/mean-absolute-deviation.mdx
+++ b/src/pages/calculators/mean-absolute-deviation.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Mean Absolute Deviation Calculator"
+description: "Average distance of numbers from their mean."
+updated: "2025-09-26"
+cluster: "Math"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "mean-absolute-deviation",
+  title: "Mean Absolute Deviation Calculator",
+  locale: "en",
+  unit: "",
+  intro: "Average distance of numbers from their mean.",
+  inputs: [
+    { name: "a", label: "Number 1", type: "number", step: "any", placeholder: "2" },
+    { name: "b", label: "Number 2", type: "number", step: "any", placeholder: "4" },
+    { name: "c", label: "Number 3", type: "number", step: "any", placeholder: "7" }
+  ],
+  expression: "((Math.abs(a-((a+b+c)/3)) + Math.abs(b-((a+b+c)/3)) + Math.abs(c-((a+b+c)/3)))/3)",
+  examples: [
+    { description: "2, 4, 7 ⇒ 1.78" }
+  ],
+  faqs: [
+    { question: "What does MAD show?", answer: "It indicates variability around the mean." }
+  ],
+  disclaimer: "For educational purposes.",
+  cluster: "Math"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/mph-to-kph.mdx
+++ b/src/pages/calculators/mph-to-kph.mdx
@@ -1,0 +1,31 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "MPH to KPH Converter"
+description: "Convert miles per hour to kilometers per hour."
+updated: "2025-09-26"
+cluster: "Conversions"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "mph-to-kph",
+  title: "MPH to KPH Converter",
+  locale: "en",
+  unit: "km/h",
+  intro: "Convert speed from miles per hour to kilometers per hour.",
+  inputs: [
+    { name: "mph", label: "Miles per hour", type: "number", step: "any", placeholder: "60" }
+  ],
+  expression: "mph * 1.60934",
+  examples: [
+    { description: "60 mph ⇒ 96.56 km/h" }
+  ],
+  faqs: [
+    { question: "Can it convert backward?", answer: "Divide km/h by 1.60934 to get mph." }
+  ],
+  disclaimer: "For quick conversions only.",
+  cluster: "Conversions"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/pmi-monthly-payment.mdx
+++ b/src/pages/calculators/pmi-monthly-payment.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "PMI Monthly Payment Calculator"
+description: "Estimate monthly private mortgage insurance cost from loan amount and PMI rate."
+updated: "2025-09-26"
+cluster: "Personal Finance & Loans"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "pmi-monthly-payment",
+  title: "PMI Monthly Payment Calculator",
+  locale: "en",
+  unit: "",
+  intro: "Estimate monthly PMI cost from loan amount and annual PMI rate.",
+  inputs: [
+    { name: "loan", label: "Loan Amount", type: "number", step: "any", placeholder: "200000" },
+    { name: "rate", label: "PMI Rate (%) per year", type: "number", step: "any", placeholder: "0.5" }
+  ],
+  expression: "(loan * rate/100) / 12",
+  examples: [
+    { description: "200,000 loan at 0.5% ⇒ 83.33" }
+  ],
+  faqs: [
+    { question: "Is PMI deductible?", answer: "Check current tax laws; this is an estimate only." },
+    { question: "When does PMI end?", answer: "Usually when loan-to-value drops below 80%." }
+  ],
+  disclaimer: "Consult a lender for exact PMI costs.",
+  cluster: "Personal Finance & Loans"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/pregnancy-due-date.mdx
+++ b/src/pages/calculators/pregnancy-due-date.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Pregnancy Due Date Calculator"
+description: "Estimate expected due date 280 days from the last menstrual period."
+updated: "2025-09-26"
+cluster: "Health"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "pregnancy-due-date",
+  title: "Pregnancy Due Date Calculator",
+  locale: "en",
+  intro: "Estimate expected due date 280 days from the last menstrual period.",
+  inputs: [
+    { name: "year", label: "LMP Year", type: "number", step: "1", placeholder: "2025" },
+    { name: "month", label: "LMP Month", type: "number", step: "1", placeholder: "1" },
+    { name: "day", label: "LMP Day", type: "number", step: "1", placeholder: "1" }
+  ],
+  expression: "(new Date(year, month-1, day + 280)).toISOString().slice(0,10)",
+  examples: [
+    { description: "LMP 2025-01-01 ⇒ 2025-10-08" }
+  ],
+  faqs: [
+    { question: "How accurate is this?", answer: "Actual delivery can vary by several weeks." }
+  ],
+  disclaimer: "Not medical advice; consult a healthcare provider.",
+  cluster: "Health"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/spring-force.mdx
+++ b/src/pages/calculators/spring-force.mdx
@@ -1,0 +1,32 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Spring Force Calculator"
+description: "Compute force using Hooke's Law (F = k × x)."
+updated: "2025-09-26"
+cluster: "Science & Engineering"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "spring-force",
+  title: "Spring Force Calculator",
+  locale: "en",
+  unit: "N",
+  intro: "Compute force using Hooke's Law (F = k × x).",
+  inputs: [
+    { name: "k", label: "Spring Constant (N/m)", type: "number", step: "any", placeholder: "200" },
+    { name: "x", label: "Displacement (m)", type: "number", step: "any", placeholder: "0.1" }
+  ],
+  expression: "k * x",
+  examples: [
+    { description: "k=200 N/m, x=0.1 m ⇒ 20 N" }
+  ],
+  faqs: [
+    { question: "Does direction matter?", answer: "This returns magnitude; direction depends on compression or extension." }
+  ],
+  disclaimer: "Ideal linear springs only.",
+  cluster: "Science & Engineering"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/unix-timestamp.mdx
+++ b/src/pages/calculators/unix-timestamp.mdx
@@ -1,0 +1,34 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Unix Timestamp Calculator"
+description: "Convert a calendar date to seconds since the Unix epoch."
+updated: "2025-09-26"
+cluster: "Date & Time"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "unix-timestamp",
+  title: "Unix Timestamp Calculator",
+  locale: "en",
+  unit: "seconds",
+  intro: "Convert a calendar date to seconds since 1 January 1970 UTC.",
+  inputs: [
+    { name: "year", label: "Year", type: "number", step: "1", placeholder: "2025" },
+    { name: "month", label: "Month", type: "number", step: "1", placeholder: "1" },
+    { name: "day", label: "Day", type: "number", step: "1", placeholder: "1" }
+  ],
+  expression: "Date.UTC(year, month-1, day)/1000",
+  examples: [
+    { description: "1970-01-01 ⇒ 0" },
+    { description: "2025-01-01 ⇒ 1735689600" }
+  ],
+  faqs: [
+    { question: "Does it account for time of day?", answer: "No, it assumes midnight UTC." }
+  ],
+  disclaimer: "Use for rough conversions only.",
+  cluster: "Date & Time"
+};
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/working-capital-ratio.mdx
+++ b/src/pages/calculators/working-capital-ratio.mdx
@@ -1,0 +1,33 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Working Capital Ratio Calculator"
+description: "Measure liquidity by dividing current assets by current liabilities."
+updated: "2025-09-26"
+cluster: "Finance"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  slug: "working-capital-ratio",
+  title: "Working Capital Ratio Calculator",
+  locale: "en",
+  unit: "",
+  intro: "Measure liquidity by dividing current assets by current liabilities.",
+  inputs: [
+    { name: "assets", label: "Current Assets", type: "number", step: "any", placeholder: "50000" },
+    { name: "liabilities", label: "Current Liabilities", type: "number", step: "any", placeholder: "25000" }
+  ],
+  expression: "assets / liabilities",
+  examples: [
+    { description: "50,000 assets and 25,000 liabilities ⇒ 2" }
+  ],
+  faqs: [
+    { question: "What does the ratio indicate?", answer: "It shows short-term financial health." },
+    { question: "What is a good ratio?", answer: "Generally between 1.2 and 2.0." }
+  ],
+  disclaimer: "For educational purposes only.",
+  cluster: "Finance"
+};
+
+<Calculator schema={schema} />


### PR DESCRIPTION
## Summary
- add Working Capital Ratio and PMI Monthly Payment calculators for finance topics
- introduce new health, math, conversion, date-time, and education calculators
- expand technology, science, home, lifestyle, and marketing sections with fresh tools

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bdef651a1c8321b09b7e186b43198f