### PR TITLE
feat: add thousands separators to scientific calculator

### DIFF
--- a/src/pages/scientific-calculator.astro
+++ b/src/pages/scientific-calculator.astro
@@ -33,9 +33,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <button data-value="-" class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold">−</button>
         <button data-value="0" class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold">0</button>
         <button data-value="." class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold">.</button>
-        <button data-value="=" class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold">=</button>
+        <button data-value="C" class="p-2 rounded border bg-blue-500 hover:bg-blue-600 text-white transition-colors font-semibold">C</button>
         <button data-value="+" class="p-2 rounded border bg-gray-100 text-slate-900 hover:bg-gray-200 active:bg-gray-300 transition-colors font-semibold">+</button>
-        <button data-value="C" class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold">C</button>
+        <button data-value="=" class="col-span-4 p-2 rounded border bg-red-500 hover:bg-red-600 text-white font-semibold">=</button>
       </div>
     </div>
   </div>
@@ -61,6 +61,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       return result;
     }
 
+    function formatExpression(expr) {
+      return expr.replace(/-?\d+(?:\.\d+)?/g, match => {
+        const [intPart, decPart] = match.split('.');
+        const formattedInt = Number(intPart).toLocaleString('en-US');
+        return decPart ? `${formattedInt}.${decPart}` : formattedInt;
+      });
+    }
+
     function handleInput(val) {
       if (val === 'C') {
         current = '';
@@ -73,7 +81,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       } else {
         current += val;
       }
-      display.value = current;
+      display.value = formatExpression(current);
     }
 
     buttons.forEach(btn => {
@@ -90,7 +98,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         handleInput('C');
       } else if (key === 'Backspace') {
         current = current.slice(0, -1);
-        display.value = current;
+        display.value = formatExpression(current);
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- add thousands separators to numbers in the scientific calculator
- swap clear and equals buttons, styling clear as blue and equals as large bottom button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bdf5e7ceb48321b7e4d16adfdfa12c