### PR TITLE
feat: add header search for calculators

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -71,6 +71,14 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
             class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/scientific-calculator') && 'active'].filter(Boolean).join(' ')}
             >Scientific Calculator</a
           >
+          <form action="/all" method="get" class="w-full sm:w-auto">
+            <input
+              type="search"
+              name="q"
+              placeholder="Search calculators"
+              class="w-full p-2 border rounded-md"
+            />
+          </form>
         </nav>
       </div>
     </header>

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -55,6 +55,12 @@ const items = Object.values(modules).map((m) => ({
         card.style.display = match ? '' : 'none';
       });
     }
+    const params = new URLSearchParams(window.location.search);
+    const initial = params.get('q') || '';
+    if (initial) {
+      input.value = initial;
+    }
+    filter();
     input.addEventListener('input', filter);
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add site-wide header search for calculators
- support query parameter on All Calculators page to filter results automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68be3965b3608321b676200e2ec16be3