### PR TITLE
Add responsive header search

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,28 @@
+---
+import calculators from '../../data/calculators.json';
+---
+<div class="relative">
+  <input
+    id="header-search"
+    list="header-search-list"
+    type="search"
+    placeholder="Search calculators"
+    class="w-48 sm:w-64 p-2 border rounded-md"
+  />
+  <datalist id="header-search-list">
+    {calculators.map((c) => (
+      <option value={c.title} data-url={`/calculators/${c.slug}/`}></option>
+    ))}
+  </datalist>
+</div>
+<script is:inline>
+  const input = document.getElementById('header-search');
+  const options = Array.from(document.querySelectorAll('#header-search-list option'));
+  input?.addEventListener('change', () => {
+    const val = input.value.toLowerCase();
+    const opt = options.find((o) => o.value.toLowerCase() === val);
+    if (opt) {
+      window.location.href = opt.dataset.url;
+    }
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/tailwind.css";
 import AdBanner from "../components/AdBanner.astro";
+import Search from "../components/Search.astro";
 const { title = 'CalcSimpler', description = 'Smart & Fast Calculators', canonical } = Astro.props;
 const site = Astro.site?.toString() || (import.meta.env.SITE_URL ?? 'https://example.com');
 const href = canonical ?? new URL(Astro.url.pathname, site).toString();
@@ -46,34 +47,51 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           <img src="/logo.svg" alt="CalcSimpler" />
           <span class="logo-text">CalcSimpler</span>
         </a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
-          <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-        <nav
-          id="nav"
-          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex flex-col items-end gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-2 md:gap-4 sm:justify-end sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
-          aria-label="Primary"
-        >
-          <a
-            href="/categories/"
-            class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
-            >Categories</a
+        <div class="relative flex items-center gap-2">
+          <div
+            id="search-container"
+            class="hidden absolute top-full left-0 right-0 mx-4 mt-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:block sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
           >
-          <a
-            href="/all"
-            class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
-            >All Calculators</a
+            <Search />
+          </div>
+          <button
+            id="search-btn"
+            class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            aria-label="Search" aria-expanded="false"
           >
-          <a
-            href="/scientific-calculator/"
-            class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/scientific-calculator') && 'active'].filter(Boolean).join(' ')}
-            >Scientific Calculator</a
+            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M10 18a8 8 0 100-16 8 8 0 000 16z" />
+            </svg>
+          </button>
+          <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
+            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <nav
+            id="nav"
+            class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex flex-col items-end gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-2 md:gap-4 sm:justify-end sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+            aria-label="Primary"
           >
-        </nav>
+            <a
+              href="/categories/"
+              class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
+              >Categories</a
+            >
+            <a
+              href="/all"
+              class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+              >All Calculators</a
+            >
+            <a
+              href="/scientific-calculator/"
+              class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/scientific-calculator') && 'active'].filter(Boolean).join(' ')}
+              >Scientific Calculator</a
+            >
+          </nav>
+        </div>
       </div>
-    </header>
+      </header>
     <main class="container" id="main" role="main">
       <slot />
       <AdBanner />
@@ -96,6 +114,16 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
         const expanded = btn.getAttribute('aria-expanded') === 'true';
         btn.setAttribute('aria-expanded', String(!expanded));
         nav.classList.toggle('hidden');
+      });
+      const searchBtn = document.getElementById('search-btn');
+      const searchContainer = document.getElementById('search-container');
+      searchBtn?.addEventListener('click', () => {
+        const expanded = searchBtn.getAttribute('aria-expanded') === 'true';
+        searchBtn.setAttribute('aria-expanded', String(!expanded));
+        searchContainer.classList.toggle('hidden');
+        if (!expanded) {
+          document.getElementById('header-search')?.focus();
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add reusable Search component for calculator lookup
- integrate search bar into header with mobile toggle
- include script to reveal search input from icon button

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be2e7434308321b3b5ad72e17eaf74