### PR TITLE
Fix calculator result errors and units

### DIFF
--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -521,6 +521,33 @@ const jsonLd = {
             value = num(vars.b) * num(vars.c) / num(vars.a);
             break;
           }
+          case 'bits-required-number': {
+            const n = num(vars.number);
+            if (n < 0) {
+              showMessage('error', 'Please fill all fields with valid numbers');
+              return;
+            }
+            value = n === 0 ? 1 : Math.floor(Math.log2(n)) + 1;
+            break;
+          }
+          case 'birthday-paradox-probability': {
+            const people = num(vars.people);
+            let p = 1;
+            for (let i = 0; i < people; i++) {
+              p *= (365 - i) / 365;
+            }
+            value = 100 * (1 - p);
+            break;
+          }
+          case 'day-of-year': {
+            const y = num(vars.year);
+            const m = num(vars.month);
+            const d = num(vars.day);
+            const days = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+            const leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+            value = days[m - 1] + d + (leap && m > 2 ? 1 : 0);
+            break;
+          }
           default: {
             showMessage('error', 'Calculation not available.');
             return;

--- a/src/pages/calculators/biweekly-mortgage-payment.mdx
+++ b/src/pages/calculators/biweekly-mortgage-payment.mdx
@@ -17,7 +17,7 @@ export const schema = {
     { "name": "rate", "label": "Annual Interest Rate (%)", "type": "number", "step": "any", "placeholder": "5" },
     { "name": "years", "label": "Loan Term (years)", "type": "number", "step": "any", "placeholder": "30" }
   ],
-  "expression": "principal * ((rate/100)/26) / (1 - (1 + (rate/100)/26)^(-26*years))",
+  "expression": "principal*(rate/100/26)/(1 - 1/(1 + rate/100/26)^(26*years))",
   "unit": "USD",
   "intro": "Find your biweekly mortgage payment based on principal, interest rate, and loan term using 26 payments per year.",
   "examples": [

--- a/src/pages/calculators/click-through-rate.mdx
+++ b/src/pages/calculators/click-through-rate.mdx
@@ -31,6 +31,7 @@ export const schema = {
     }
   ],
   "expression": "(clicks / impressions) * 100",
+  "unit": "%",
   "intro": "Determine the percentage of impressions that result in clicks for an ad or email campaign.",
   "examples": [
     {

--- a/src/pages/calculators/compost-carbon-nitrogen-ratio.mdx
+++ b/src/pages/calculators/compost-carbon-nitrogen-ratio.mdx
@@ -43,6 +43,7 @@ export const schema = {
     }
   ],
   "expression": "(green_weight * green_cn + brown_weight * brown_cn) / (green_weight + brown_weight)",
+  "unit": "C:N",
   "intro": "Determine the overall carbon-to-nitrogen ratio when mixing green and brown compost materials.",
   "examples": [
     {

--- a/src/pages/calculators/cpu-utilization.mdx
+++ b/src/pages/calculators/cpu-utilization.mdx
@@ -31,6 +31,7 @@ export const schema = {
     }
   ],
   "expression": "(busy / total) * 100",
+  "unit": "%",
   "intro": "Estimate CPU utilization percentage from measured busy time over total time.",
   "examples": [
     {

--- a/src/pages/calculators/credit-hours-to-ects.mdx
+++ b/src/pages/calculators/credit-hours-to-ects.mdx
@@ -22,6 +22,7 @@ export const schema = {
     }
   ],
   "expression": "credits * 2",
+  "unit": "ECTS",
   "intro": "Translate academic credit hours into the European Credit Transfer and Accumulation System.",
   "examples": [
     {

--- a/src/pages/calculators/cups-to-tbsp.mdx
+++ b/src/pages/calculators/cups-to-tbsp.mdx
@@ -23,6 +23,7 @@ export const schema = {
     }
   ],
   "expression": "cups * 16",
+  "unit": "tbsp",
   "intro": "Convert volume in cups to tablespoons using the US customary system.",
   "examples": [
     {

--- a/src/pages/calculators/decimal-to-percentage.mdx
+++ b/src/pages/calculators/decimal-to-percentage.mdx
@@ -19,6 +19,7 @@ export const schema = {
     }
   ],
   "expression": "decimal*100",
+  "unit": "%",
   "intro": "Convert decimals to percentages for reports and presentations.",
   "examples": [
     {

--- a/src/pages/calculators/determinant-3x3-matrix.mdx
+++ b/src/pages/calculators/determinant-3x3-matrix.mdx
@@ -106,6 +106,10 @@ export const schema = {
   ],
   "disclaimer": "For educational purposes; verify results for critical applications.",
   "cluster": "Math & Statistics",
+  "info": [
+    "A zero determinant means the matrix is singular.",
+    "Positive determinant preserves orientation." 
+  ],
   "related": [
     "circle-area",
     "cylinder-volume-calculator",


### PR DESCRIPTION
## Summary
- ensure birthday paradox, bits-required, and day-of-year calculators compute correctly
- fix biweekly mortgage exponent handling
- show output units and add info to various converters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c14499f6fc832191ad2417e9cfcc37