### PR TITLE
Refine color palette with blue/turquoise navigation and neutral cards

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -2,8 +2,9 @@
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
     The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    legible, while blue and turquoise from the logo color the
+    headers and navigation. Red is reserved for calls to action,
+    with yellow adding secondary highlights.
   */
   --bg: #f9fafb;
   --surface: #f2f2f2;
@@ -11,11 +12,13 @@
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
+  --primary-blue: #2563eb;
+  --primary-turquoise: #10b981;
+  --primary: var(--primary-blue);
   --accent: #facc15;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
-  --card: #ffffff;
+  --card: #f5f5f4;
   --border: #e5e7eb;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.08);
   --radius: 14px;
@@ -72,8 +75,9 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
+  background: linear-gradient(90deg, var(--primary-blue), var(--primary-turquoise));
+  color: var(--primary-ink);
+  border-bottom: none;
   z-index: 50;
   box-shadow: var(--shadow);
 }
@@ -94,7 +98,7 @@ body {
 }
 .logo-text {
   font-size: 1.25rem;
-  background: linear-gradient(90deg, var(--primary), var(--accent));
+  background: linear-gradient(90deg, var(--primary-blue), var(--primary-turquoise));
   background-clip: text;
   -webkit-background-clip: text;
   line-height: 1;
@@ -105,14 +109,14 @@ body {
   transform: scale(1.05);
 }
 .logo:hover .logo-text {
-  background: linear-gradient(90deg, var(--accent-red), var(--accent));
+  background: linear-gradient(90deg, var(--primary-turquoise), var(--primary-blue));
 }
 .nav-link {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 700;
   color: #ffffff;
-  background: var(--primary);
+  background: linear-gradient(90deg, var(--primary-blue), var(--primary-turquoise));
   border-radius: 4px;
   box-shadow: var(--shadow);
   text-align: center;
@@ -124,8 +128,8 @@ body {
 }
 .nav-link:hover,
 .nav-link:focus {
-  background: #ffffff;
-  color: #000000;
+  background: var(--primary-turquoise);
+  color: #ffffff;
   transform: translateY(1px);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
@@ -141,8 +145,8 @@ body {
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.active {
-  background: #d1d5db;
-  color: #1f2937;
+  background: var(--primary-turquoise);
+  color: #ffffff;
 }
 @media (max-width: 768px) {
   .nav-link {
@@ -211,13 +215,11 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: #dc2626;
-  border: 1px solid #b91c1c;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 8px 16px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -225,8 +227,8 @@ ul.grid li {
 }
 .card:hover {
   transform: translateY(1px);
-  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2);
-  border-color: #b91c1c;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.1);
+  border-color: var(--border);
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -234,23 +236,23 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  color: #ffffff;
+  color: var(--ink);
   font-weight: 700;
 }
 .card:hover h3 {
-  color: #ffffff;
+  color: var(--ink);
   font-weight: 700;
 }
 .card p {
-  color: #ffffff;
+  color: var(--muted);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 400;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
 }
 .card img {
-  filter: brightness(0) invert(1);
+  filter: none;
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -8,11 +8,13 @@
   /* Neutral palette combining soft greys */
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
-  /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
+  /* Primary brand colours from the logo */
+  --primary-blue:#2563EB;
+  --primary-turquoise:#10B981;
+  --primary:var(--primary-blue);
   --accent:#FACC15; /* Energetic yellow accent */
   --accent-red:#DC2626;
-  --ring:#0057B833;
+  --ring:#2563EB33;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,9 +15,9 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
     <meta name="description" content={description} />
     <link rel="canonical" href={href} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <!-- Set the theme colour to match the primary brand colour.
-         This provides a consistent browser UI in light mode. -->
-    <meta name="theme-color" content="#0057B8">
+      <!-- Set the theme colour to match the primary brand colour.
+           This provides a consistent browser UI in light mode. -->
+      <meta name="theme-color" content="#2563EB">
     <link rel="stylesheet" href="/styles/theme.css">
     <link rel="stylesheet" href="/styles/tokens.css" />
     {adsClient && (

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
     extend: {
       container: { center: true, padding: "1rem" },
       colors: {
-        primary: "#0057B8",
+        primary: "#2563EB",
+        turquoise: "#10B981",
         accent: { yellow: "#FACC15", red: "#DC2626" },
-        neutral: { ink: "#000000", muted: "#4B5563" }
+        neutral: { ink: "#000000", muted: "#4B5563", card: "#F5F5F4", border: "#E5E7EB" }
       },
       boxShadow: {
         brand: "0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.08)"


### PR DESCRIPTION
## Summary
- Use logo-inspired blue and turquoise for headers and navigation
- Keep red for call-to-action elements and neutral tones for cards
- Update theme color token and meta tag accordingly

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'yargs-parser/build/lib/index.js')*

------
https://chatgpt.com/codex/tasks/task_b_68be0e4452748321adbc0dfd498c826a