### PR TITLE
Refine color palette across site

### DIFF
--- a/public/styles/theme.css
+++ b/public/styles/theme.css
@@ -2,8 +2,8 @@
   /*
     Equilibrio Moderno: a neutral foundation with vibrant accents.
     The base relies on black, grey and white tones to keep content
-    legible, while blue and red provide primary emphasis and yellow
-    adds secondary highlights.
+    legible, while blue and turquoise guide navigation and headings,
+    red highlights calls to action and yellow adds secondary accents.
   */
   --bg: #f9fafb;
   --surface: #f2f2f2;
@@ -11,7 +11,8 @@
   --muted: #4b5563;
   --neutral-sky: #e5e7eb;
   --neutral-warm: #f5f5f4;
-  --primary: #0057b8;
+  --primary: #2563eb;
+  --secondary: #10b981;
   --accent: #facc15;
   --accent-red: #dc2626;
   --primary-ink: #ffffff;
@@ -40,7 +41,11 @@ body {
 h1,
 h2,
 h3 {
-  color: #000000;
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
 }
 a {
   color: var(--primary);
@@ -94,7 +99,7 @@ body {
 }
 .logo-text {
   font-size: 1.25rem;
-  background: linear-gradient(90deg, var(--primary), var(--accent));
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
   background-clip: text;
   -webkit-background-clip: text;
   line-height: 1;
@@ -105,29 +110,25 @@ body {
   transform: scale(1.05);
 }
 .logo:hover .logo-text {
-  background: linear-gradient(90deg, var(--accent-red), var(--accent));
+  background: linear-gradient(90deg, var(--accent-red), var(--secondary));
 }
 .nav-link {
   display: inline-block;
   padding: 8px 12px;
   font-weight: 700;
   color: #ffffff;
-  background: var(--primary);
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
   border-radius: 4px;
   box-shadow: var(--shadow);
   text-align: center;
   transition:
-    background 0.2s,
-    box-shadow 0.2s,
-    color 0.2s,
+    filter 0.2s,
     transform 0.2s;
 }
 .nav-link:hover,
 .nav-link:focus {
-  background: #ffffff;
-  color: #000000;
+  filter: brightness(1.05);
   transform: translateY(1px);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.traditional {
   background: var(--accent-red);
@@ -138,11 +139,9 @@ body {
   background: #b91c1c;
   color: #ffffff;
   transform: translateY(1px);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .nav-link.active {
-  background: #d1d5db;
-  color: #1f2937;
+  filter: brightness(0.9);
 }
 @media (max-width: 768px) {
   .nav-link {
@@ -211,13 +210,11 @@ ul.grid li {
      content from being clipped when long titles wrap. */
   display: block;
   width: 100%;
-  background: #dc2626;
-  border: 1px solid #b91c1c;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 8px 16px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -225,8 +222,8 @@ ul.grid li {
 }
 .card:hover {
   transform: translateY(1px);
-  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.2);
-  border-color: #b91c1c;
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.05);
+  border-color: var(--primary);
 }
 .card h3 {
   margin: 2px 0 6px;
@@ -234,23 +231,22 @@ ul.grid li {
   word-wrap: break-word;
   white-space: normal;
   padding: 2px 4px;
-  color: #ffffff;
+  color: var(--primary);
   font-weight: 700;
 }
 .card:hover h3 {
-  color: #ffffff;
-  font-weight: 700;
+  color: var(--primary);
 }
 .card p {
-  color: #ffffff;
+  color: var(--ink);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 400;
   /* Ensure descriptions wrap naturally within the card. */
   word-wrap: break-word;
   white-space: normal;
 }
 .card img {
-  filter: brightness(0) invert(1);
+  filter: none;
 }
 .ad-slot {
   border: 1px dashed var(--border);

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -9,10 +9,11 @@
   --neutral-sky:#e5e7eb;
   --neutral-warm:#f5f5f4;
   /* Primary brand colour and complementary accents */
-  --primary:#0057B8;
+  --primary:#2563EB;
+  --secondary:#10B981;
   --accent:#FACC15; /* Energetic yellow accent */
   --accent-red:#DC2626;
-  --ring:#0057B833;
+  --ring:#2563EB33;
   --radius:12px;
   --shadow:0 2px 4px rgba(0,0,0,.1),0 8px 16px rgba(0,0,0,.08);
 }


### PR DESCRIPTION
## Summary
- introduce primary blue and secondary turquoise design tokens
- apply blue/turquoise gradient to headings and navigation
- switch cards to neutral styling while preserving red call-to-action accents

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be0e4452748321adbc0dfd498c826a