### PR TITLE
Refine site color palette and navigation styling

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -11,11 +11,12 @@
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
+  --primary: #2563eb;
+  --primary-alt: #10b981;
   --accent: #facc15;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
-  --card: #ffffff;
+  --card: #f5f5f4;
   --border: #e5e7eb;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
   --radius: 14px;
@@ -40,7 +41,7 @@ body {
 h1,
 h2,
 h3 {
-  color: #000000;
+  color: var(--primary);
 }
 a {
   color: var(--primary);
@@ -48,12 +49,12 @@ a {
 }
 a:hover,
 a:focus {
-  color: var(--accent-red);
+  color: var(--primary-alt);
   font-weight: 600;
 }
 a:focus-visible,
 button:focus-visible {
-  outline: 2px solid var(--accent-red);
+  outline: 2px solid var(--primary-alt);
   outline-offset: 2px;
 }
 h1 {
@@ -72,7 +73,8 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: var(--card);
+  background: linear-gradient(90deg, var(--primary), var(--primary-alt));
+  color: var(--primary-ink);
   border-bottom: 1px solid var(--border);
   z-index: 50;
   box-shadow: var(--shadow);
@@ -111,27 +113,22 @@ body {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 700;
-  color: #ffffff;
-  background: var(--primary);
+  color: var(--primary-ink);
   border-radius: 4px;
-  box-shadow: var(--shadow);
   text-align: center;
   transition:
-    background 0.2s,
-    box-shadow 0.2s,
     color 0.2s,
     transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
-  background: #ffffff;
-  color: #000000;
+  color: var(--primary-alt);
   transform: translateY(1px);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.traditional {
   background: var(--accent-red);
   color: #ffffff;
+  box-shadow: var(--shadow);
 }
 .nav-link.traditional:hover,
 .nav-link.traditional:focus {
@@ -211,13 +208,13 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: #dc2626;
-  border: 1px solid #b91c1c;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
   box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 8px 16px rgba(0, 0, 0, 0.25);
+    0 4px 8px rgba(0, 0, 0, 0.1),
+    0 8px 16px rgba(0, 0, 0, 0.08);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -225,8 +222,8 @@ ul.grid li {
 }
 .card:hover {
   transform: translateY(1px);
-  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2);
-  border-color: #b91c1c;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.05);
+  border-color: var(--border);
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -234,23 +231,23 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  color: #ffffff;
+  color: var(--ink);
   font-weight: 700;
 }
 .card:hover h3 {
-  color: #ffffff;
+  color: var(--ink);
   font-weight: 700;
 }
 .card p {
-  color: #ffffff;
+  color: var(--muted);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 400;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
 }
 .card img {
-  filter: brightness(0) invert(1);
+  filter: none;
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
+        primary: "#2563EB",
+        secondary: "#10B981",
         accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        neutral: { ink: "#000000", muted: "#4B5563", card: "#F5F5F4" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- Use logo-inspired blue and turquoise for headers, navigation, and links.
- Apply neutral card backgrounds and muted text while keeping red for call-to-action elements.
- Update Tailwind palette to include new brand colors and neutral card tone.

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'yargs-parser/build/lib/index.js')*


------
https://chatgpt.com/codex/tasks/task_b_68be0be08e848321aa7895f5d1a83f2f