### PR TITLE
feat: add sort options to calculator search

### DIFF
--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -8,7 +8,8 @@ const items = Object.values(modules).map((m) => ({
     m.frontmatter?.title ||
     m.url.replace('/calculators/', '').replace('.mdx', ''),
   description:
-    m.frontmatter?.intro || m.frontmatter?.description || ''
+    m.frontmatter?.intro || m.frontmatter?.description || '',
+  date: m.frontmatter?.date || ''
 }));
 ---
 <BaseLayout title="Search Calculators" description="Find any calculator available on the site.">
@@ -21,6 +22,14 @@ const items = Object.values(modules).map((m) => ({
       placeholder="Search calculators"
       class="w-full mt-4 p-2 border rounded-md"
     />
+    <label for="sort-select" class="sr-only">Sort calculators</label>
+    <select
+      id="sort-select"
+      class="mt-4 p-2 border rounded-md"
+    >
+      <option value="alpha">Alphabetical</option>
+      <option value="date">Newest</option>
+    </select>
   </section>
   <AdBanner />
   <section class="section container mx-auto max-w-5xl px-4" aria-labelledby="list-all">
@@ -34,6 +43,7 @@ const items = Object.values(modules).map((m) => ({
         <div
           data-title={it.title.toLowerCase()}
           data-description={it.description.toLowerCase()}
+          data-date={it.date}
         >
           <a class="card" href={it.url}>
             <h3>{it.title}</h3>
@@ -45,7 +55,21 @@ const items = Object.values(modules).map((m) => ({
   </section>
   <script is:inline>
     const input = document.getElementById('search-input');
+    const sortSelect = document.getElementById('sort-select');
+    const results = document.getElementById('results');
     const cards = Array.from(document.querySelectorAll('#results > div'));
+
+    function applySort() {
+      const type = sortSelect.value;
+      cards.sort((a, b) => {
+        if (type === 'alpha') {
+          return a.dataset.title.localeCompare(b.dataset.title);
+        }
+        return (b.dataset.date || '').localeCompare(a.dataset.date || '');
+      });
+      cards.forEach((card) => results.appendChild(card));
+    }
+
     function filter() {
       const q = input.value.trim().toLowerCase();
       cards.forEach((card) => {
@@ -55,6 +79,13 @@ const items = Object.values(modules).map((m) => ({
         card.style.display = match ? '' : 'none';
       });
     }
+
     input.addEventListener('input', filter);
+    sortSelect.addEventListener('change', () => {
+      applySort();
+      filter();
+    });
+
+    applySort();
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add dropdown to order calculators alphabetically or by newest
- sort calculator cards dynamically on selection

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c0b10687408321972ea77fb999d200