### PR TITLE
Improve home hero focus and move ad placement

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,16 +24,26 @@ const CATEGORIES = [
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
-  <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+  <section class="container mx-auto max-w-5xl px-4 pt-16 text-center">
+    <img
+      src="/logo.svg"
+      width="96"
+      height="96"
+      alt=""
+      class="mx-auto mb-6"
+      loading="lazy"
+    />
+    <h1
+      class="text-4xl sm:text-5xl font-extrabold leading-tight"
+      style="color: var(--ink)"
+    >
       Smart &amp; Fast<br />Calculators
     </h1>
-    <p class="mt-3" style="color: var(--muted)">
-      Calculate anything quickly and easily with our collection of online calculators.
+    <p class="mt-4 text-[var(--muted)]">
+      Access quick answers for finance, health, math and more — our tools cover
+      every niche to help solve your everyday calculations.
     </p>
   </section>
-
-  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <h2 class="sr-only">Categories</h2>
@@ -63,5 +73,7 @@ const CATEGORIES = [
       ))}
     </ul>
   </section>
+
+  <AdBanner />
 
 </BaseLayout>


### PR DESCRIPTION
## Summary
- expand home hero with descriptive subtitle and logo graphic
- move homepage ad banner below the category section for better hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68be12d37d188321af08566e92650892