### PR TITLE
feat: show logo in placeholder ad slots

### DIFF
--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <div class="container mx-auto max-w-5xl px-4 pb-10">
-  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 728 × 90 reserved
+  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 grid place-items-center">
+    <img src="/logo.svg" alt="CalcSimpler logo" class="h-16" />
   </div>
 </div>

--- a/src/components/AdSidebar.astro
+++ b/src/components/AdSidebar.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <div class="hidden lg:block">
-  <div class="w-[160px] min-h-[600px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 160 × 600 reserved
+  <div class="w-[160px] min-h-[600px] rounded-xl border border-dashed border-slate-300 grid place-items-center">
+    <img src="/logo.svg" alt="CalcSimpler logo" class="w-24" />
   </div>
 </div>


### PR DESCRIPTION
## Summary
- display site logo in banner ad placeholder
- display site logo in sidebar ad placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c0be456a088321bee79bf949ad11ef