### PR TITLE
feat: add header search bar

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -46,32 +46,59 @@ const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
           <img src="/logo.svg" alt="CalcSimpler" />
           <span class="logo-text">CalcSimpler</span>
         </a>
-        <button id="menu-btn" class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" aria-label="Toggle navigation" aria-expanded="false">
-          <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-        <nav
-          id="nav"
-          class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex flex-col items-end gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-2 md:gap-4 sm:justify-end sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
-          aria-label="Primary"
-        >
-          <a
-            href="/categories/"
-            class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
-            >Categories</a
+        <div class="flex items-center gap-2">
+          <form action="/all" method="get">
+            <input
+              type="search"
+              name="q"
+              placeholder="Search calculators"
+              aria-label="Search calculators"
+              class="w-32 sm:w-48 p-2 border rounded-md"
+            />
+          </form>
+          <button
+            id="menu-btn"
+            class="sm:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            aria-label="Toggle navigation"
+            aria-expanded="false"
           >
-          <a
-            href="/all"
-            class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
-            >All Calculators</a
+            <svg
+              class="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <nav
+            id="nav"
+            class="hidden absolute top-full left-0 right-0 mx-4 mt-2 flex flex-col items-end gap-2 bg-[var(--card)] border border-[var(--border)] rounded-md p-4 shadow-md sm:static sm:flex sm:flex-row sm:items-center sm:gap-2 md:gap-4 sm:justify-end sm:mx-0 sm:mt-0 sm:border-0 sm:p-0 sm:shadow-none"
+            aria-label="Primary"
           >
-          <a
-            href="/scientific-calculator/"
-            class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/scientific-calculator') && 'active'].filter(Boolean).join(' ')}
-            >Scientific Calculator</a
-          >
-        </nav>
+            <a
+              href="/categories/"
+              class={['nav-link', Astro.url.pathname.startsWith('/categories') && 'active'].filter(Boolean).join(' ')}
+              >Categories</a
+            >
+            <a
+              href="/all"
+              class={['nav-link', Astro.url.pathname.startsWith('/all') && 'active'].filter(Boolean).join(' ')}
+              >All Calculators</a
+            >
+            <a
+              href="/scientific-calculator/"
+              class={['nav-link', 'traditional', Astro.url.pathname.startsWith('/scientific-calculator') && 'active'].filter(Boolean).join(' ')}
+              >Scientific Calculator</a
+            >
+          </nav>
+        </div>
       </div>
     </header>
     <main class="container" id="main" role="main">

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -10,6 +10,7 @@ const items = Object.values(modules).map((m) => ({
   description:
     m.frontmatter?.intro || m.frontmatter?.description || ''
 }));
+const q = Astro.url.searchParams.get('q') || '';
 ---
 <BaseLayout title="All Calculators" description="Browse every calculator available on the site.">
   <section class="hero container mx-auto max-w-5xl px-4">
@@ -20,6 +21,7 @@ const items = Object.values(modules).map((m) => ({
       type="search"
       placeholder="Search calculators"
       class="w-full mt-4 p-2 border rounded-md"
+      value={q}
     />
   </section>
   <AdBanner />
@@ -56,5 +58,6 @@ const items = Object.values(modules).map((m) => ({
       });
     }
     input.addEventListener('input', filter);
+    filter();
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add calculator search field to header visible on all pages
- support query parameter filtering on All Calculators page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68be3965b3608321b676200e2ec16be3