### PR TITLE
Add output units for birthday paradox and day-of-year calculators

### DIFF
--- a/src/pages/calculators/birthday-paradox-probability.mdx
+++ b/src/pages/calculators/birthday-paradox-probability.mdx
@@ -13,6 +13,7 @@ export const schema = {
   slug: "birthday-paradox-probability",
   title: "Birthday Paradox Probability",
   locale: "en",
+  unit: "%",
   inputs: [
     {
       name: "people",

--- a/src/pages/calculators/day-of-year.mdx
+++ b/src/pages/calculators/day-of-year.mdx
@@ -13,6 +13,7 @@ export const schema = {
   slug: "day-of-year",
   title: "Day of Year Calculator",
   locale: "en",
+  unit: "day",
   inputs: [
     {
       name: "year",


### PR DESCRIPTION
## Summary
- Add percent unit to birthday paradox probability calculator
- Define day unit for day-of-year calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c19109485c8321ba86cded41b5dffb