### PR TITLE
style: unify info section styling

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -241,6 +241,7 @@ const jsonLd = {
   }
   .examples,
   .faq,
+  .info,
   .related {
     max-width: 720px;
     margin: 24px auto 0;
@@ -254,6 +255,7 @@ const jsonLd = {
   .faq details { margin: 8px 0; }
   .faq summary { cursor: pointer; font-weight: 600; }
   .faq p { margin: 4px 0 0 16px; }
+  .info ul { margin: 8px 0 0 20px; }
   .related ul { margin: 8px 0 0 20px; }
 </style>
 


### PR DESCRIPTION
## Summary
- Match Additional Information section styles with Examples, FAQ, and Related sections
- Keep Additional Information positioned between FAQ and related calculators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c128e833cc8321b3319f599813f806