### PR TITLE
feat: display logo and site name in ad placeholders

### DIFF
--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -1,7 +1,10 @@
 ---
 ---
 <div class="container mx-auto max-w-5xl px-4 pb-10">
-  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 728 × 90 reserved
+  <div class="min-h-[90px] rounded-xl border border-dashed border-slate-300 flex items-center justify-center p-4">
+    <div class="flex items-center gap-4">
+      <img src="/logo.svg" alt="CalcSimpler logo" class="h-16 w-auto" />
+      <span class="logo-text" style="font-size:2.25rem;">CalcSimpler</span>
+    </div>
   </div>
 </div>

--- a/src/components/AdSidebar.astro
+++ b/src/components/AdSidebar.astro
@@ -1,7 +1,8 @@
 ---
 ---
 <div class="hidden lg:block">
-  <div class="w-[160px] min-h-[600px] rounded-xl border border-dashed border-slate-300 grid place-items-center text-slate-500">
-    Ad — 160 × 600 reserved
+  <div class="w-[160px] min-h-[600px] rounded-xl border border-dashed border-slate-300 flex flex-col items-center justify-center p-4 text-center">
+    <img src="/logo.svg" alt="CalcSimpler logo" class="w-24 mb-4" />
+    <span class="logo-text" style="font-size:1.5rem;">CalcSimpler</span>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- show CalcSimpler logo and name in banner ad placeholder
- show logo and name in sidebar ad placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c0be456a088321bee79bf949ad11ef