### PR TITLE
feat: enhance homepage hero and reposition ad

### DIFF
--- a/public/illustrations/hero-calculator.svg
+++ b/public/illustrations/hero-calculator.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="20" fill="#f3f4f6"/>
+  <rect x="20" y="20" width="80" height="80" rx="8" fill="#fff" stroke="#2563eb" stroke-width="4"/>
+  <rect x="32" y="32" width="56" height="12" rx="2" fill="#e5e7eb"/>
+  <g fill="#2563eb">
+    <rect x="32" y="50" width="12" height="12" rx="2"/>
+    <rect x="50" y="50" width="12" height="12" rx="2"/>
+    <rect x="68" y="50" width="12" height="12" rx="2"/>
+    <rect x="32" y="68" width="12" height="12" rx="2"/>
+    <rect x="50" y="68" width="12" height="12" rx="2"/>
+    <rect x="68" y="68" width="12" height="12" rx="2"/>
+  </g>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,16 +24,23 @@ const CATEGORIES = [
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
-  <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
-      Smart &amp; Fast<br />Calculators
-    </h1>
-    <p class="mt-3" style="color: var(--muted)">
-      Calculate anything quickly and easily with our collection of online calculators.
+  <section class="container mx-auto max-w-5xl px-4 pt-16 text-center">
+    <div class="flex items-center justify-center gap-3">
+      <img src="/logo.svg" alt="Smart &amp; Fast Calculators logo" class="h-12 w-12" />
+      <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
+        Smart &amp; Fast Calculators
+      </h1>
+    </div>
+    <p class="mt-4 text-lg" style="color: var(--muted)">
+      Explore hundreds of smart tools for finance, health, math and more.
     </p>
+    <img
+      src="/illustrations/hero-calculator.svg"
+      alt="Illustration of a calculator"
+      class="mx-auto mt-8 w-48 h-auto"
+      loading="lazy"
+    />
   </section>
-
-  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <h2 class="sr-only">Categories</h2>
@@ -63,5 +70,7 @@ const CATEGORIES = [
       ))}
     </ul>
   </section>
+
+  <AdBanner />
 
 </BaseLayout>


### PR DESCRIPTION
## Summary
- expand hero with site logo, clearer subtitle and supporting illustration
- move homepage ad below the category grid

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be1d92b49883219a7689a0ba320fd5