### PR TITLE
refine site color palette

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -2,8 +2,8 @@
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
     The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    legible, while blue and turquoise provide primary emphasis and red
+    highlights calls to action.
   */
   --bg: #f9fafb;
   --surface: #f2f2f2;
@@ -11,8 +11,8 @@
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
-  --accent: #facc15;
+  --primary: #2563eb;
+  --accent: #10b981;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
   --card: #ffffff;
@@ -40,7 +40,7 @@ body {
 h1,
 h2,
 h3 {
-  color: #000000;
+  color: var(--primary);
 }
 a {
   color: var(--primary);
@@ -72,13 +72,15 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: var(--card);
+  background: var(--primary);
+  color: #ffffff;
   border-bottom: 1px solid var(--border);
   z-index: 50;
   box-shadow: var(--shadow);
 }
 .header a {
   text-decoration: none;
+  color: inherit;
 }
 .logo {
   display: inline-flex;
@@ -112,7 +114,7 @@ body {
   padding: 8px 12px;
   font-weight: 700;
   color: #ffffff;
-  background: var(--primary);
+  background: var(--accent);
   border-radius: 4px;
   box-shadow: var(--shadow);
   text-align: center;
@@ -124,8 +126,8 @@ body {
 }
 .nav-link:hover,
 .nav-link:focus {
-  background: #ffffff;
-  color: #000000;
+  background: var(--primary);
+  color: #ffffff;
   transform: translateY(1px);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
@@ -141,8 +143,8 @@ body {
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.active {
-  background: #d1d5db;
-  color: #1f2937;
+  background: var(--primary);
+  color: #ffffff;
 }
 @media (max-width: 768px) {
   .nav-link {
@@ -211,13 +213,11 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: #dc2626;
-  border: 1px solid #b91c1c;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 8px 16px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -226,7 +226,7 @@ ul.grid li {
 .card:hover {
   transform: translateY(1px);
   box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2);
-  border-color: #b91c1c;
+  border-color: var(--primary);
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -234,23 +234,23 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  color: #ffffff;
+  color: var(--ink);
   font-weight: 700;
 }
 .card:hover h3 {
-  color: #ffffff;
+  color: var(--primary);
   font-weight: 700;
 }
 .card p {
-  color: #ffffff;
+  color: var(--muted);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 400;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
 }
 .card img {
-  filter: brightness(0) invert(1);
+  filter: none;
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -9,10 +9,10 @@
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
-  --accent:#FACC15; /* Energetic yellow accent */
+  --primary:#2563EB;
+  --accent:#10B981; /* Turquoise accent */
   --accent-red:#DC2626;
-  --ring:#0057B833;
+  --ring:#2563EB33;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,8 +4,8 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
-        accent: { yellow: "#FACC15", red: "#DC2626" },
+        primary: "#2563EB",
+        accent: { turquoise: "#10B981", red: "#DC2626" },
         neutral: { ink: "#000000", muted: "#4B5563" }
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- align Tailwind palette with logo by switching primary to blue and accent to turquoise while keeping red for calls to action
- recolor headers and navigation using logo hues
- neutralize card styling for a softer look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68be0be08e848321aa7895f5d1a83f2f