### PR TITLE
Improve homepage hero layout and ad placement

### DIFF
--- a/public/hero-illustration.svg
+++ b/public/hero-illustration.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect x="10" y="10" width="100" height="100" rx="8" fill="#f3f4f6" stroke="#cbd5e1" stroke-width="2" />
+  <rect x="30" y="30" width="60" height="20" fill="#cbd5e1" />
+  <rect x="30" y="60" width="20" height="20" fill="#94a3b8" />
+  <rect x="55" y="60" width="20" height="20" fill="#94a3b8" />
+  <rect x="80" y="60" width="20" height="20" fill="#94a3b8" />
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,16 +24,25 @@ const CATEGORIES = [
 ];
 ---
 <BaseLayout title="Smart & Fast Calculators" description="Calculate anything quickly and easily with our collection of online calculators.">
-  <section class="container mx-auto max-w-5xl px-4 pt-10">
-    <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight" style="color: var(--ink)">
-      Smart &amp; Fast<br />Calculators
-    </h1>
-    <p class="mt-3" style="color: var(--muted)">
-      Calculate anything quickly and easily with our collection of online calculators.
-    </p>
+  <section class="container mx-auto max-w-5xl px-4 pt-16 flex flex-col sm:flex-row items-center gap-8">
+    <div class="flex-1">
+      <h1 class="text-4xl sm:text-5xl font-extrabold leading-tight flex items-center gap-3" style="color: var(--ink)">
+        <img src="/logo.svg" alt="Smart & Fast Calculators logo" class="w-12 h-12" />
+        <span>Smart &amp; Fast<br />Calculators</span>
+      </h1>
+      <p class="mt-4 text-lg" style="color: var(--muted)">
+        Explore a growing network of calculators for math, finance, health and more.
+      </p>
+    </div>
+    <img
+      src="/hero-illustration.svg"
+      width="160"
+      height="160"
+      alt="Illustration of a calculator"
+      loading="lazy"
+      class="w-32 h-32 sm:w-40 sm:h-40"
+    />
   </section>
-
-  <AdBanner />
 
   <section class="container mx-auto max-w-5xl px-4 py-8">
     <h2 class="sr-only">Categories</h2>
@@ -64,4 +73,5 @@ const CATEGORIES = [
     </ul>
   </section>
 
+  <AdBanner />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- refine homepage hero with site logo, larger intro space, descriptive subtitle and illustration
- move ad banner to follow category grid for better content hierarchy

## Testing
- `npx prettier --write src/pages/index.astro public/hero-illustration.svg` *(fails: No parser could be inferred for .astro)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be1d92b49883219a7689a0ba320fd5