### PR TITLE
Improve homepage hero hierarchy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import AdBanner from '../components/AdBanner.astro';
 
 /*
  * The home page lists twelve high‑level calculator categories.  Each item
@@ -24,16 +23,20 @@ const CATEGORIES = [
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
-  <section class="container mx-auto max-w-5xl px-4 pt-10">
+  <section class="container mx-auto max-w-5xl px-4 pt-20 text-center">
     <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
       Smart &amp; Fast<br />Calculators
     </h1>
-    <p class="mt-3" style="color: var(--muted)">
-      Calculate anything quickly and easily with our collection of online calculators.
+    <p class="mt-4" style="color: var(--muted)">
+      Find quick answers for finance, health, math, and more with our directory of free online calculators.
     </p>
+    <img
+      src="/logo.svg"
+      alt="Calculator illustration"
+      class="mx-auto mt-8 w-32 h-32"
+      loading="lazy"
+    />
   </section>
-
-  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <h2 class="sr-only">Categories</h2>


### PR DESCRIPTION
## Summary
- enlarge hero spacing with centered layout and illustration
- remove top ad from hero so promotions follow categories

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be12d37d188321af08566e92650892