### PR TITLE
feat: show logo in ad placeholders

### DIFF
--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -2,6 +2,6 @@
 ---
 <div class="container mx-auto max-w-5xl px-4 pb-10">
   <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 728 × 90 reserved
+    <img src="/logo.svg" alt="CalcSimpler" class="h-12 w-auto opacity-70" />
   </div>
 </div>

--- a/src/components/AdSidebar.astro
+++ b/src/components/AdSidebar.astro
@@ -2,6 +2,6 @@
 ---
 <div class="hidden lg:block">
   <div class="w-[160px] min-h-[600px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 160 × 600 reserved
+    <img src="/logo.svg" alt="CalcSimpler" class="h-16 w-auto opacity-70" />
   </div>
 </div>


### PR DESCRIPTION
## Summary
- display site logo in banner ad placeholders
- show site logo in sidebar ad spaces

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'yargs-parser/build/lib/index.js')*


------
https://chatgpt.com/codex/tasks/task_b_68c0be456a088321bee79bf949ad11ef