### PR TITLE
Add twelve niche calculators and support prime factorization

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -28,10 +28,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$100 with a 20% discount ⇒ $80"
+        "description": "$100 with a 20% discount \u21d2 $80"
       },
       {
-        "description": "$250 with a 15% discount ⇒ $212.50"
+        "description": "$250 with a 15% discount \u21d2 $212.50"
       }
     ],
     "faqs": [
@@ -92,10 +92,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1,000 at 5% for 3 years ⇒ $150 interest"
+        "description": "$1,000 at 5% for 3 years \u21d2 $150 interest"
       },
       {
-        "description": "$2,500 at 4% for 2 years ⇒ $200 interest"
+        "description": "$2,500 at 4% for 2 years \u21d2 $200 interest"
       }
     ],
     "faqs": [
@@ -157,10 +157,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1,000 at 5% compounded quarterly for 10 years ⇒ $1,643.62"
+        "description": "$1,000 at 5% compounded quarterly for 10 years \u21d2 $1,643.62"
       },
       {
-        "description": "$500 at 3% compounded monthly for 5 years ⇒ $580.81"
+        "description": "$500 at 3% compounded monthly for 5 years \u21d2 $580.81"
       }
     ],
     "faqs": [
@@ -211,13 +211,13 @@
       }
     ],
     "expression": "weight / ((height/100) ** 2)",
-    "unit": "kg/m²",
+    "unit": "kg/m\u00b2",
     "examples": [
       {
-        "description": "70 kg and 175 cm ⇒ 22.86 kg/m²"
+        "description": "70 kg and 175 cm \u21d2 22.86 kg/m\u00b2"
       },
       {
-        "description": "90 kg and 160 cm ⇒ 35.16 kg/m²"
+        "description": "90 kg and 160 cm \u21d2 35.16 kg/m\u00b2"
       }
     ],
     "faqs": [
@@ -268,10 +268,10 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "8000 steps and 30 min exercise ⇒ ≈ 470 kcal"
+        "description": "8000 steps and 30 min exercise \u21d2 \u2248 470 kcal"
       },
       {
-        "description": "5000 steps and 60 min exercise ⇒ ≈ 620 kcal"
+        "description": "5000 steps and 60 min exercise \u21d2 \u2248 620 kcal"
       }
     ],
     "faqs": [
@@ -302,7 +302,7 @@
     "title": "Celsius to Fahrenheit",
     "cluster": "Conversions",
     "description": "Convert a temperature from Celsius into Fahrenheit.",
-    "intro": "This calculator converts temperatures in degrees Celsius to degrees Fahrenheit using the formula F = C × 9/5 + 32. Enter any Celsius value to see the equivalent Fahrenheit reading.",
+    "intro": "This calculator converts temperatures in degrees Celsius to degrees Fahrenheit using the formula F = C \u00d7 9/5 + 32. Enter any Celsius value to see the equivalent Fahrenheit reading.",
     "inputs": [
       {
         "name": "c",
@@ -313,13 +313,13 @@
       }
     ],
     "expression": "(c * 9/5) + 32",
-    "unit": "°F",
+    "unit": "\u00b0F",
     "examples": [
       {
-        "description": "0°C ⇒ 32°F"
+        "description": "0\u00b0C \u21d2 32\u00b0F"
       },
       {
-        "description": "37°C ⇒ 98.6°F"
+        "description": "37\u00b0C \u21d2 98.6\u00b0F"
       }
     ],
     "faqs": [
@@ -337,11 +337,11 @@
       },
       {
         "question": "How do I convert Fahrenheit to Celsius?",
-        "answer": "Use the Fahrenheit to Celsius calculator or apply C = (F - 32) × 5/9."
+        "answer": "Use the Fahrenheit to Celsius calculator or apply C = (F - 32) \u00d7 5/9."
       }
     ],
     "info": [
-      "Applies the precise formula F = C × 9/5 + 32, rounding results to a practical level.",
+      "Applies the precise formula F = C \u00d7 9/5 + 32, rounding results to a practical level.",
       "Note that Celsius is the international standard, while Fahrenheit is primarily used in the United States."
     ]
   },
@@ -363,7 +363,7 @@
     "expression": "km * 0.621371",
     "examples": [
       {
-        "description": "10 km ⇒ 6.21371 miles"
+        "description": "10 km \u21d2 6.21371 miles"
       }
     ],
     "faqs": [
@@ -394,7 +394,7 @@
     "expression": "meters * 3.28084",
     "examples": [
       {
-        "description": "2 m ⇒ 6.56168 ft"
+        "description": "2 m \u21d2 6.56168 ft"
       }
     ],
     "faqs": [
@@ -433,10 +433,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "From 50 to 70 ⇒ 40% increase"
+        "description": "From 50 to 70 \u21d2 40% increase"
       },
       {
-        "description": "From 80 to 100 ⇒ 25% increase"
+        "description": "From 80 to 100 \u21d2 25% increase"
       }
     ],
     "faqs": [
@@ -492,16 +492,16 @@
     "unit": "same as C",
     "examples": [
       {
-        "description": "2 books cost $10 ⇒ 5 books cost $25"
+        "description": "2 books cost $10 \u21d2 5 books cost $25"
       },
       {
-        "description": "3 kg correspond to $12 ⇒ 7 kg cost $28"
+        "description": "3 kg correspond to $12 \u21d2 7 kg cost $28"
       }
     ],
     "faqs": [
       {
         "question": "What is the rule of three?",
-        "answer": "It solves a proportion a:b = c:x by computing x = b × c / a."
+        "answer": "It solves a proportion a:b = c:x by computing x = b \u00d7 c / a."
       },
       {
         "question": "Can I use decimals?",
@@ -523,7 +523,7 @@
     "title": "Circle Area",
     "cluster": "Math",
     "description": "Calculate the area of a circle from its radius.",
-    "intro": "Determine the surface area enclosed by a circle using A = πr². Enter the radius to compute the area.",
+    "intro": "Determine the surface area enclosed by a circle using A = \u03c0r\u00b2. Enter the radius to compute the area.",
     "inputs": [
       {
         "name": "r",
@@ -535,19 +535,19 @@
       }
     ],
     "expression": "3.141592653589793 * r * r",
-    "unit": "units²",
+    "unit": "units\u00b2",
     "examples": [
       {
-        "description": "radius 3 m ⇒ 28.27 m²"
+        "description": "radius 3 m \u21d2 28.27 m\u00b2"
       },
       {
-        "description": "radius 10 cm ⇒ 314.16 cm²"
+        "description": "radius 10 cm \u21d2 314.16 cm\u00b2"
       }
     ],
     "faqs": [
       {
         "question": "What formula is used?",
-        "answer": "The area equals π times the radius squared."
+        "answer": "The area equals \u03c0 times the radius squared."
       },
       {
         "question": "Can I use the diameter instead?",
@@ -592,10 +592,10 @@
     "unit": "seconds",
     "examples": [
       {
-        "description": "700 MB at 50 Mbps ⇒ 112 s"
+        "description": "700 MB at 50 Mbps \u21d2 112 s"
       },
       {
-        "description": "1500 MB at 100 Mbps ⇒ 120 s"
+        "description": "1500 MB at 100 Mbps \u21d2 120 s"
       }
     ],
     "faqs": [
@@ -637,10 +637,10 @@
     "unit": "in",
     "examples": [
       {
-        "description": "10 cm ⇒ 3.94 in"
+        "description": "10 cm \u21d2 3.94 in"
       },
       {
-        "description": "25 cm ⇒ 9.84 in"
+        "description": "25 cm \u21d2 9.84 in"
       }
     ],
     "faqs": [
@@ -668,7 +668,7 @@
     "title": "Cylinder Volume Calculator",
     "cluster": "Math",
     "description": "Calculate the volume of a cylinder from radius and height.",
-    "intro": "Compute the volume of a cylinder using πr²h. Enter the radius and height in centimeters to get the volume in cubic centimeters.",
+    "intro": "Compute the volume of a cylinder using \u03c0r\u00b2h. Enter the radius and height in centimeters to get the volume in cubic centimeters.",
     "inputs": [
       {
         "name": "height",
@@ -686,19 +686,19 @@
       }
     ],
     "expression": "3.141592653589793 * radius ^ 2 * height",
-    "unit": "cm³",
+    "unit": "cm\u00b3",
     "examples": [
       {
-        "description": "radius 5 cm & height 10 cm ⇒ 785.40 cm³"
+        "description": "radius 5 cm & height 10 cm \u21d2 785.40 cm\u00b3"
       },
       {
-        "description": "radius 2 cm & height 4 cm ⇒ 50.27 cm³"
+        "description": "radius 2 cm & height 4 cm \u21d2 50.27 cm\u00b3"
       }
     ],
     "faqs": [
       {
         "question": "What formula is used?",
-        "answer": "Volume equals π times the radius squared times the height."
+        "answer": "Volume equals \u03c0 times the radius squared times the height."
       },
       {
         "question": "Can I use different units?",
@@ -731,13 +731,13 @@
       }
     ],
     "expression": "(f - 32) * 5 / 9",
-    "unit": "°C",
+    "unit": "\u00b0C",
     "examples": [
       {
-        "description": "32°F ⇒ 0°C"
+        "description": "32\u00b0F \u21d2 0\u00b0C"
       },
       {
-        "description": "68°F ⇒ 20°C"
+        "description": "68\u00b0F \u21d2 20\u00b0C"
       }
     ],
     "faqs": [
@@ -755,7 +755,7 @@
       },
       {
         "question": "How do I convert Celsius back to Fahrenheit?",
-        "answer": "Use the Celsius to Fahrenheit calculator or apply F = C × 9/5 + 32."
+        "answer": "Use the Celsius to Fahrenheit calculator or apply F = C \u00d7 9/5 + 32."
       }
     ],
     "info": []
@@ -788,10 +788,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "10 TB data with 5 TB redundancy ⇒ 50% overhead"
+        "description": "10 TB data with 5 TB redundancy \u21d2 50% overhead"
       },
       {
-        "description": "100 TB data with 20 TB redundancy ⇒ 20% overhead"
+        "description": "100 TB data with 20 TB redundancy \u21d2 20% overhead"
       }
     ],
     "faqs": [
@@ -850,10 +850,10 @@
     "unit": "seconds",
     "examples": [
       {
-        "description": "1h 30m 15s ⇒ 5415 seconds"
+        "description": "1h 30m 15s \u21d2 5415 seconds"
       },
       {
-        "description": "0h 45m 0s ⇒ 2700 seconds"
+        "description": "0h 45m 0s \u21d2 2700 seconds"
       }
     ],
     "faqs": [
@@ -894,7 +894,7 @@
     "expression": "days * 24",
     "examples": [
       {
-        "description": "3.5 days ⇒ 84 hours"
+        "description": "3.5 days \u21d2 84 hours"
       }
     ],
     "faqs": [
@@ -913,7 +913,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (m²)",
+        "label": "Area (m\u00b2)",
         "type": "number",
         "min": 0,
         "step": "any",
@@ -921,7 +921,7 @@
       },
       {
         "name": "coverage",
-        "label": "Coverage (m²/L)",
+        "label": "Coverage (m\u00b2/L)",
         "type": "number",
         "min": 0.1,
         "step": "any",
@@ -931,7 +931,7 @@
     "expression": "area / coverage",
     "examples": [
       {
-        "description": "100 m² at 12 m²/L ⇒ ≈ 8.33 L"
+        "description": "100 m\u00b2 at 12 m\u00b2/L \u21d2 \u2248 8.33 L"
       }
     ],
     "faqs": [
@@ -946,7 +946,7 @@
     "slug": "garden-soil-volume",
     "title": "Garden Soil Volume",
     "cluster": "home & diy",
-    "description": "Compute soil volume for a rectangular bed (m³).",
+    "description": "Compute soil volume for a rectangular bed (m\u00b3).",
     "inputs": [
       {
         "name": "length",
@@ -976,7 +976,7 @@
     "expression": "length * width * depth",
     "examples": [
       {
-        "description": "4×2×0.3 m ⇒ 2.4 m³"
+        "description": "4\u00d72\u00d70.3 m \u21d2 2.4 m\u00b3"
       }
     ],
     "faqs": [
@@ -1013,7 +1013,7 @@
     "expression": "bill * (1 + tip/100)",
     "examples": [
       {
-        "description": "$50 with 15% tip ⇒ $57.5"
+        "description": "$50 with 15% tip \u21d2 $57.5"
       }
     ],
     "faqs": [
@@ -1061,7 +1061,7 @@
     "expression": "(a + b + c) / 3",
     "examples": [
       {
-        "description": "80, 90, 70 ⇒ 80"
+        "description": "80, 90, 70 \u21d2 80"
       }
     ],
     "faqs": [
@@ -1099,10 +1099,10 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "Jogging at MET 7, 70 kg, 30 min ⇒ about 257 kcal"
+        "description": "Jogging at MET 7, 70 kg, 30 min \u21d2 about 257 kcal"
       },
       {
-        "description": "Cycling at MET 5, 80 kg, 45 min ⇒ about 315 kcal"
+        "description": "Cycling at MET 5, 80 kg, 45 min \u21d2 about 315 kcal"
       }
     ],
     "faqs": [
@@ -1140,7 +1140,7 @@
     "expression": "weight*0.033",
     "examples": [
       {
-        "description": "75 kg → ~2.48 liters/day"
+        "description": "75 kg \u2192 ~2.48 liters/day"
       }
     ],
     "faqs": [
@@ -1173,10 +1173,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "80 cm waist and 170 cm height ⇒ 0.47"
+        "description": "80 cm waist and 170 cm height \u21d2 0.47"
       },
       {
-        "description": "90 cm waist and 180 cm height ⇒ 0.50"
+        "description": "90 cm waist and 180 cm height \u21d2 0.50"
       }
     ],
     "faqs": [
@@ -1222,7 +1222,7 @@
     "expression": "(size_mb*8)/speed_mbps/60",
     "examples": [
       {
-        "description": "700 MB at 20 Mbps → ~4.67 minutes"
+        "description": "700 MB at 20 Mbps \u2192 ~4.67 minutes"
       }
     ],
     "faqs": [
@@ -1250,10 +1250,10 @@
     "unit": "MB",
     "examples": [
       {
-        "description": "2048 KB → 2 MB"
+        "description": "2048 KB \u2192 2 MB"
       },
       {
-        "description": "5000 KB → 4.88 MB"
+        "description": "5000 KB \u2192 4.88 MB"
       }
     ],
     "faqs": [
@@ -1299,7 +1299,7 @@
     "expression": "size_gb*price_per_gb",
     "examples": [
       {
-        "description": "10 GB at $0.10/GB → $1"
+        "description": "10 GB at $0.10/GB \u2192 $1"
       }
     ],
     "faqs": [
@@ -1330,7 +1330,7 @@
     "expression": "pixels/inches",
     "examples": [
       {
-        "description": "3000 px across 10 inches → 300 DPI"
+        "description": "3000 px across 10 inches \u2192 300 DPI"
       }
     ],
     "faqs": [
@@ -1400,10 +1400,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "2 years ⇒ 730 days"
+        "description": "2 years \u21d2 730 days"
       },
       {
-        "description": "3.5 years ⇒ 1277.5 days"
+        "description": "3.5 years \u21d2 1277.5 days"
       }
     ],
     "faqs": [
@@ -1434,12 +1434,12 @@
     "inputs": [
       {
         "name": "area",
-        "hint": "Wall area (m²)",
+        "hint": "Wall area (m\u00b2)",
         "placeholder": "Enter area"
       },
       {
         "name": "coverage",
-        "hint": "Coverage (m²/L)",
+        "hint": "Coverage (m\u00b2/L)",
         "placeholder": "Enter coverage"
       }
     ],
@@ -1461,12 +1461,12 @@
     "inputs": [
       {
         "name": "area",
-        "hint": "Area (m²)",
+        "hint": "Area (m\u00b2)",
         "placeholder": "50"
       },
       {
         "name": "cost",
-        "hint": "Cost per m² ($)",
+        "hint": "Cost per m\u00b2 ($)",
         "placeholder": "10"
       }
     ],
@@ -1474,16 +1474,16 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "50 m² at $10 per m² ⇒ $500"
+        "description": "50 m\u00b2 at $10 per m\u00b2 \u21d2 $500"
       },
       {
-        "description": "75 m² at $12 per m² ⇒ $900"
+        "description": "75 m\u00b2 at $12 per m\u00b2 \u21d2 $900"
       }
     ],
     "faqs": [
       {
         "question": "Does the price include installation?",
-        "answer": "No, it only multiplies area by cost per m²."
+        "answer": "No, it only multiplies area by cost per m\u00b2."
       },
       {
         "question": "Can I use square feet?",
@@ -1542,12 +1542,12 @@
     "inputs": [
       {
         "name": "wall_area",
-        "hint": "Wall area (m²)",
+        "hint": "Wall area (m\u00b2)",
         "placeholder": "Enter wall_area"
       },
       {
         "name": "roll_coverage",
-        "hint": "Coverage per roll (m²)",
+        "hint": "Coverage per roll (m\u00b2)",
         "placeholder": "Enter roll_coverage"
       }
     ],
@@ -1646,7 +1646,7 @@
     "expression": "Math.sqrt(a ** 2 + b ** 2)",
     "examples": [
       {
-        "description": "3 and 4 ⇒ 5"
+        "description": "3 and 4 \u21d2 5"
       }
     ],
     "faqs": [
@@ -1773,7 +1773,7 @@
     "expression": "s * 1.7018",
     "examples": [
       {
-        "description": "5 smoots ⇒ 8.509 m"
+        "description": "5 smoots \u21d2 8.509 m"
       }
     ],
     "faqs": [
@@ -1801,7 +1801,7 @@
     "expression": "h * 238.481",
     "examples": [
       {
-        "description": "1 hogshead ⇒ 238.481 L"
+        "description": "1 hogshead \u21d2 238.481 L"
       }
     ],
     "faqs": [
@@ -1829,7 +1829,7 @@
     "expression": "fpf * 201.168 / 1209600",
     "examples": [
       {
-        "description": "1000 fpf ⇒ 0.1663 m/s"
+        "description": "1000 fpf \u21d2 0.1663 m/s"
       }
     ],
     "faqs": [
@@ -1857,7 +1857,7 @@
     "expression": "sols * 1.027491",
     "examples": [
       {
-        "description": "3 sols ⇒ 3.0825 Earth days"
+        "description": "3 sols \u21d2 3.0825 Earth days"
       }
     ],
     "faqs": [
@@ -1885,7 +1885,7 @@
     "expression": "mf * 1.2096",
     "examples": [
       {
-        "description": "10 µfortnights ⇒ 12.096 s"
+        "description": "10 \u00b5fortnights \u21d2 12.096 s"
       }
     ],
     "faqs": [
@@ -1924,7 +1924,7 @@
     "expression": "s * f + (s - 1) * b",
     "examples": [
       {
-        "description": "4 sessions ⇒ 110 minutes"
+        "description": "4 sessions \u21d2 110 minutes"
       }
     ],
     "faqs": [
@@ -1959,10 +1959,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "$3,000 hardware cost with $10 daily profit ⇒ 300 days"
+        "description": "$3,000 hardware cost with $10 daily profit \u21d2 300 days"
       },
       {
-        "description": "$5,000 hardware cost with $25 daily profit ⇒ 200 days"
+        "description": "$5,000 hardware cost with $25 daily profit \u21d2 200 days"
       }
     ],
     "faqs": [
@@ -2018,16 +2018,16 @@
     "unit": "USD/hr",
     "examples": [
       {
-        "description": "$80k income, 30 h/week, 48 weeks ⇒ $55.56/hr"
+        "description": "$80k income, 30 h/week, 48 weeks \u21d2 $55.56/hr"
       },
       {
-        "description": "$50k income, 20 h/week, 40 weeks ⇒ $62.50/hr"
+        "description": "$50k income, 20 h/week, 40 weeks \u21d2 $62.50/hr"
       }
     ],
     "faqs": [
       {
         "question": "Why billable hours?",
-        "answer": "Non‑billable time isn't paid, so exclude it to price correctly."
+        "answer": "Non\u2011billable time isn't paid, so exclude it to price correctly."
       },
       {
         "question": "Should I include taxes and expenses?",
@@ -2071,10 +2071,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$20 monthly fee for 12 months ⇒ $240 LTV"
+        "description": "$20 monthly fee for 12 months \u21d2 $240 LTV"
       },
       {
-        "description": "$15 monthly fee for 24 months ⇒ $360 LTV"
+        "description": "$15 monthly fee for 24 months \u21d2 $360 LTV"
       }
     ],
     "faqs": [
@@ -2117,13 +2117,13 @@
     "expression": "(8 - hours) * 7",
     "examples": [
       {
-        "description": "6 h/night ⇒ 14 h debt"
+        "description": "6 h/night \u21d2 14 h debt"
       }
     ],
     "faqs": [
       {
         "question": "What if result is negative?",
-        "answer": "Negative means you exceed the 8‑hour recommendation."
+        "answer": "Negative means you exceed the 8\u2011hour recommendation."
       }
     ],
     "info": [
@@ -2148,7 +2148,7 @@
     "expression": "grams / 4",
     "examples": [
       {
-        "description": "16 g ⇒ 4 cubes"
+        "description": "16 g \u21d2 4 cubes"
       }
     ],
     "faqs": [
@@ -2181,7 +2181,7 @@
     "expression": "mg * (0.5 ^ (hrs / 5))",
     "examples": [
       {
-        "description": "200 mg after 5 h ⇒ 100 mg"
+        "description": "200 mg after 5 h \u21d2 100 mg"
       }
     ],
     "faqs": [
@@ -2192,7 +2192,7 @@
     ],
     "info": [
       "Real-world caffeine clearance varies widely with factors like age, liver function, medications, and pregnancy.",
-      "Treat results as a general estimate—genetics, smoking, and regular consumption also influence how fast caffeine leaves the body."
+      "Treat results as a general estimate\u2014genetics, smoking, and regular consumption also influence how fast caffeine leaves the body."
     ]
   },
   {
@@ -2203,7 +2203,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Roof area (m²)",
+        "label": "Roof area (m\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "50"
@@ -2226,7 +2226,7 @@
     "expression": "area * rain * (eff / 100) / 1000",
     "examples": [
       {
-        "description": "50 m², 20 mm, 80% ⇒ 0.8 m³"
+        "description": "50 m\u00b2, 20 mm, 80% \u21d2 0.8 m\u00b3"
       }
     ],
     "faqs": [
@@ -2266,7 +2266,7 @@
       },
       {
         "name": "density",
-        "label": "Soil density (kg/m³)",
+        "label": "Soil density (kg/m\u00b3)",
         "type": "number",
         "placeholder": "1200"
       }
@@ -2274,13 +2274,13 @@
     "expression": "length * width * depth * density",
     "examples": [
       {
-        "description": "2×1×0.5 m at 1200 kg/m³ ⇒ 1200 kg"
+        "description": "2\u00d71\u00d70.5 m at 1200 kg/m\u00b3 \u21d2 1200 kg"
       }
     ],
     "faqs": [
       {
         "question": "Why approximate density?",
-        "answer": "Different soils vary; 1200 kg/m³ is a common average."
+        "answer": "Different soils vary; 1200 kg/m\u00b3 is a common average."
       }
     ],
     "info": []
@@ -2293,7 +2293,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Wall area (m²)",
+        "label": "Wall area (m\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "10"
@@ -2314,7 +2314,7 @@
     "expression": "area / (length * height / 10000)",
     "examples": [
       {
-        "description": "10 m² wall, 20×6 cm bricks ⇒ ~833 bricks"
+        "description": "10 m\u00b2 wall, 20\u00d76 cm bricks \u21d2 ~833 bricks"
       }
     ],
     "faqs": [
@@ -2354,7 +2354,7 @@
     "expression": "a1 * (1 - r ^ n) / (1 - r)",
     "examples": [
       {
-        "description": "a1=2, r=0.5, n=4 ⇒ 3.75"
+        "description": "a1=2, r=0.5, n=4 \u21d2 3.75"
       }
     ],
     "faqs": [
@@ -2382,13 +2382,13 @@
     "expression": "2 * (area * 3.141592653589793) ^ 0.5",
     "examples": [
       {
-        "description": "Area 50 ⇒ 25.07 circumference"
+        "description": "Area 50 \u21d2 25.07 circumference"
       }
     ],
     "faqs": [
       {
         "question": "Why such a long number?",
-        "answer": "It's a high-precision value of π."
+        "answer": "It's a high-precision value of \u03c0."
       }
     ],
     "info": []
@@ -2424,7 +2424,7 @@
     "expression": "(( (a + b + c) / 2 * ((a + b + c) / 2 - a) * ((a + b + c) / 2 - b) * ((a + b + c) / 2 - c) ) ^ 0.5) / ((a + b + c) / 2)",
     "examples": [
       {
-        "description": "3-4-5 triangle ⇒ 1 radius"
+        "description": "3-4-5 triangle \u21d2 1 radius"
       }
     ],
     "faqs": [
@@ -2457,7 +2457,7 @@
     "expression": "capacity / draw",
     "examples": [
       {
-        "description": "3000 mAh at 150 mA ⇒ 20 h"
+        "description": "3000 mAh at 150 mA \u21d2 20 h"
       }
     ],
     "faqs": [
@@ -2490,7 +2490,7 @@
     "expression": "power / voltage",
     "examples": [
       {
-        "description": "95 W at 12 V ⇒ 7.92 A"
+        "description": "95 W at 12 V \u21d2 7.92 A"
       }
     ],
     "faqs": [
@@ -2525,10 +2525,10 @@
     "unit": "bytes",
     "examples": [
       {
-        "description": "100 Mbps with 50 ms ⇒ 625000 bytes"
+        "description": "100 Mbps with 50 ms \u21d2 625000 bytes"
       },
       {
-        "description": "10 Mbps with 100 ms ⇒ 125000 bytes"
+        "description": "10 Mbps with 100 ms \u21d2 125000 bytes"
       }
     ],
     "faqs": [
@@ -2577,7 +2577,7 @@
     "expression": "coffee * ratio",
     "examples": [
       {
-        "description": "30 g at 1:15 ⇒ 450 g water"
+        "description": "30 g at 1:15 \u21d2 450 g water"
       }
     ],
     "faqs": [
@@ -2610,13 +2610,13 @@
     "expression": "words / speed",
     "examples": [
       {
-        "description": "1200 words at 200 wpm ⇒ 6 minutes"
+        "description": "1200 words at 200 wpm \u21d2 6 minutes"
       }
     ],
     "faqs": [
       {
         "question": "Typical speed?",
-        "answer": "Around 200 words per minute for non‑technical texts."
+        "answer": "Around 200 words per minute for non\u2011technical texts."
       }
     ],
     "info": []
@@ -2643,7 +2643,7 @@
     "expression": "budget / days",
     "examples": [
       {
-        "description": "$1000 over 5 days ⇒ $200/day"
+        "description": "$1000 over 5 days \u21d2 $200/day"
       }
     ],
     "faqs": [
@@ -2678,10 +2678,10 @@
     "unit": "months",
     "examples": [
       {
-        "description": "$5,000 savings with $1,500 monthly expenses ⇒ 3.33 months"
+        "description": "$5,000 savings with $1,500 monthly expenses \u21d2 3.33 months"
       },
       {
-        "description": "$12,000 savings with $2,000 monthly expenses ⇒ 6 months"
+        "description": "$12,000 savings with $2,000 monthly expenses \u21d2 6 months"
       }
     ],
     "faqs": [
@@ -2731,10 +2731,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$40,000 yearly expenses at a 4% rate ⇒ $1,000,000"
+        "description": "$40,000 yearly expenses at a 4% rate \u21d2 $1,000,000"
       },
       {
-        "description": "$60,000 yearly expenses at a 3.5% rate ⇒ $1,714,286"
+        "description": "$60,000 yearly expenses at a 3.5% rate \u21d2 $1,714,286"
       }
     ],
     "faqs": [
@@ -2776,7 +2776,7 @@
     "expression": "(100/(100 - loss) - 1) * 100",
     "examples": [
       {
-        "description": "A 25% drop needs ≈33.33% gain"
+        "description": "A 25% drop needs \u224833.33% gain"
       }
     ],
     "faqs": [
@@ -2809,7 +2809,7 @@
     "expression": "(protein * 4) / calories * 100",
     "examples": [
       {
-        "description": "50 g protein in 2000 kcal ⇒ 10%"
+        "description": "50 g protein in 2000 kcal \u21d2 10%"
       }
     ],
     "faqs": [
@@ -2845,7 +2845,7 @@
     "expression": "(weight / ((height/100)^2)) / 25",
     "examples": [
       {
-        "description": "70 kg and 175 cm ⇒ 0.91"
+        "description": "70 kg and 175 cm \u21d2 0.91"
       }
     ],
     "faqs": [
@@ -2884,7 +2884,7 @@
     "expression": "(current - rest) / (max - rest) * 100",
     "examples": [
       {
-        "description": "Rest 60, max 190, current 150 ⇒ 69%"
+        "description": "Rest 60, max 190, current 150 \u21d2 69%"
       }
     ],
     "faqs": [
@@ -2903,7 +2903,7 @@
     "inputs": [
       {
         "name": "usv",
-        "label": "Dose (µSv)",
+        "label": "Dose (\u00b5Sv)",
         "type": "number",
         "placeholder": "1"
       }
@@ -2911,13 +2911,13 @@
     "expression": "usv / 0.1",
     "examples": [
       {
-        "description": "1 µSv ⇒ 10 bananas"
+        "description": "1 \u00b5Sv \u21d2 10 bananas"
       }
     ],
     "faqs": [
       {
         "question": "How much radiation is one banana?",
-        "answer": "About 0.1 µSv per banana."
+        "answer": "About 0.1 \u00b5Sv per banana."
       }
     ],
     "info": []
@@ -2938,7 +2938,7 @@
     "expression": "beards * 5e-9",
     "examples": [
       {
-        "description": "1 beard-second ⇒ 5e-9 m"
+        "description": "1 beard-second \u21d2 5e-9 m"
       }
     ],
     "faqs": [
@@ -2965,13 +2965,13 @@
     "expression": "shep * 1400",
     "examples": [
       {
-        "description": "1 sheppey ⇒ 1400 m"
+        "description": "1 sheppey \u21d2 1400 m"
       }
     ],
     "faqs": [
       {
         "question": "What's a sheppey?",
-        "answer": "A whimsical unit equal to about 1.4 km—the distance at which sheep remain picturesque."
+        "answer": "A whimsical unit equal to about 1.4 km\u2014the distance at which sheep remain picturesque."
       }
     ],
     "info": []
@@ -3004,7 +3004,7 @@
     "expression": "(((a + b + c)/2) * ((a + b + c)/2 - a) * ((a + b + c)/2 - b) * ((a + b + c)/2 - c))^(0.5)",
     "examples": [
       {
-        "description": "3,4,5 ⇒ 6"
+        "description": "3,4,5 \u21d2 6"
       }
     ],
     "faqs": [
@@ -3023,25 +3023,25 @@
     "inputs": [
       {
         "name": "x1",
-        "label": "x₁",
+        "label": "x\u2081",
         "type": "number",
         "placeholder": "0"
       },
       {
         "name": "y1",
-        "label": "y₁",
+        "label": "y\u2081",
         "type": "number",
         "placeholder": "0"
       },
       {
         "name": "x2",
-        "label": "x₂",
+        "label": "x\u2082",
         "type": "number",
         "placeholder": "3"
       },
       {
         "name": "y2",
-        "label": "y₂",
+        "label": "y\u2082",
         "type": "number",
         "placeholder": "4"
       }
@@ -3049,7 +3049,7 @@
     "expression": "((x2 - x1)^2 + (y2 - y1)^2)^(0.5)",
     "examples": [
       {
-        "description": "(0,0) to (3,4) ⇒ 5"
+        "description": "(0,0) to (3,4) \u21d2 5"
       }
     ],
     "faqs": [
@@ -3067,7 +3067,7 @@
     "slug": "polygon-diagonals",
     "title": "Polygon Diagonals Calculator",
     "cluster": "math",
-    "intro": "Number of diagonals in an n‑sided polygon.",
+    "intro": "Number of diagonals in an n\u2011sided polygon.",
     "inputs": [
       {
         "name": "n",
@@ -3079,7 +3079,7 @@
     "expression": "n * (n - 3) / 2",
     "examples": [
       {
-        "description": "Hexagon ⇒ 9 diagonals"
+        "description": "Hexagon \u21d2 9 diagonals"
       }
     ],
     "faqs": [
@@ -3108,10 +3108,10 @@
     "unit": "km",
     "examples": [
       {
-        "description": "50 ms ⇒ ~7,494 km"
+        "description": "50 ms \u21d2 ~7,494 km"
       },
       {
-        "description": "20 ms ⇒ ~2,998 km"
+        "description": "20 ms \u21d2 ~2,998 km"
       }
     ],
     "faqs": [
@@ -3166,7 +3166,7 @@
     "expression": "((width^2 + height^2)^(0.5)) / diagonal",
     "examples": [
       {
-        "description": "1920×1080 at 24\" ⇒ ~92 PPI"
+        "description": "1920\u00d71080 at 24\" \u21d2 ~92 PPI"
       }
     ],
     "faqs": [
@@ -3199,13 +3199,13 @@
     "expression": "tbw * 1000 / (daily * 365)",
     "examples": [
       {
-        "description": "600 TBW with 50 GB/day ⇒ 32.9 years"
+        "description": "600 TBW with 50 GB/day \u21d2 32.9 years"
       }
     ],
     "faqs": [
       {
         "question": "What is TBW?",
-        "answer": "Terabytes written—an endurance rating for SSDs."
+        "answer": "Terabytes written\u2014an endurance rating for SSDs."
       }
     ],
     "info": []
@@ -3226,7 +3226,7 @@
     "expression": "years / 1.8808",
     "examples": [
       {
-        "description": "5 Earth years ⇒ 2.66 Mars years"
+        "description": "5 Earth years \u21d2 2.66 Mars years"
       }
     ],
     "faqs": [
@@ -3253,7 +3253,7 @@
     "expression": "jiffies / 60",
     "examples": [
       {
-        "description": "120 jiffies ⇒ 2 seconds"
+        "description": "120 jiffies \u21d2 2 seconds"
       }
     ],
     "faqs": [
@@ -3280,7 +3280,7 @@
     "expression": "sidereal * 23.9344696",
     "examples": [
       {
-        "description": "1 sidereal day ⇒ 23.93 h"
+        "description": "1 sidereal day \u21d2 23.93 h"
       }
     ],
     "faqs": [
@@ -3313,7 +3313,7 @@
     "expression": "volume / flow",
     "examples": [
       {
-        "description": "200 L at 10 L/min ⇒ 20 min"
+        "description": "200 L at 10 L/min \u21d2 20 min"
       }
     ],
     "faqs": [
@@ -3352,7 +3352,7 @@
     "expression": "length * wpm / voltage",
     "examples": [
       {
-        "description": "5 m at 14 W/m on 12 V ⇒ 5.83 A"
+        "description": "5 m at 14 W/m on 12 V \u21d2 5.83 A"
       }
     ],
     "faqs": [
@@ -3397,7 +3397,7 @@
     "expression": "(roomL * roomW) / (tileL * tileW)",
     "examples": [
       {
-        "description": "4×3 m with 0.3×0.3 m tiles ⇒ 133.33 tiles"
+        "description": "4\u00d73 m with 0.3\u00d70.3 m tiles \u21d2 133.33 tiles"
       }
     ],
     "faqs": [
@@ -3430,7 +3430,7 @@
     "expression": "desired / original",
     "examples": [
       {
-        "description": "4 to 6 servings ⇒ factor 1.5"
+        "description": "4 to 6 servings \u21d2 factor 1.5"
       }
     ],
     "faqs": [
@@ -3457,7 +3457,7 @@
     "expression": "360 / slices",
     "examples": [
       {
-        "description": "8 slices ⇒ 45° each"
+        "description": "8 slices \u21d2 45\u00b0 each"
       }
     ],
     "faqs": [
@@ -3490,7 +3490,7 @@
     "expression": "people * minutes",
     "examples": [
       {
-        "description": "5 people at 3 min ⇒ 15 minutes"
+        "description": "5 people at 3 min \u21d2 15 minutes"
       }
     ],
     "faqs": [
@@ -3560,10 +3560,10 @@
     "expression": "nm * 1.852",
     "examples": [
       {
-        "description": "1 nmi ⇒ 1.85 km"
+        "description": "1 nmi \u21d2 1.85 km"
       },
       {
-        "description": "50 nmi ⇒ 92.6 km"
+        "description": "50 nmi \u21d2 92.6 km"
       }
     ],
     "faqs": [
@@ -3595,10 +3595,10 @@
     "expression": "bits / 8",
     "examples": [
       {
-        "description": "8 bits ⇒ 1 byte"
+        "description": "8 bits \u21d2 1 byte"
       },
       {
-        "description": "1024 bits ⇒ 128 bytes"
+        "description": "1024 bits \u21d2 128 bytes"
       }
     ],
     "faqs": [
@@ -3608,7 +3608,7 @@
       },
       {
         "question": "Does this handle large numbers?",
-        "answer": "Yes, enter any non‑negative numeric value."
+        "answer": "Yes, enter any non\u2011negative numeric value."
       }
     ],
     "info": []
@@ -3630,10 +3630,10 @@
     "expression": "seconds / 604800",
     "examples": [
       {
-        "description": "604800 seconds ⇒ 1 week"
+        "description": "604800 seconds \u21d2 1 week"
       },
       {
-        "description": "1209600 seconds ⇒ 2 weeks"
+        "description": "1209600 seconds \u21d2 2 weeks"
       }
     ],
     "faqs": [
@@ -3665,10 +3665,10 @@
     "expression": "distance_km / 299792.458",
     "examples": [
       {
-        "description": "299,792.458 km ⇒ 1 s"
+        "description": "299,792.458 km \u21d2 1 s"
       },
       {
-        "description": "384,400 km ⇒ 1.28 s"
+        "description": "384,400 km \u21d2 1.28 s"
       }
     ],
     "faqs": [
@@ -3707,10 +3707,10 @@
     "expression": "(loan / value) * 100",
     "examples": [
       {
-        "description": "150000 / 200000 ⇒ 75%"
+        "description": "150000 / 200000 \u21d2 75%"
       },
       {
-        "description": "80000 / 100000 ⇒ 80%"
+        "description": "80000 / 100000 \u21d2 80%"
       }
     ],
     "faqs": [
@@ -3749,10 +3749,10 @@
     "expression": "(income / equity) * 100",
     "examples": [
       {
-        "description": "50000 / 250000 ⇒ 20%"
+        "description": "50000 / 250000 \u21d2 20%"
       },
       {
-        "description": "75000 / 300000 ⇒ 25%"
+        "description": "75000 / 300000 \u21d2 25%"
       }
     ],
     "faqs": [
@@ -3784,10 +3784,10 @@
     "expression": "220 - age",
     "examples": [
       {
-        "description": "Age 30 ⇒ 190 bpm"
+        "description": "Age 30 \u21d2 190 bpm"
       },
       {
-        "description": "Age 50 ⇒ 170 bpm"
+        "description": "Age 50 \u21d2 170 bpm"
       }
     ],
     "faqs": [
@@ -3819,10 +3819,10 @@
     "expression": "weight_kg * 0.8",
     "examples": [
       {
-        "description": "70 kg ⇒ 56 g"
+        "description": "70 kg \u21d2 56 g"
       },
       {
-        "description": "90 kg ⇒ 72 g"
+        "description": "90 kg \u21d2 72 g"
       }
     ],
     "faqs": [
@@ -3875,10 +3875,10 @@
     "expression": "(deck_length * deck_width) / (board_length * board_width)",
     "examples": [
       {
-        "description": "6×4 m deck with 2×0.15 m boards ⇒ 80 boards"
+        "description": "6\u00d74 m deck with 2\u00d70.15 m boards \u21d2 80 boards"
       },
       {
-        "description": "5×5 m deck with 2.5×0.1 m boards ⇒ 100 boards"
+        "description": "5\u00d75 m deck with 2.5\u00d70.1 m boards \u21d2 100 boards"
       }
     ],
     "faqs": [
@@ -3917,10 +3917,10 @@
     "expression": "3.141592653589793 * (diameter/2)^2 * depth",
     "examples": [
       {
-        "description": "0.3 m × 0.6 m ⇒ 0.042 m³"
+        "description": "0.3 m \u00d7 0.6 m \u21d2 0.042 m\u00b3"
       },
       {
-        "description": "0.2 m × 0.8 m ⇒ 0.025 m³"
+        "description": "0.2 m \u00d7 0.8 m \u21d2 0.025 m\u00b3"
       }
     ],
     "faqs": [
@@ -3952,16 +3952,16 @@
     "expression": "(4/3) * 3.141592653589793 * radius^3",
     "examples": [
       {
-        "description": "r = 1 ⇒ 4.19"
+        "description": "r = 1 \u21d2 4.19"
       },
       {
-        "description": "r = 3 ⇒ 113.10"
+        "description": "r = 3 \u21d2 113.10"
       }
     ],
     "faqs": [
       {
         "question": "What is the formula?",
-        "answer": "4/3 × π × r³."
+        "answer": "4/3 \u00d7 \u03c0 \u00d7 r\u00b3."
       },
       {
         "question": "Are units cubed?",
@@ -3985,7 +3985,7 @@
       },
       {
         "name": "angle",
-        "label": "Angle (°)",
+        "label": "Angle (\u00b0)",
         "type": "number",
         "step": "any",
         "placeholder": "90"
@@ -3994,10 +3994,10 @@
     "expression": "3.141592653589793 * radius^2 * angle / 360",
     "examples": [
       {
-        "description": "r = 5, angle = 90° ⇒ 19.63"
+        "description": "r = 5, angle = 90\u00b0 \u21d2 19.63"
       },
       {
-        "description": "r = 3, angle = 45° ⇒ 3.53"
+        "description": "r = 3, angle = 45\u00b0 \u21d2 3.53"
       }
     ],
     "faqs": [
@@ -4006,7 +4006,7 @@
         "answer": "Degrees."
       },
       {
-        "question": "What if the angle is 360°?",
+        "question": "What if the angle is 360\u00b0?",
         "answer": "The area equals that of the full circle."
       }
     ],
@@ -4029,10 +4029,10 @@
     "expression": "2^(32 - prefix) - 2",
     "examples": [
       {
-        "description": "/24 ⇒ 254 hosts"
+        "description": "/24 \u21d2 254 hosts"
       },
       {
-        "description": "/16 ⇒ 65534 hosts"
+        "description": "/16 \u21d2 65534 hosts"
       }
     ],
     "faqs": [
@@ -4071,10 +4071,10 @@
     "expression": "bitrate * duration * 60 / 8",
     "examples": [
       {
-        "description": "5 Mbps for 10 min ⇒ 375 MB"
+        "description": "5 Mbps for 10 min \u21d2 375 MB"
       },
       {
-        "description": "8 Mbps for 60 min ⇒ 3600 MB"
+        "description": "8 Mbps for 60 min \u21d2 3600 MB"
       }
     ],
     "faqs": [
@@ -4113,10 +4113,10 @@
     "expression": "price / mpg",
     "examples": [
       {
-        "description": "$3.50 and 25 mpg ⇒ $0.14/mi"
+        "description": "$3.50 and 25 mpg \u21d2 $0.14/mi"
       },
       {
-        "description": "$4.20 and 30 mpg ⇒ $0.14/mi"
+        "description": "$4.20 and 30 mpg \u21d2 $0.14/mi"
       }
     ],
     "faqs": [
@@ -4155,16 +4155,16 @@
     "expression": "flow_rate * minutes",
     "examples": [
       {
-        "description": "9 L/min × 5 min ⇒ 45 L"
+        "description": "9 L/min \u00d7 5 min \u21d2 45 L"
       },
       {
-        "description": "12 L/min × 10 min ⇒ 120 L"
+        "description": "12 L/min \u00d7 10 min \u21d2 120 L"
       }
     ],
     "faqs": [
       {
         "question": "Typical shower flow rate?",
-        "answer": "Around 9–12 liters per minute."
+        "answer": "Around 9\u201312 liters per minute."
       },
       {
         "question": "How can I reduce usage?",
@@ -4224,10 +4224,10 @@
     "expression": "oz * 29.5735",
     "examples": [
       {
-        "description": "3 oz ⇒ 88.72 mL"
+        "description": "3 oz \u21d2 88.72 mL"
       },
       {
-        "description": "12 oz ⇒ 354.88 mL"
+        "description": "12 oz \u21d2 354.88 mL"
       }
     ],
     "faqs": [
@@ -4268,10 +4268,10 @@
     "expression": "235.215 / mpg",
     "examples": [
       {
-        "description": "30 mpg ⇒ 7.84 L/100km"
+        "description": "30 mpg \u21d2 7.84 L/100km"
       },
       {
-        "description": "50 mpg ⇒ 4.70 L/100km"
+        "description": "50 mpg \u21d2 4.70 L/100km"
       }
     ],
     "faqs": [
@@ -4330,10 +4330,10 @@
     "expression": "(days * 24 + depart) - arrival",
     "examples": [
       {
-        "description": "Arrival 9, departure 14, days 0 ⇒ 5 hours"
+        "description": "Arrival 9, departure 14, days 0 \u21d2 5 hours"
       },
       {
-        "description": "Arrival 22, departure 7, days 1 ⇒ 9 hours"
+        "description": "Arrival 22, departure 7, days 1 \u21d2 9 hours"
       }
     ],
     "faqs": [
@@ -4384,10 +4384,10 @@
     "expression": "end - start",
     "examples": [
       {
-        "description": "Start 120, end 127 ⇒ 7 days"
+        "description": "Start 120, end 127 \u21d2 7 days"
       },
       {
-        "description": "Start 200, end 205 ⇒ 5 days"
+        "description": "Start 200, end 205 \u21d2 5 days"
       }
     ],
     "faqs": [
@@ -4444,10 +4444,10 @@
     "expression": "bill * (tip / 100) * rate",
     "examples": [
       {
-        "description": "€50 bill, 15% tip, rate 1.1 ⇒ 8.25 home currency"
+        "description": "\u20ac50 bill, 15% tip, rate 1.1 \u21d2 8.25 home currency"
       },
       {
-        "description": "¥2000 bill, 10% tip, rate 0.007 ⇒ 14 home currency"
+        "description": "\u00a52000 bill, 10% tip, rate 0.007 \u21d2 14 home currency"
       }
     ],
     "faqs": [
@@ -4504,10 +4504,10 @@
     "expression": "rate * nights * (1 + tax / 100)",
     "examples": [
       {
-        "description": "$120, 3 nights, 10% tax ⇒ $396"
+        "description": "$120, 3 nights, 10% tax \u21d2 $396"
       },
       {
-        "description": "$80, 5 nights, 8% tax ⇒ $432"
+        "description": "$80, 5 nights, 8% tax \u21d2 $432"
       }
     ],
     "faqs": [
@@ -4556,10 +4556,10 @@
     "expression": "hours * rate",
     "examples": [
       {
-        "description": "5 h, 0.25 L/h ⇒ 1.25 L"
+        "description": "5 h, 0.25 L/h \u21d2 1.25 L"
       },
       {
-        "description": "8 h, 0.2 L/h ⇒ 1.6 L"
+        "description": "8 h, 0.2 L/h \u21d2 1.6 L"
       }
     ],
     "faqs": [
@@ -4600,10 +4600,10 @@
     "expression": "zones / 2",
     "examples": [
       {
-        "description": "6 zones ⇒ 3 days"
+        "description": "6 zones \u21d2 3 days"
       },
       {
-        "description": "3 zones ⇒ 1.5 days"
+        "description": "3 zones \u21d2 1.5 days"
       }
     ],
     "faqs": [
@@ -4660,10 +4660,10 @@
     "expression": "(length * width * height) / 1000",
     "examples": [
       {
-        "description": "55×40×20 cm ⇒ 44 L"
+        "description": "55\u00d740\u00d720 cm \u21d2 44 L"
       },
       {
-        "description": "70×50×30 cm ⇒ 105 L"
+        "description": "70\u00d750\u00d730 cm \u21d2 105 L"
       }
     ],
     "faqs": [
@@ -4712,10 +4712,10 @@
     "expression": "garments * spacing",
     "examples": [
       {
-        "description": "8 garments, 0.15 m spacing ⇒ 1.2 m"
+        "description": "8 garments, 0.15 m spacing \u21d2 1.2 m"
       },
       {
-        "description": "5 garments, 0.2 m spacing ⇒ 1 m"
+        "description": "5 garments, 0.2 m spacing \u21d2 1 m"
       }
     ],
     "faqs": [
@@ -4764,10 +4764,10 @@
     "expression": "(rise / run) * 100",
     "examples": [
       {
-        "description": "300 m rise over 2000 m run ⇒ 15%"
+        "description": "300 m rise over 2000 m run \u21d2 15%"
       },
       {
-        "description": "100 m rise over 1000 m run ⇒ 10%"
+        "description": "100 m rise over 1000 m run \u21d2 10%"
       }
     ],
     "faqs": [
@@ -4832,10 +4832,10 @@
     "expression": "(distance / speed) + (stops * stopTime)",
     "examples": [
       {
-        "description": "600 km at 100 km/h with 2 stops of 0.5 h ⇒ 7 h"
+        "description": "600 km at 100 km/h with 2 stops of 0.5 h \u21d2 7 h"
       },
       {
-        "description": "300 km at 75 km/h with 1 stop of 0.25 h ⇒ 4.25 h"
+        "description": "300 km at 75 km/h with 1 stop of 0.25 h \u21d2 4.25 h"
       }
     ],
     "faqs": [
@@ -4893,10 +4893,10 @@
     "expression": "(bank * (eff / 100)) / device",
     "examples": [
       {
-        "description": "10000 mAh bank, 3000 mAh device, 85% ⇒ 2.83 charges"
+        "description": "10000 mAh bank, 3000 mAh device, 85% \u21d2 2.83 charges"
       },
       {
-        "description": "20000 mAh bank, 4000 mAh device, 90% ⇒ 4.5 charges"
+        "description": "20000 mAh bank, 4000 mAh device, 90% \u21d2 4.5 charges"
       }
     ],
     "faqs": [
@@ -4945,10 +4945,10 @@
     "expression": "data * price",
     "examples": [
       {
-        "description": "500 MB at 0.02 ⇒ 10"
+        "description": "500 MB at 0.02 \u21d2 10"
       },
       {
-        "description": "200 MB at 0.05 ⇒ 10"
+        "description": "200 MB at 0.05 \u21d2 10"
       }
     ],
     "faqs": [
@@ -4975,7 +4975,7 @@
     "slug": "flight-carbon-footprint",
     "title": "Flight Carbon Footprint",
     "cluster": "other",
-    "description": "Estimate CO₂ emissions from a flight.",
+    "description": "Estimate CO\u2082 emissions from a flight.",
     "inputs": [
       {
         "name": "distance",
@@ -4997,16 +4997,16 @@
     "expression": "distance * factor",
     "examples": [
       {
-        "description": "1000 km at 0.115 ⇒ 115 kg CO₂"
+        "description": "1000 km at 0.115 \u21d2 115 kg CO\u2082"
       },
       {
-        "description": "5000 km at 0.115 ⇒ 575 kg CO₂"
+        "description": "5000 km at 0.115 \u21d2 575 kg CO\u2082"
       }
     ],
     "faqs": [
       {
         "question": "What emission factor is used?",
-        "answer": "0.115 kg CO₂ per passenger-km is a common estimate."
+        "answer": "0.115 kg CO\u2082 per passenger-km is a common estimate."
       },
       {
         "question": "Does this include radiative forcing?",
@@ -5049,10 +5049,10 @@
     "expression": "limit - current",
     "examples": [
       {
-        "description": "Limit 23 kg, current 17 kg ⇒ 6 kg left"
+        "description": "Limit 23 kg, current 17 kg \u21d2 6 kg left"
       },
       {
-        "description": "Limit 20 kg, current 19.5 kg ⇒ 0.5 kg left"
+        "description": "Limit 20 kg, current 19.5 kg \u21d2 0.5 kg left"
       }
     ],
     "faqs": [
@@ -5094,10 +5094,10 @@
     "unit": "L",
     "examples": [
       {
-        "description": "1 gal ⇒ 3.79 L"
+        "description": "1 gal \u21d2 3.79 L"
       },
       {
-        "description": "5 gal ⇒ 18.93 L"
+        "description": "5 gal \u21d2 18.93 L"
       }
     ],
     "faqs": [
@@ -5140,10 +5140,10 @@
     "unit": "MJ",
     "examples": [
       {
-        "description": "1 kWh ⇒ 3.6 MJ"
+        "description": "1 kWh \u21d2 3.6 MJ"
       },
       {
-        "description": "5 kWh ⇒ 18 MJ"
+        "description": "5 kWh \u21d2 18 MJ"
       }
     ],
     "faqs": [
@@ -5186,10 +5186,10 @@
     "unit": "min",
     "examples": [
       {
-        "description": "120 s ⇒ 2 min"
+        "description": "120 s \u21d2 2 min"
       },
       {
-        "description": "90 s ⇒ 1.5 min"
+        "description": "90 s \u21d2 1.5 min"
       }
     ],
     "faqs": [
@@ -5232,16 +5232,16 @@
     "unit": "s",
     "examples": [
       {
-        "description": "1 week ⇒ 604,800 s"
+        "description": "1 week \u21d2 604,800 s"
       },
       {
-        "description": "2.5 weeks ⇒ 1,512,000 s"
+        "description": "2.5 weeks \u21d2 1,512,000 s"
       }
     ],
     "faqs": [
       {
         "question": "Why 604,800 seconds per week?",
-        "answer": "It's 7 days × 24 hours × 60 minutes × 60 seconds."
+        "answer": "It's 7 days \u00d7 24 hours \u00d7 60 minutes \u00d7 60 seconds."
       },
       {
         "question": "Does it handle fractional weeks?",
@@ -5286,10 +5286,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Dividend 2, Price 40 ⇒ 5%"
+        "description": "Dividend 2, Price 40 \u21d2 5%"
       },
       {
-        "description": "Dividend 1.5, Price 30 ⇒ 5%"
+        "description": "Dividend 1.5, Price 30 \u21d2 5%"
       }
     ],
     "faqs": [
@@ -5348,10 +5348,10 @@
     "unit": "per year",
     "examples": [
       {
-        "description": "Cost 10000, Salvage 1000, Life 5 ⇒ 1800 per year"
+        "description": "Cost 10000, Salvage 1000, Life 5 \u21d2 1800 per year"
       },
       {
-        "description": "Cost 5000, Salvage 500, Life 10 ⇒ 450 per year"
+        "description": "Cost 5000, Salvage 500, Life 10 \u21d2 450 per year"
       }
     ],
     "faqs": [
@@ -5394,10 +5394,10 @@
     "unit": "g",
     "examples": [
       {
-        "description": "2000 kcal ⇒ 28 g"
+        "description": "2000 kcal \u21d2 28 g"
       },
       {
-        "description": "1500 kcal ⇒ 21 g"
+        "description": "1500 kcal \u21d2 21 g"
       }
     ],
     "faqs": [
@@ -5448,10 +5448,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Fat 20 g, Calories 500 ⇒ 36%"
+        "description": "Fat 20 g, Calories 500 \u21d2 36%"
       },
       {
-        "description": "Fat 10 g, Calories 300 ⇒ 30%"
+        "description": "Fat 10 g, Calories 300 \u21d2 30%"
       }
     ],
     "faqs": [
@@ -5502,10 +5502,10 @@
     "unit": "BTU",
     "examples": [
       {
-        "description": "Area 250 sq ft, BTU 20 ⇒ 5000 BTU"
+        "description": "Area 250 sq ft, BTU 20 \u21d2 5000 BTU"
       },
       {
-        "description": "Area 400 sq ft, BTU 25 ⇒ 10000 BTU"
+        "description": "Area 400 sq ft, BTU 25 \u21d2 10000 BTU"
       }
     ],
     "faqs": [
@@ -5556,10 +5556,10 @@
     "unit": "bundles",
     "examples": [
       {
-        "description": "Area 1500 sq ft, Coverage 33 ⇒ 45.45 bundles"
+        "description": "Area 1500 sq ft, Coverage 33 \u21d2 45.45 bundles"
       },
       {
-        "description": "Area 2000 sq ft, Coverage 25 ⇒ 80 bundles"
+        "description": "Area 2000 sq ft, Coverage 25 \u21d2 80 bundles"
       }
     ],
     "faqs": [
@@ -5591,28 +5591,28 @@
     "inputs": [
       {
         "name": "x1",
-        "label": "x₁",
+        "label": "x\u2081",
         "type": "number",
         "step": "any",
         "placeholder": "1"
       },
       {
         "name": "y1",
-        "label": "y₁",
+        "label": "y\u2081",
         "type": "number",
         "step": "any",
         "placeholder": "2"
       },
       {
         "name": "x2",
-        "label": "x₂",
+        "label": "x\u2082",
         "type": "number",
         "step": "any",
         "placeholder": "4"
       },
       {
         "name": "y2",
-        "label": "y₂",
+        "label": "y\u2082",
         "type": "number",
         "step": "any",
         "placeholder": "6"
@@ -5622,15 +5622,15 @@
     "unit": "slope",
     "examples": [
       {
-        "description": "(1,2) to (4,6) ⇒ 4/3"
+        "description": "(1,2) to (4,6) \u21d2 4/3"
       },
       {
-        "description": "(0,0) to (5,5) ⇒ 1"
+        "description": "(0,0) to (5,5) \u21d2 1"
       }
     ],
     "faqs": [
       {
-        "question": "What if x₂ equals x₁?",
+        "question": "What if x\u2082 equals x\u2081?",
         "answer": "The slope is undefined because division by zero occurs."
       },
       {
@@ -5675,10 +5675,10 @@
     "unit": "value",
     "examples": [
       {
-        "description": "Value 27, n 3 ⇒ 3"
+        "description": "Value 27, n 3 \u21d2 3"
       },
       {
-        "description": "Value 16, n 4 ⇒ 2"
+        "description": "Value 16, n 4 \u21d2 2"
       }
     ],
     "faqs": [
@@ -5729,10 +5729,10 @@
     "unit": "MH/s per W",
     "examples": [
       {
-        "description": "500 MH/s at 100 W ⇒ 5 MH/s per W"
+        "description": "500 MH/s at 100 W \u21d2 5 MH/s per W"
       },
       {
-        "description": "120 MH/s at 60 W ⇒ 2 MH/s per W"
+        "description": "120 MH/s at 60 W \u21d2 2 MH/s per W"
       }
     ],
     "faqs": [
@@ -5783,10 +5783,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Output 400 W, Input 500 W ⇒ 80%"
+        "description": "Output 400 W, Input 500 W \u21d2 80%"
       },
       {
-        "description": "Output 300 W, Input 360 W ⇒ 83.33%"
+        "description": "Output 300 W, Input 360 W \u21d2 83.33%"
       }
     ],
     "faqs": [
@@ -5846,10 +5846,10 @@
     "unit": "m",
     "examples": [
       {
-        "description": "Outer 10 cm, Core 4 cm, Thickness 0.1 mm ⇒ 2356 m"
+        "description": "Outer 10 cm, Core 4 cm, Thickness 0.1 mm \u21d2 2356 m"
       },
       {
-        "description": "Outer 8 cm, Core 3 cm, Thickness 0.12 mm ⇒ 1222 m"
+        "description": "Outer 8 cm, Core 3 cm, Thickness 0.12 mm \u21d2 1222 m"
       }
     ],
     "faqs": [
@@ -5903,10 +5903,10 @@
     "unit": "min",
     "examples": [
       {
-        "description": "Time 60 min, Factor 0.75 ⇒ 45 min"
+        "description": "Time 60 min, Factor 0.75 \u21d2 45 min"
       },
       {
-        "description": "Time 40 min, Factor 0.7 ⇒ 28 min"
+        "description": "Time 40 min, Factor 0.7 \u21d2 28 min"
       }
     ],
     "faqs": [
@@ -5920,7 +5920,7 @@
       },
       {
         "question": "Does temperature change too?",
-        "answer": "Usually reduce temperature by 25°F."
+        "answer": "Usually reduce temperature by 25\u00b0F."
       },
       {
         "question": "Is this for baking and roasting?",
@@ -5948,10 +5948,10 @@
     "unit": "kg",
     "examples": [
       {
-        "description": "150 lb ⇒ 68.04 kg"
+        "description": "150 lb \u21d2 68.04 kg"
       },
       {
-        "description": "10 lb ⇒ 4.54 kg"
+        "description": "10 lb \u21d2 4.54 kg"
       }
     ],
     "faqs": [
@@ -5983,20 +5983,20 @@
     "inputs": [
       {
         "name": "sqft",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "100"
       }
     ],
     "expression": "sqft * 0.092903",
-    "unit": "m²",
+    "unit": "m\u00b2",
     "examples": [
       {
-        "description": "100 ft² ⇒ 9.29 m²"
+        "description": "100 ft\u00b2 \u21d2 9.29 m\u00b2"
       },
       {
-        "description": "250 ft² ⇒ 23.23 m²"
+        "description": "250 ft\u00b2 \u21d2 23.23 m\u00b2"
       }
     ],
     "faqs": [
@@ -6038,10 +6038,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "1 year ⇒ 365.25 days"
+        "description": "1 year \u21d2 365.25 days"
       },
       {
-        "description": "30 years ⇒ 10,957.5 days"
+        "description": "30 years \u21d2 10,957.5 days"
       }
     ],
     "faqs": [
@@ -6083,10 +6083,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "86,400 s ⇒ 1 day"
+        "description": "86,400 s \u21d2 1 day"
       },
       {
-        "description": "172,800 s ⇒ 2 days"
+        "description": "172,800 s \u21d2 2 days"
       }
     ],
     "faqs": [
@@ -6135,10 +6135,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1,000 balance at 18% APR ⇒ $15.00"
+        "description": "$1,000 balance at 18% APR \u21d2 $15.00"
       },
       {
-        "description": "$5,000 balance at 22% APR ⇒ $91.67"
+        "description": "$5,000 balance at 22% APR \u21d2 $91.67"
       }
     ],
     "faqs": [
@@ -6187,10 +6187,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$500 balance on $2,000 limit ⇒ 25%"
+        "description": "$500 balance on $2,000 limit \u21d2 25%"
       },
       {
-        "description": "$1,200 balance on $1,500 limit ⇒ 80%"
+        "description": "$1,200 balance on $1,500 limit \u21d2 80%"
       }
     ],
     "faqs": [
@@ -6253,10 +6253,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "70 kg, 175 cm, age 30, male ⇒ 18.22%"
+        "description": "70 kg, 175 cm, age 30, male \u21d2 18.22%"
       },
       {
-        "description": "60 kg, 165 cm, age 25, female ⇒ 24.22%"
+        "description": "60 kg, 165 cm, age 25, female \u21d2 24.22%"
       }
     ],
     "faqs": [
@@ -6305,10 +6305,10 @@
     "unit": "kg",
     "examples": [
       {
-        "description": "100 kg for 5 reps ⇒ 116.67 kg"
+        "description": "100 kg for 5 reps \u21d2 116.67 kg"
       },
       {
-        "description": "50 kg for 10 reps ⇒ 66.67 kg"
+        "description": "50 kg for 10 reps \u21d2 66.67 kg"
       }
     ],
     "faqs": [
@@ -6354,13 +6354,13 @@
       }
     ],
     "expression": "Math.atan(rise / run) * (180/Math.PI)",
-    "unit": "°",
+    "unit": "\u00b0",
     "examples": [
       {
-        "description": "Rise 4, Run 12 ⇒ 18.43°"
+        "description": "Rise 4, Run 12 \u21d2 18.43\u00b0"
       },
       {
-        "description": "Rise 6, Run 12 ⇒ 26.57°"
+        "description": "Rise 6, Run 12 \u21d2 26.57\u00b0"
       }
     ],
     "faqs": [
@@ -6399,7 +6399,7 @@
       },
       {
         "name": "rise",
-        "label": "Temperature Rise (°F)",
+        "label": "Temperature Rise (\u00b0F)",
         "type": "number",
         "step": "any",
         "placeholder": "70"
@@ -6416,10 +6416,10 @@
     "unit": "h",
     "examples": [
       {
-        "description": "40 gal, 70°F rise, 40,000 BTU ⇒ 0.58 h"
+        "description": "40 gal, 70\u00b0F rise, 40,000 BTU \u21d2 0.58 h"
       },
       {
-        "description": "50 gal, 60°F rise, 30,000 BTU ⇒ 0.83 h"
+        "description": "50 gal, 60\u00b0F rise, 30,000 BTU \u21d2 0.83 h"
       }
     ],
     "faqs": [
@@ -6475,10 +6475,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "1, 5, 3 ⇒ 3"
+        "description": "1, 5, 3 \u21d2 3"
       },
       {
-        "description": "10, 20, 15 ⇒ 15"
+        "description": "10, 20, 15 \u21d2 15"
       }
     ],
     "faqs": [
@@ -6527,10 +6527,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "a=1, b=4 ⇒ -2"
+        "description": "a=1, b=4 \u21d2 -2"
       },
       {
-        "description": "a=2, b=-8 ⇒ 2"
+        "description": "a=2, b=-8 \u21d2 2"
       }
     ],
     "faqs": [
@@ -6548,7 +6548,7 @@
       },
       {
         "question": "Can I find y too?",
-        "answer": "Use y = c - b²/(4a) once you know a, b, and c."
+        "answer": "Use y = c - b\u00b2/(4a) once you know a, b, and c."
       }
     ],
     "disclaimer": "Provides only the x-coordinate; verify calculations in complex cases.",
@@ -6586,10 +6586,10 @@
     "unit": "h",
     "examples": [
       {
-        "description": "3000 mAh with 1000 mA at 90% ⇒ 3.33 h"
+        "description": "3000 mAh with 1000 mA at 90% \u21d2 3.33 h"
       },
       {
-        "description": "2000 mAh with 500 mA at 85% ⇒ 4.71 h"
+        "description": "2000 mAh with 500 mA at 85% \u21d2 4.71 h"
       }
     ],
     "faqs": [
@@ -6631,7 +6631,7 @@
       },
       {
         "name": "resistance",
-        "label": "Resistance (Ω)",
+        "label": "Resistance (\u03a9)",
         "type": "number",
         "step": "any",
         "placeholder": "6"
@@ -6641,16 +6641,16 @@
     "unit": "A",
     "examples": [
       {
-        "description": "12 V and 6 Ω ⇒ 2 A"
+        "description": "12 V and 6 \u03a9 \u21d2 2 A"
       },
       {
-        "description": "5 V and 10 Ω ⇒ 0.5 A"
+        "description": "5 V and 10 \u03a9 \u21d2 0.5 A"
       }
     ],
     "faqs": [
       {
         "question": "What is Ohm's Law?",
-        "answer": "It states that voltage = current × resistance."
+        "answer": "It states that voltage = current \u00d7 resistance."
       },
       {
         "question": "Can resistance be zero?",
@@ -6686,10 +6686,10 @@
     "unit": "years",
     "examples": [
       {
-        "description": "1 year ⇒ 12 human years"
+        "description": "1 year \u21d2 12 human years"
       },
       {
-        "description": "5 years ⇒ 36 human years"
+        "description": "5 years \u21d2 36 human years"
       }
     ],
     "faqs": [
@@ -6738,10 +6738,10 @@
     "unit": "pages",
     "examples": [
       {
-        "description": "50,000 words at 300 wpp ⇒ 167 pages"
+        "description": "50,000 words at 300 wpp \u21d2 167 pages"
       },
       {
-        "description": "8,000 words at 250 wpp ⇒ 32 pages"
+        "description": "8,000 words at 250 wpp \u21d2 32 pages"
       }
     ],
     "faqs": [
@@ -6783,13 +6783,13 @@
     "unit": "cm",
     "examples": [
       {
-        "description": "10 in ⇒ 25.4 cm"
+        "description": "10 in \u21d2 25.4 cm"
       },
       {
-        "description": "5.5 in ⇒ 13.97 cm"
+        "description": "5.5 in \u21d2 13.97 cm"
       },
       {
-        "description": "0.25 in ⇒ 0.635 cm"
+        "description": "0.25 in \u21d2 0.635 cm"
       }
     ],
     "faqs": [
@@ -6827,13 +6827,13 @@
     "unit": "st",
     "examples": [
       {
-        "description": "140 lb ⇒ 10 st"
+        "description": "140 lb \u21d2 10 st"
       },
       {
-        "description": "200 lb ⇒ 14.29 st"
+        "description": "200 lb \u21d2 14.29 st"
       },
       {
-        "description": "90 lb ⇒ 6.43 st"
+        "description": "90 lb \u21d2 6.43 st"
       }
     ],
     "faqs": [
@@ -6871,13 +6871,13 @@
     "unit": "seconds",
     "examples": [
       {
-        "description": "1 day ⇒ 86400 seconds"
+        "description": "1 day \u21d2 86400 seconds"
       },
       {
-        "description": "2.5 days ⇒ 216000 seconds"
+        "description": "2.5 days \u21d2 216000 seconds"
       },
       {
-        "description": "0.1 day ⇒ 8640 seconds"
+        "description": "0.1 day \u21d2 8640 seconds"
       }
     ],
     "faqs": [
@@ -6915,13 +6915,13 @@
     "unit": "months",
     "examples": [
       {
-        "description": "5 years ⇒ 60 months"
+        "description": "5 years \u21d2 60 months"
       },
       {
-        "description": "0.5 years ⇒ 6 months"
+        "description": "0.5 years \u21d2 6 months"
       },
       {
-        "description": "25 years ⇒ 300 months"
+        "description": "25 years \u21d2 300 months"
       }
     ],
     "faqs": [
@@ -6966,13 +6966,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Revenue $1000, COGS $600 ⇒ 40%"
+        "description": "Revenue $1000, COGS $600 \u21d2 40%"
       },
       {
-        "description": "Revenue $250, COGS $200 ⇒ 20%"
+        "description": "Revenue $250, COGS $200 \u21d2 20%"
       },
       {
-        "description": "Revenue $5000, COGS $3500 ⇒ 30%"
+        "description": "Revenue $5000, COGS $3500 \u21d2 30%"
       }
     ],
     "faqs": [
@@ -7024,13 +7024,13 @@
     "unit": "units",
     "examples": [
       {
-        "description": "Fixed $1000, Price $50, Variable $30 ⇒ 50 units"
+        "description": "Fixed $1000, Price $50, Variable $30 \u21d2 50 units"
       },
       {
-        "description": "Fixed $5000, Price $100, Variable $60 ⇒ 125 units"
+        "description": "Fixed $5000, Price $100, Variable $60 \u21d2 125 units"
       },
       {
-        "description": "Fixed $2000, Price $80, Variable $40 ⇒ 50 units"
+        "description": "Fixed $2000, Price $80, Variable $40 \u21d2 50 units"
       }
     ],
     "faqs": [
@@ -7075,13 +7075,13 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "Maintenance 2500 kcal, Deficit 500 ⇒ 2000 kcal"
+        "description": "Maintenance 2500 kcal, Deficit 500 \u21d2 2000 kcal"
       },
       {
-        "description": "Maintenance 2000 kcal, Deficit 300 ⇒ 1700 kcal"
+        "description": "Maintenance 2000 kcal, Deficit 300 \u21d2 1700 kcal"
       },
       {
-        "description": "Maintenance 2800 kcal, Deficit 1000 ⇒ 1800 kcal"
+        "description": "Maintenance 2800 kcal, Deficit 1000 \u21d2 1800 kcal"
       }
     ],
     "faqs": [
@@ -7123,16 +7123,16 @@
       }
     ],
     "expression": "0.007184 * Math.pow(weight,0.425) * Math.pow(height,0.725)",
-    "unit": "m²",
+    "unit": "m\u00b2",
     "examples": [
       {
-        "description": "70 kg & 170 cm ⇒ 1.84 m²"
+        "description": "70 kg & 170 cm \u21d2 1.84 m\u00b2"
       },
       {
-        "description": "50 kg & 160 cm ⇒ 1.48 m²"
+        "description": "50 kg & 160 cm \u21d2 1.48 m\u00b2"
       },
       {
-        "description": "90 kg & 180 cm ⇒ 2.08 m²"
+        "description": "90 kg & 180 cm \u21d2 2.08 m\u00b2"
       }
     ],
     "faqs": [
@@ -7177,13 +7177,13 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "500 bricks at $0.75 ⇒ $375"
+        "description": "500 bricks at $0.75 \u21d2 $375"
       },
       {
-        "description": "1000 bricks at $0.50 ⇒ $500"
+        "description": "1000 bricks at $0.50 \u21d2 $500"
       },
       {
-        "description": "250 bricks at $1.20 ⇒ $300"
+        "description": "250 bricks at $1.20 \u21d2 $300"
       }
     ],
     "faqs": [
@@ -7211,7 +7211,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (m²)",
+        "label": "Area (m\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "100"
@@ -7235,19 +7235,19 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "100 m², 2 cm, 15 L/min ⇒ 133.33 minutes"
+        "description": "100 m\u00b2, 2 cm, 15 L/min \u21d2 133.33 minutes"
       },
       {
-        "description": "50 m², 1 cm, 10 L/min ⇒ 50 minutes"
+        "description": "50 m\u00b2, 1 cm, 10 L/min \u21d2 50 minutes"
       },
       {
-        "description": "200 m², 2.5 cm, 20 L/min ⇒ 250 minutes"
+        "description": "200 m\u00b2, 2.5 cm, 20 L/min \u21d2 250 minutes"
       }
     ],
     "faqs": [
       {
         "question": "Why multiply by 10?",
-        "answer": "1 m² × 1 cm equals 10 liters of water."
+        "answer": "1 m\u00b2 \u00d7 1 cm equals 10 liters of water."
       },
       {
         "question": "Can I use gallons?",
@@ -7290,16 +7290,16 @@
       }
     ],
     "expression": "length * width * height",
-    "unit": "unit³",
+    "unit": "unit\u00b3",
     "examples": [
       {
-        "description": "2 × 3 × 4 ⇒ 24 unit³"
+        "description": "2 \u00d7 3 \u00d7 4 \u21d2 24 unit\u00b3"
       },
       {
-        "description": "5 × 5 × 5 ⇒ 125 unit³"
+        "description": "5 \u00d7 5 \u00d7 5 \u21d2 125 unit\u00b3"
       },
       {
-        "description": "1.5 × 2 × 3 ⇒ 9 unit³"
+        "description": "1.5 \u00d7 2 \u00d7 3 \u21d2 9 unit\u00b3"
       }
     ],
     "faqs": [
@@ -7334,16 +7334,16 @@
       }
     ],
     "expression": "(3 * Math.sqrt(3) / 2) * side * side",
-    "unit": "unit²",
+    "unit": "unit\u00b2",
     "examples": [
       {
-        "description": "Side 2 ⇒ 10.39 unit²"
+        "description": "Side 2 \u21d2 10.39 unit\u00b2"
       },
       {
-        "description": "Side 5 ⇒ 64.95 unit²"
+        "description": "Side 5 \u21d2 64.95 unit\u00b2"
       },
       {
-        "description": "Side 10 ⇒ 259.81 unit²"
+        "description": "Side 10 \u21d2 259.81 unit\u00b2"
       }
     ],
     "faqs": [
@@ -7385,16 +7385,16 @@
       }
     ],
     "expression": "voltage / current",
-    "unit": "Ω",
+    "unit": "\u03a9",
     "examples": [
       {
-        "description": "10 V / 2 A ⇒ 5 Ω"
+        "description": "10 V / 2 A \u21d2 5 \u03a9"
       },
       {
-        "description": "5 V / 0.5 A ⇒ 10 Ω"
+        "description": "5 V / 0.5 A \u21d2 10 \u03a9"
       },
       {
-        "description": "12 V / 3 A ⇒ 4 Ω"
+        "description": "12 V / 3 A \u21d2 4 \u03a9"
       }
     ],
     "faqs": [
@@ -7404,7 +7404,7 @@
       },
       {
         "question": "What unit is the result?",
-        "answer": "Ohms (Ω)."
+        "answer": "Ohms (\u03a9)."
       },
       {
         "question": "Does this apply to AC and DC?",
@@ -7432,13 +7432,13 @@
     "unit": "colors",
     "examples": [
       {
-        "description": "8 bits ⇒ 256 colors"
+        "description": "8 bits \u21d2 256 colors"
       },
       {
-        "description": "16 bits ⇒ 65536 colors"
+        "description": "16 bits \u21d2 65536 colors"
       },
       {
-        "description": "24 bits ⇒ 16777216 colors"
+        "description": "24 bits \u21d2 16777216 colors"
       }
     ],
     "faqs": [
@@ -7476,13 +7476,13 @@
     "unit": "years",
     "examples": [
       {
-        "description": "1 year ⇒ 6.5 human years"
+        "description": "1 year \u21d2 6.5 human years"
       },
       {
-        "description": "5 years ⇒ 26.5 human years"
+        "description": "5 years \u21d2 26.5 human years"
       },
       {
-        "description": "10 years ⇒ 49 human years"
+        "description": "10 years \u21d2 49 human years"
       }
     ],
     "faqs": [
@@ -7527,13 +7527,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "1 die (6 sides) ⇒ 16.67%"
+        "description": "1 die (6 sides) \u21d2 16.67%"
       },
       {
-        "description": "2 dice (6 sides) ⇒ 30.56%"
+        "description": "2 dice (6 sides) \u21d2 30.56%"
       },
       {
-        "description": "3 dice (20 sides) ⇒ 14.26%"
+        "description": "3 dice (20 sides) \u21d2 14.26%"
       }
     ],
     "faqs": [
@@ -7571,10 +7571,10 @@
     "unit": "W",
     "examples": [
       {
-        "description": "1000 BTU/hr ⇒ 293.07 W"
+        "description": "1000 BTU/hr \u21d2 293.07 W"
       },
       {
-        "description": "5000 BTU/hr ⇒ 1465.36 W"
+        "description": "5000 BTU/hr \u21d2 1465.36 W"
       }
     ],
     "faqs": [
@@ -7616,10 +7616,10 @@
     "unit": "Hz",
     "examples": [
       {
-        "description": "120 RPM ⇒ 2 Hz"
+        "description": "120 RPM \u21d2 2 Hz"
       },
       {
-        "description": "3600 RPM ⇒ 60 Hz"
+        "description": "3600 RPM \u21d2 60 Hz"
       }
     ],
     "faqs": [
@@ -7675,10 +7675,10 @@
     "unit": "weekday index",
     "examples": [
       {
-        "description": "2023-09-01 ⇒ 5"
+        "description": "2023-09-01 \u21d2 5"
       },
       {
-        "description": "2000-01-01 ⇒ 6"
+        "description": "2000-01-01 \u21d2 6"
       }
     ],
     "faqs": [
@@ -7755,10 +7755,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "2024-01-01 to 2024-01-31 ⇒ 30 days"
+        "description": "2024-01-01 to 2024-01-31 \u21d2 30 days"
       },
       {
-        "description": "2020-02-01 to 2020-03-01 ⇒ 29 days"
+        "description": "2020-02-01 to 2020-03-01 \u21d2 29 days"
       }
     ],
     "faqs": [
@@ -7814,16 +7814,16 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$20/hr × 5 hrs × 1.5 ⇒ $150"
+        "description": "$20/hr \u00d7 5 hrs \u00d7 1.5 \u21d2 $150"
       },
       {
-        "description": "$15/hr × 10 hrs × 2 ⇒ $300"
+        "description": "$15/hr \u00d7 10 hrs \u00d7 2 \u21d2 $300"
       }
     ],
     "faqs": [
       {
         "question": "What is an overtime multiplier?",
-        "answer": "It's the factor by which overtime hours are paid, such as 1.5× for time-and-a-half."
+        "answer": "It's the factor by which overtime hours are paid, such as 1.5\u00d7 for time-and-a-half."
       },
       {
         "question": "Does this include taxes or deductions?",
@@ -7873,10 +7873,10 @@
     "unit": "months",
     "examples": [
       {
-        "description": "$10,000 target, $200 monthly, 2% APR ⇒ 48.0 months"
+        "description": "$10,000 target, $200 monthly, 2% APR \u21d2 48.0 months"
       },
       {
-        "description": "$5,000 target, $300 monthly, 0% APR ⇒ 16.67 months"
+        "description": "$5,000 target, $300 monthly, 0% APR \u21d2 16.67 months"
       }
     ],
     "faqs": [
@@ -7939,10 +7939,10 @@
     "unit": "kcal/day",
     "examples": [
       {
-        "description": "70kg, 175cm, 30y, male ⇒ 1648.8 kcal/day"
+        "description": "70kg, 175cm, 30y, male \u21d2 1648.8 kcal/day"
       },
       {
-        "description": "60kg, 160cm, 25y, female ⇒ 1314 kcal/day"
+        "description": "60kg, 160cm, 25y, female \u21d2 1314 kcal/day"
       }
     ],
     "faqs": [
@@ -7991,10 +7991,10 @@
     "unit": "g/day",
     "examples": [
       {
-        "description": "70 kg at 0.8 g/kg ⇒ 56 g/day"
+        "description": "70 kg at 0.8 g/kg \u21d2 56 g/day"
       },
       {
-        "description": "80 kg at 1.2 g/kg ⇒ 96 g/day"
+        "description": "80 kg at 1.2 g/kg \u21d2 96 g/day"
       }
     ],
     "faqs": [
@@ -8004,7 +8004,7 @@
       },
       {
         "question": "Can the factor exceed 1?",
-        "answer": "Yes, active individuals often use 1.2–2.0 g/kg."
+        "answer": "Yes, active individuals often use 1.2\u20132.0 g/kg."
       },
       {
         "question": "Does this account for age or health conditions?",
@@ -8050,10 +8050,10 @@
     "unit": "gallons",
     "examples": [
       {
-        "description": "10 ft × 5 in × 4 in ⇒ 10.39 gallons"
+        "description": "10 ft \u00d7 5 in \u00d7 4 in \u21d2 10.39 gallons"
       },
       {
-        "description": "20 ft × 6 in × 4 in ⇒ 24.94 gallons"
+        "description": "20 ft \u00d7 6 in \u00d7 4 in \u21d2 24.94 gallons"
       }
     ],
     "faqs": [
@@ -8102,10 +8102,10 @@
     "unit": "steps",
     "examples": [
       {
-        "description": "96 in total rise at 7.5 in ⇒ 13 steps"
+        "description": "96 in total rise at 7.5 in \u21d2 13 steps"
       },
       {
-        "description": "108 in total rise at 7 in ⇒ 16 steps"
+        "description": "108 in total rise at 7 in \u21d2 16 steps"
       }
     ],
     "faqs": [
@@ -8119,7 +8119,7 @@
       },
       {
         "question": "What is a typical rise per step?",
-        "answer": "Most building codes allow 7–8 inches per step."
+        "answer": "Most building codes allow 7\u20138 inches per step."
       },
       {
         "question": "Should local codes be checked?",
@@ -8144,7 +8144,7 @@
       },
       {
         "name": "angle",
-        "label": "Angle (°)",
+        "label": "Angle (\u00b0)",
         "type": "number",
         "step": "any",
         "placeholder": "60"
@@ -8154,10 +8154,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "r=5, angle=60° ⇒ 5.24 units"
+        "description": "r=5, angle=60\u00b0 \u21d2 5.24 units"
       },
       {
-        "description": "r=10, angle=90° ⇒ 15.71 units"
+        "description": "r=10, angle=90\u00b0 \u21d2 15.71 units"
       }
     ],
     "faqs": [
@@ -8166,7 +8166,7 @@
         "answer": "Degrees; convert from radians if necessary."
       },
       {
-        "question": "Can the angle exceed 360°?",
+        "question": "Can the angle exceed 360\u00b0?",
         "answer": "Yes, the formula works for any positive angle."
       },
       {
@@ -8175,7 +8175,7 @@
       },
       {
         "question": "Is the arc length always less than the circumference?",
-        "answer": "If angle is ≤360°, yes; larger angles yield multiple laps."
+        "answer": "If angle is \u2264360\u00b0, yes; larger angles yield multiple laps."
       }
     ],
     "disclaimer": "Ideal geometric calculation; ensure measurements are accurate.",
@@ -8196,13 +8196,13 @@
       }
     ],
     "expression": "(sides - 2) * 180",
-    "unit": "°",
+    "unit": "\u00b0",
     "examples": [
       {
-        "description": "3 sides ⇒ 180°"
+        "description": "3 sides \u21d2 180\u00b0"
       },
       {
-        "description": "6 sides ⇒ 720°"
+        "description": "6 sides \u21d2 720\u00b0"
       }
     ],
     "faqs": [
@@ -8220,7 +8220,7 @@
       },
       {
         "question": "Why multiply by 180?",
-        "answer": "Each triangle has 180°, and a polygon can be divided into (n−2) triangles."
+        "answer": "Each triangle has 180\u00b0, and a polygon can be divided into (n\u22122) triangles."
       }
     ],
     "disclaimer": "Pure geometric formula; ensure the figure is a simple polygon.",
@@ -8251,10 +8251,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "10 MB / 2 MB ⇒ 5 ratio"
+        "description": "10 MB / 2 MB \u21d2 5 ratio"
       },
       {
-        "description": "50 MB / 20 MB ⇒ 2.5 ratio"
+        "description": "50 MB / 20 MB \u21d2 2.5 ratio"
       }
     ],
     "faqs": [
@@ -8296,10 +8296,10 @@
     "unit": "ns",
     "examples": [
       {
-        "description": "1000 MHz ⇒ 1 ns"
+        "description": "1000 MHz \u21d2 1 ns"
       },
       {
-        "description": "3200 MHz ⇒ 0.31 ns"
+        "description": "3200 MHz \u21d2 0.31 ns"
       }
     ],
     "faqs": [
@@ -8331,7 +8331,7 @@
     "inputs": [
       {
         "name": "temperature",
-        "label": "Temperature (°F)",
+        "label": "Temperature (\u00b0F)",
         "type": "number",
         "step": "any",
         "placeholder": "30"
@@ -8345,19 +8345,19 @@
       }
     ],
     "expression": "35.74 + 0.6215*temperature - 35.75*(wind**0.16) + 0.4275*temperature*(wind**0.16)",
-    "unit": "°F",
+    "unit": "\u00b0F",
     "examples": [
       {
-        "description": "30°F & 10 mph ⇒ 21.25°F"
+        "description": "30\u00b0F & 10 mph \u21d2 21.25\u00b0F"
       },
       {
-        "description": "0°F & 20 mph ⇒ -22.00°F"
+        "description": "0\u00b0F & 20 mph \u21d2 -22.00\u00b0F"
       }
     ],
     "faqs": [
       {
         "question": "When is this formula valid?",
-        "answer": "For temperatures at or below 50°F and winds above 3 mph."
+        "answer": "For temperatures at or below 50\u00b0F and winds above 3 mph."
       },
       {
         "question": "Does sunshine affect wind chill?",
@@ -8379,11 +8379,11 @@
     "slug": "tree-carbon-offset",
     "title": "Tree Carbon Offset Calculator",
     "cluster": "Other",
-    "description": "Estimate trees needed to offset CO₂ emissions.",
+    "description": "Estimate trees needed to offset CO\u2082 emissions.",
     "inputs": [
       {
         "name": "co2",
-        "label": "CO₂ Emissions (kg/yr)",
+        "label": "CO\u2082 Emissions (kg/yr)",
         "type": "number",
         "step": "any",
         "placeholder": "100"
@@ -8393,16 +8393,16 @@
     "unit": "trees",
     "examples": [
       {
-        "description": "100 kg CO₂ ⇒ 4.59 trees"
+        "description": "100 kg CO\u2082 \u21d2 4.59 trees"
       },
       {
-        "description": "1000 kg CO₂ ⇒ 45.92 trees"
+        "description": "1000 kg CO\u2082 \u21d2 45.92 trees"
       }
     ],
     "faqs": [
       {
         "question": "What absorption rate is assumed?",
-        "answer": "Each tree is estimated to absorb 21.77 kg of CO₂ per year."
+        "answer": "Each tree is estimated to absorb 21.77 kg of CO\u2082 per year."
       },
       {
         "question": "Do different species absorb different amounts?",
@@ -8424,7 +8424,7 @@
     "slug": "electronvolt-to-joule",
     "title": "Electronvolt to Joule Converter",
     "cluster": "Conversions",
-    "intro": "Convert electronvolt energy to joules using the factor 1 eV = 1.602176634×10⁻¹⁹ J. Enter eV and press Calculate.",
+    "intro": "Convert electronvolt energy to joules using the factor 1 eV = 1.602176634\u00d710\u207b\u00b9\u2079 J. Enter eV and press Calculate.",
     "inputs": [
       {
         "name": "ev",
@@ -8438,10 +8438,10 @@
     "unit": "J",
     "examples": [
       {
-        "description": "1 eV ⇒ 1.60e-19 J"
+        "description": "1 eV \u21d2 1.60e-19 J"
       },
       {
-        "description": "5 eV ⇒ 8.01e-19 J"
+        "description": "5 eV \u21d2 8.01e-19 J"
       }
     ],
     "faqs": [
@@ -8483,10 +8483,10 @@
     "unit": "mph",
     "examples": [
       {
-        "description": "10 ft/s ⇒ 6.82 mph"
+        "description": "10 ft/s \u21d2 6.82 mph"
       },
       {
-        "description": "88 ft/s ⇒ 60 mph"
+        "description": "88 ft/s \u21d2 60 mph"
       }
     ],
     "faqs": [
@@ -8542,10 +8542,10 @@
     "unit": "week",
     "examples": [
       {
-        "description": "2023-09-01 ⇒ 35"
+        "description": "2023-09-01 \u21d2 35"
       },
       {
-        "description": "2025-01-01 ⇒ 1"
+        "description": "2025-01-01 \u21d2 1"
       }
     ],
     "faqs": [
@@ -8554,7 +8554,7 @@
         "answer": "It's a standard where weeks start on Monday and week 1 is the week with the year's first Thursday."
       },
       {
-        "question": "Are week numbers always 1–52?",
+        "question": "Are week numbers always 1\u201352?",
         "answer": "Some years have 53 ISO weeks."
       },
       {
@@ -8594,10 +8594,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "February 2024 ⇒ 29 days"
+        "description": "February 2024 \u21d2 29 days"
       },
       {
-        "description": "April 2025 ⇒ 30 days"
+        "description": "April 2025 \u21d2 30 days"
       }
     ],
     "faqs": [
@@ -8646,10 +8646,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$1000 cost, $1200 gain ⇒ 20%"
+        "description": "$1000 cost, $1200 gain \u21d2 20%"
       },
       {
-        "description": "$5000 cost, $4500 gain ⇒ -10%"
+        "description": "$5000 cost, $4500 gain \u21d2 -10%"
       }
     ],
     "faqs": [
@@ -8698,10 +8698,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$2000 debt, $5000 income ⇒ 40%"
+        "description": "$2000 debt, $5000 income \u21d2 40%"
       },
       {
-        "description": "$1500 debt, $3000 income ⇒ 50%"
+        "description": "$1500 debt, $3000 income \u21d2 50%"
       }
     ],
     "faqs": [
@@ -8750,10 +8750,10 @@
     "unit": "kg",
     "examples": [
       {
-        "description": "70 in, base 50 ⇒ 73.0 kg"
+        "description": "70 in, base 50 \u21d2 73.0 kg"
       },
       {
-        "description": "64 in, base 45.5 ⇒ 60.7 kg"
+        "description": "64 in, base 45.5 \u21d2 60.7 kg"
       }
     ],
     "faqs": [
@@ -8802,10 +8802,10 @@
     "unit": "bpm",
     "examples": [
       {
-        "description": "Age 30 at 70% ⇒ 133 bpm"
+        "description": "Age 30 at 70% \u21d2 133 bpm"
       },
       {
-        "description": "Age 40 at 85% ⇒ 153 bpm"
+        "description": "Age 40 at 85% \u21d2 153 bpm"
       }
     ],
     "faqs": [
@@ -8815,7 +8815,7 @@
       },
       {
         "question": "What intensity should I use?",
-        "answer": "Use 50–85% for moderate to vigorous exercise."
+        "answer": "Use 50\u201385% for moderate to vigorous exercise."
       },
       {
         "question": "Is the formula accurate for everyone?",
@@ -8861,16 +8861,16 @@
     "unit": "board ft",
     "examples": [
       {
-        "description": "2×6×96 in ⇒ 8 board ft"
+        "description": "2\u00d76\u00d796 in \u21d2 8 board ft"
       },
       {
-        "description": "1×10×120 in ⇒ 8.33 board ft"
+        "description": "1\u00d710\u00d7120 in \u21d2 8.33 board ft"
       }
     ],
     "faqs": [
       {
         "question": "What is a board foot?",
-        "answer": "A volume of lumber equal to 1 in × 12 in × 12 in."
+        "answer": "A volume of lumber equal to 1 in \u00d7 12 in \u00d7 12 in."
       },
       {
         "question": "Can I use metric units?",
@@ -8896,7 +8896,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Wall Area (ft²)",
+        "label": "Wall Area (ft\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "500"
@@ -8920,10 +8920,10 @@
     "unit": "sheets",
     "examples": [
       {
-        "description": "500 ft² area with 4×8 ft sheets ⇒ 15.63 sheets"
+        "description": "500 ft\u00b2 area with 4\u00d78 ft sheets \u21d2 15.63 sheets"
       },
       {
-        "description": "800 ft² area with 4×12 ft sheets ⇒ 16.67 sheets"
+        "description": "800 ft\u00b2 area with 4\u00d712 ft sheets \u21d2 16.67 sheets"
       }
     ],
     "faqs": [
@@ -8965,10 +8965,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "5 ⇒ 120"
+        "description": "5 \u21d2 120"
       },
       {
-        "description": "3 ⇒ 6"
+        "description": "3 \u21d2 6"
       }
     ],
     "faqs": [
@@ -9017,10 +9017,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "48 & 18 ⇒ 6"
+        "description": "48 & 18 \u21d2 6"
       },
       {
-        "description": "21 & 14 ⇒ 7"
+        "description": "21 & 14 \u21d2 7"
       }
     ],
     "faqs": [
@@ -9062,10 +9062,10 @@
     "unit": "hosts",
     "examples": [
       {
-        "description": "/24 ⇒ 254 hosts"
+        "description": "/24 \u21d2 254 hosts"
       },
       {
-        "description": "/30 ⇒ 2 hosts"
+        "description": "/30 \u21d2 2 hosts"
       }
     ],
     "faqs": [
@@ -9114,10 +9114,10 @@
     "unit": "TB",
     "examples": [
       {
-        "description": "4 drives at 2 TB ⇒ 6 TB"
+        "description": "4 drives at 2 TB \u21d2 6 TB"
       },
       {
-        "description": "6 drives at 4 TB ⇒ 20 TB"
+        "description": "6 drives at 4 TB \u21d2 20 TB"
       }
     ],
     "faqs": [
@@ -9159,10 +9159,10 @@
     "unit": "km",
     "examples": [
       {
-        "description": "3 s ⇒ 1.03 km"
+        "description": "3 s \u21d2 1.03 km"
       },
       {
-        "description": "5 s ⇒ 1.72 km"
+        "description": "5 s \u21d2 1.72 km"
       }
     ],
     "faqs": [
@@ -9212,10 +9212,10 @@
     "unit": "g",
     "examples": [
       {
-        "description": "20 g coffee at 15 ⇒ 300 g water"
+        "description": "20 g coffee at 15 \u21d2 300 g water"
       },
       {
-        "description": "30 g coffee at 16 ⇒ 480 g water"
+        "description": "30 g coffee at 16 \u21d2 480 g water"
       }
     ],
     "faqs": [
@@ -9259,10 +9259,10 @@
     "intro": "Convert light level from lux to foot-candles. Enter the lux value and press Calculate.",
     "examples": [
       {
-        "description": "500 lux ⇒ 46.45 fc"
+        "description": "500 lux \u21d2 46.45 fc"
       },
       {
-        "description": "1000 lux ⇒ 92.90 fc"
+        "description": "1000 lux \u21d2 92.90 fc"
       }
     ],
     "faqs": [
@@ -9304,10 +9304,10 @@
     "intro": "Convert energy from kilojoules to kilocalories. Enter kilojoules and calculate.",
     "examples": [
       {
-        "description": "100 kJ ⇒ 23.90 kcal"
+        "description": "100 kJ \u21d2 23.90 kcal"
       },
       {
-        "description": "250 kJ ⇒ 59.77 kcal"
+        "description": "250 kJ \u21d2 59.77 kcal"
       }
     ],
     "faqs": [
@@ -9349,10 +9349,10 @@
     "intro": "Convert any number of weeks into hours.",
     "examples": [
       {
-        "description": "2 weeks ⇒ 336 hours"
+        "description": "2 weeks \u21d2 336 hours"
       },
       {
-        "description": "0.5 weeks ⇒ 84 hours"
+        "description": "0.5 weeks \u21d2 84 hours"
       }
     ],
     "faqs": [
@@ -9394,10 +9394,10 @@
     "intro": "Approximate how many 30-day months fit in a number of seconds.",
     "examples": [
       {
-        "description": "2,592,000 s ⇒ 1 month"
+        "description": "2,592,000 s \u21d2 1 month"
       },
       {
-        "description": "5,184,000 s ⇒ 2 months"
+        "description": "5,184,000 s \u21d2 2 months"
       }
     ],
     "faqs": [
@@ -9445,10 +9445,10 @@
     "intro": "Determine how efficiently a company uses its assets to generate profit.",
     "examples": [
       {
-        "description": "$50,000 net income / $200,000 assets ⇒ 25%"
+        "description": "$50,000 net income / $200,000 assets \u21d2 25%"
       },
       {
-        "description": "$80,000 net income / $1,000,000 assets ⇒ 8%"
+        "description": "$80,000 net income / $1,000,000 assets \u21d2 8%"
       }
     ],
     "faqs": [
@@ -9496,10 +9496,10 @@
     "intro": "Assess a company's leverage by comparing liabilities to equity.",
     "examples": [
       {
-        "description": "$150,000 liabilities / $100,000 equity ⇒ 1.5"
+        "description": "$150,000 liabilities / $100,000 equity \u21d2 1.5"
       },
       {
-        "description": "$80,000 liabilities / $200,000 equity ⇒ 0.4"
+        "description": "$80,000 liabilities / $200,000 equity \u21d2 0.4"
       }
     ],
     "faqs": [
@@ -9547,10 +9547,10 @@
     "intro": "Find the mass of body fat based on total weight and body fat percentage.",
     "examples": [
       {
-        "description": "70 kg at 20% ⇒ 14 kg fat"
+        "description": "70 kg at 20% \u21d2 14 kg fat"
       },
       {
-        "description": "80 kg at 15% ⇒ 12 kg fat"
+        "description": "80 kg at 15% \u21d2 12 kg fat"
       }
     ],
     "faqs": [
@@ -9592,10 +9592,10 @@
     "intro": "Estimate potential weight gain from extra calories consumed.",
     "examples": [
       {
-        "description": "7000 calories ⇒ 2 lb"
+        "description": "7000 calories \u21d2 2 lb"
       },
       {
-        "description": "1750 calories ⇒ 0.5 lb"
+        "description": "1750 calories \u21d2 0.5 lb"
       }
     ],
     "faqs": [
@@ -9628,7 +9628,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "placeholder": "50"
       },
@@ -9649,10 +9649,10 @@
     "intro": "Approximate the amount of grout needed based on area and joint dimensions.",
     "examples": [
       {
-        "description": "50 ft², 0.125 in width, 0.25 in depth ⇒ 3.69 L"
+        "description": "50 ft\u00b2, 0.125 in width, 0.25 in depth \u21d2 3.69 L"
       },
       {
-        "description": "100 ft², 0.1 in width, 0.3 in depth ⇒ 7.09 L"
+        "description": "100 ft\u00b2, 0.1 in width, 0.3 in depth \u21d2 7.09 L"
       }
     ],
     "faqs": [
@@ -9685,13 +9685,13 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "placeholder": "500"
       },
       {
         "name": "coverage",
-        "label": "Coverage per Roll (ft²)",
+        "label": "Coverage per Roll (ft\u00b2)",
         "type": "number",
         "placeholder": "40"
       }
@@ -9700,10 +9700,10 @@
     "intro": "Figure out how many insulation rolls to purchase based on area coverage.",
     "examples": [
       {
-        "description": "500 ft² area, 40 ft² per roll ⇒ 12.5 rolls"
+        "description": "500 ft\u00b2 area, 40 ft\u00b2 per roll \u21d2 12.5 rolls"
       },
       {
-        "description": "800 ft² area, 30 ft² per roll ⇒ 26.67 rolls"
+        "description": "800 ft\u00b2 area, 30 ft\u00b2 per roll \u21d2 26.67 rolls"
       }
     ],
     "faqs": [
@@ -9754,10 +9754,10 @@
     "intro": "Find the percent error between a measured quantity and its true value.",
     "examples": [
       {
-        "description": "Measured 105 vs actual 100 ⇒ 5%"
+        "description": "Measured 105 vs actual 100 \u21d2 5%"
       },
       {
-        "description": "Measured 95 vs actual 100 ⇒ 5%"
+        "description": "Measured 95 vs actual 100 \u21d2 5%"
       }
     ],
     "faqs": [
@@ -9796,13 +9796,13 @@
       }
     ],
     "expression": "360 / n",
-    "intro": "Compute the exterior angle of a regular polygon by dividing 360° by the number of sides.",
+    "intro": "Compute the exterior angle of a regular polygon by dividing 360\u00b0 by the number of sides.",
     "examples": [
       {
-        "description": "n = 6 ⇒ 60°"
+        "description": "n = 6 \u21d2 60\u00b0"
       },
       {
-        "description": "n = 8 ⇒ 45°"
+        "description": "n = 8 \u21d2 45\u00b0"
       }
     ],
     "faqs": [
@@ -9811,8 +9811,8 @@
         "answer": "It's the angle formed by one side of a polygon and the extension of an adjacent side."
       },
       {
-        "question": "Do the exterior angles sum to 360°?",
-        "answer": "Yes, for any polygon the exterior angles sum to 360°."
+        "question": "Do the exterior angles sum to 360\u00b0?",
+        "answer": "Yes, for any polygon the exterior angles sum to 360\u00b0."
       },
       {
         "question": "Does this work for irregular polygons?",
@@ -9820,7 +9820,7 @@
       },
       {
         "question": "How about interior angles?",
-        "answer": "Interior angle = 180° - exterior angle."
+        "answer": "Interior angle = 180\u00b0 - exterior angle."
       }
     ],
     "disclaimer": "Assumes a regular polygon.",
@@ -9850,10 +9850,10 @@
     "intro": "See how much space you save after compressing files.",
     "examples": [
       {
-        "description": "10 MB → 6 MB ⇒ 40%"
+        "description": "10 MB \u2192 6 MB \u21d2 40%"
       },
       {
-        "description": "50 MB → 25 MB ⇒ 50%"
+        "description": "50 MB \u2192 25 MB \u21d2 50%"
       }
     ],
     "faqs": [
@@ -9913,10 +9913,10 @@
     "intro": "Calculate the screen area as a percentage of the device's front surface.",
     "examples": [
       {
-        "description": "Screen 68×152 mm, body 70×155 mm ⇒ 95.26%"
+        "description": "Screen 68\u00d7152 mm, body 70\u00d7155 mm \u21d2 95.26%"
       },
       {
-        "description": "Screen 60×130 mm, body 65×140 mm ⇒ 85.71%"
+        "description": "Screen 60\u00d7130 mm, body 65\u00d7140 mm \u21d2 85.71%"
       }
     ],
     "faqs": [
@@ -9958,10 +9958,10 @@
     "intro": "Approximate a rabbit's age in human years using a factor of eight.",
     "examples": [
       {
-        "description": "2 rabbit years ⇒ 16 human years"
+        "description": "2 rabbit years \u21d2 16 human years"
       },
       {
-        "description": "5 rabbit years ⇒ 40 human years"
+        "description": "5 rabbit years \u21d2 40 human years"
       }
     ],
     "faqs": [
@@ -10003,10 +10003,10 @@
     "intro": "Convert beats per minute into milliseconds per beat for music production.",
     "examples": [
       {
-        "description": "120 BPM ⇒ 500 ms"
+        "description": "120 BPM \u21d2 500 ms"
       },
       {
-        "description": "90 BPM ⇒ 666.67 ms"
+        "description": "90 BPM \u21d2 666.67 ms"
       }
     ],
     "faqs": [
@@ -10049,10 +10049,10 @@
     "intro": "Convert electrical power in watts to mechanical horsepower for equipment comparisons.",
     "examples": [
       {
-        "description": "1000 W ⇒ 1.34 hp"
+        "description": "1000 W \u21d2 1.34 hp"
       },
       {
-        "description": "1500 W ⇒ 2.01 hp"
+        "description": "1500 W \u21d2 2.01 hp"
       }
     ],
     "faqs": [
@@ -10095,10 +10095,10 @@
     "intro": "Convert liquid volumes from liters to US gallons quickly and accurately.",
     "examples": [
       {
-        "description": "10 L ⇒ 2.64 gal"
+        "description": "10 L \u21d2 2.64 gal"
       },
       {
-        "description": "25 L ⇒ 6.60 gal"
+        "description": "25 L \u21d2 6.60 gal"
       }
     ],
     "faqs": [
@@ -10176,10 +10176,10 @@
     "intro": "Find how many business days fall between two dates, excluding weekends.",
     "examples": [
       {
-        "description": "2024-06-03 to 2024-06-07 ⇒ 5 days"
+        "description": "2024-06-03 to 2024-06-07 \u21d2 5 days"
       },
       {
-        "description": "2024-06-01 to 2024-06-10 ⇒ 6 days"
+        "description": "2024-06-01 to 2024-06-10 \u21d2 6 days"
       }
     ],
     "faqs": [
@@ -10236,10 +10236,10 @@
     "intro": "Calculate the Julian Day Number for any given calendar date.",
     "examples": [
       {
-        "description": "2000-01-01 ⇒ 2451545"
+        "description": "2000-01-01 \u21d2 2451545"
       },
       {
-        "description": "2024-05-15 ⇒ 2460446"
+        "description": "2024-05-15 \u21d2 2460446"
       }
     ],
     "faqs": [
@@ -10289,10 +10289,10 @@
     "intro": "Determine what percentage of earnings is distributed to shareholders as dividends.",
     "examples": [
       {
-        "description": "Dividends 2, earnings 5 ⇒ 40%"
+        "description": "Dividends 2, earnings 5 \u21d2 40%"
       },
       {
-        "description": "Dividends 3, earnings 6 ⇒ 50%"
+        "description": "Dividends 3, earnings 6 \u21d2 50%"
       }
     ],
     "faqs": [
@@ -10342,10 +10342,10 @@
     "intro": "Assess how many times a company's earnings can cover its interest payments.",
     "examples": [
       {
-        "description": "EBIT 60000, interest 10000 ⇒ 6"
+        "description": "EBIT 60000, interest 10000 \u21d2 6"
       },
       {
-        "description": "EBIT 45000, interest 15000 ⇒ 3"
+        "description": "EBIT 45000, interest 15000 \u21d2 3"
       }
     ],
     "faqs": [
@@ -10423,10 +10423,10 @@
     "intro": "Calculate how many weeks pregnant you are based on the last menstrual period and today's date.",
     "examples": [
       {
-        "description": "LMP 2024-01-01, current 2024-03-15 ⇒ 10.29 weeks"
+        "description": "LMP 2024-01-01, current 2024-03-15 \u21d2 10.29 weeks"
       },
       {
-        "description": "LMP 2024-06-01, current 2024-07-13 ⇒ 6.00 weeks"
+        "description": "LMP 2024-06-01, current 2024-07-13 \u21d2 6.00 weeks"
       }
     ],
     "faqs": [
@@ -10476,10 +10476,10 @@
     "intro": "Estimate cumulative smoking exposure by multiplying daily packs by years smoked.",
     "examples": [
       {
-        "description": "1 pack/day for 10 years ⇒ 10 pack-years"
+        "description": "1 pack/day for 10 years \u21d2 10 pack-years"
       },
       {
-        "description": "0.5 pack/day for 20 years ⇒ 10 pack-years"
+        "description": "0.5 pack/day for 20 years \u21d2 10 pack-years"
       }
     ],
     "faqs": [
@@ -10512,14 +10512,14 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "200"
       },
       {
         "name": "price",
-        "label": "Cost per ft²",
+        "label": "Cost per ft\u00b2",
         "type": "number",
         "step": "any",
         "placeholder": "3"
@@ -10529,10 +10529,10 @@
     "intro": "Estimate how much new carpet will cost based on room size and price per square foot.",
     "examples": [
       {
-        "description": "Area 200 ft², price $3 ⇒ $600"
+        "description": "Area 200 ft\u00b2, price $3 \u21d2 $600"
       },
       {
-        "description": "Area 150 ft², price $2.5 ⇒ $375"
+        "description": "Area 150 ft\u00b2, price $2.5 \u21d2 $375"
       }
     ],
     "faqs": [
@@ -10565,7 +10565,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "100"
@@ -10582,10 +10582,10 @@
     "intro": "Figure out how many evenly spaced plants can fit into a garden area.",
     "examples": [
       {
-        "description": "Area 100 ft², spacing 2 ft ⇒ 25 plants"
+        "description": "Area 100 ft\u00b2, spacing 2 ft \u21d2 25 plants"
       },
       {
-        "description": "Area 200 ft², spacing 1.5 ft ⇒ 89 plants"
+        "description": "Area 200 ft\u00b2, spacing 1.5 ft \u21d2 89 plants"
       }
     ],
     "faqs": [
@@ -10635,10 +10635,10 @@
     "intro": "Compute the smallest common multiple shared by two integers.",
     "examples": [
       {
-        "description": "LCM of 12 and 18 ⇒ 36"
+        "description": "LCM of 12 and 18 \u21d2 36"
       },
       {
-        "description": "LCM of 7 and 5 ⇒ 35"
+        "description": "LCM of 7 and 5 \u21d2 35"
       }
     ],
     "faqs": [
@@ -10688,10 +10688,10 @@
     "intro": "Compute the non-negative remainder after dividing one number by another.",
     "examples": [
       {
-        "description": "10 mod 3 ⇒ 1"
+        "description": "10 mod 3 \u21d2 1"
       },
       {
-        "description": "-10 mod 3 ⇒ 2"
+        "description": "-10 mod 3 \u21d2 2"
       }
     ],
     "faqs": [
@@ -10741,10 +10741,10 @@
     "intro": "Gauge the theoretical strength of a password using entropy in bits.",
     "examples": [
       {
-        "description": "Length 8, charset 62 ⇒ 47.60 bits"
+        "description": "Length 8, charset 62 \u21d2 47.60 bits"
       },
       {
-        "description": "Length 12, charset 96 ⇒ 79.61 bits"
+        "description": "Length 12, charset 96 \u21d2 79.61 bits"
       }
     ],
     "faqs": [
@@ -10794,10 +10794,10 @@
     "intro": "Compute power in watts using voltage and current values.",
     "examples": [
       {
-        "description": "120 V and 2 A ⇒ 240 W"
+        "description": "120 V and 2 A \u21d2 240 W"
       },
       {
-        "description": "12 V and 1.5 A ⇒ 18 W"
+        "description": "12 V and 1.5 A \u21d2 18 W"
       }
     ],
     "faqs": [
@@ -10840,10 +10840,10 @@
     "intro": "Estimate the probability that at least two people in a group share the same birthday.",
     "examples": [
       {
-        "description": "Group of 23 ⇒ 50.73%"
+        "description": "Group of 23 \u21d2 50.73%"
       },
       {
-        "description": "Group of 50 ⇒ 97.04%"
+        "description": "Group of 50 \u21d2 97.04%"
       }
     ],
     "faqs": [
@@ -10883,7 +10883,7 @@
       },
       {
         "name": "angle",
-        "label": "Sun Angle (°)",
+        "label": "Sun Angle (\u00b0)",
         "type": "number",
         "step": "any",
         "placeholder": "45"
@@ -10893,10 +10893,10 @@
     "intro": "Calculate how long a shadow will be based on object height and sun elevation angle.",
     "examples": [
       {
-        "description": "Height 2 m, angle 45° ⇒ 2 m"
+        "description": "Height 2 m, angle 45\u00b0 \u21d2 2 m"
       },
       {
-        "description": "Height 1.5 m, angle 30° ⇒ 2.60 m"
+        "description": "Height 1.5 m, angle 30\u00b0 \u21d2 2.60 m"
       }
     ],
     "faqs": [
@@ -10936,10 +10936,10 @@
     "expression": "nm * 0.737562149",
     "examples": [
       {
-        "description": "10 Nm → 7.38 ft·lb"
+        "description": "10 Nm \u2192 7.38 ft\u00b7lb"
       },
       {
-        "description": "250 Nm → 184.39 ft·lb"
+        "description": "250 Nm \u2192 184.39 ft\u00b7lb"
       }
     ],
     "faqs": [
@@ -10961,7 +10961,7 @@
       }
     ],
     "disclaimer": "Verify torque settings with manufacturer documentation.",
-    "unit": "ft·lb",
+    "unit": "ft\u00b7lb",
     "info": []
   },
   {
@@ -10979,10 +10979,10 @@
     "expression": "psi * 6.89476",
     "examples": [
       {
-        "description": "30 PSI → 206.84 kPa"
+        "description": "30 PSI \u2192 206.84 kPa"
       },
       {
-        "description": "100 PSI → 689.48 kPa"
+        "description": "100 PSI \u2192 689.48 kPa"
       }
     ],
     "faqs": [
@@ -11022,10 +11022,10 @@
     "expression": "hours * 10",
     "examples": [
       {
-        "description": "1.5 h → 15 units"
+        "description": "1.5 h \u2192 15 units"
       },
       {
-        "description": "0.3 h → 3 units"
+        "description": "0.3 h \u2192 3 units"
       }
     ],
     "faqs": [
@@ -11074,10 +11074,10 @@
     "expression": "Math.max(total - regular, 0)",
     "examples": [
       {
-        "description": "45 total, 40 regular → 5"
+        "description": "45 total, 40 regular \u2192 5"
       },
       {
-        "description": "38 total, 40 regular → 0"
+        "description": "38 total, 40 regular \u2192 0"
       }
     ],
     "faqs": [
@@ -11125,10 +11125,10 @@
     "expression": "amount * percent / 100",
     "examples": [
       {
-        "description": "$50,000 at 30% → $15,000"
+        "description": "$50,000 at 30% \u2192 $15,000"
       },
       {
-        "description": "$120,000 at 25% → $30,000"
+        "description": "$120,000 at 25% \u2192 $30,000"
       }
     ],
     "faqs": [
@@ -11173,10 +11173,10 @@
     "expression": "hours * rate",
     "examples": [
       {
-        "description": "3 h at $90/hr → $270"
+        "description": "3 h at $90/hr \u2192 $270"
       },
       {
-        "description": "1.5 h at $120/hr → $180"
+        "description": "1.5 h at $120/hr \u2192 $180"
       }
     ],
     "faqs": [
@@ -11221,10 +11221,10 @@
     "expression": "weight * hours * 1.3",
     "examples": [
       {
-        "description": "70 kg for 8 h → 728 kcal"
+        "description": "70 kg for 8 h \u2192 728 kcal"
       },
       {
-        "description": "80 kg for 2 h → 208 kcal"
+        "description": "80 kg for 2 h \u2192 208 kcal"
       }
     ],
     "faqs": [
@@ -11257,7 +11257,7 @@
     "inputs": [
       {
         "name": "acc",
-        "hint": "Acceleration (m/s²)",
+        "hint": "Acceleration (m/s\u00b2)",
         "placeholder": "Enter acc"
       },
       {
@@ -11269,10 +11269,10 @@
     "expression": "acc * acc * hours",
     "examples": [
       {
-        "description": "5 m/s² for 2 h → 50 points"
+        "description": "5 m/s\u00b2 for 2 h \u2192 50 points"
       },
       {
-        "description": "8 m/s² for 0.5 h → 32 points"
+        "description": "8 m/s\u00b2 for 0.5 h \u2192 32 points"
       }
     ],
     "faqs": [
@@ -11317,10 +11317,10 @@
     "expression": "rise / run * 100",
     "examples": [
       {
-        "description": "6 in rise over 72 in run → 8.33%"
+        "description": "6 in rise over 72 in run \u2192 8.33%"
       },
       {
-        "description": "4 in rise over 48 in run → 8.33%"
+        "description": "4 in rise over 48 in run \u2192 8.33%"
       }
     ],
     "faqs": [
@@ -11365,10 +11365,10 @@
     "expression": "area / coverage",
     "examples": [
       {
-        "description": "400 sq ft at 250 sq ft/gal → 1.6 gal"
+        "description": "400 sq ft at 250 sq ft/gal \u2192 1.6 gal"
       },
       {
-        "description": "600 sq ft at 200 sq ft/gal → 3 gal"
+        "description": "600 sq ft at 200 sq ft/gal \u2192 3 gal"
       }
     ],
     "faqs": [
@@ -11413,10 +11413,10 @@
     "expression": "load / effort",
     "examples": [
       {
-        "description": "Load arm 2 m, effort arm 0.5 m → 4"
+        "description": "Load arm 2 m, effort arm 0.5 m \u2192 4"
       },
       {
-        "description": "Load arm 1 m, effort arm 0.25 m → 4"
+        "description": "Load arm 1 m, effort arm 0.25 m \u2192 4"
       }
     ],
     "faqs": [
@@ -11461,10 +11461,10 @@
     "expression": "part / total * 100",
     "examples": [
       {
-        "description": "30 of 120 pages → 25%"
+        "description": "30 of 120 pages \u2192 25%"
       },
       {
-        "description": "15 of 60 exhibits → 25%"
+        "description": "15 of 60 exhibits \u2192 25%"
       }
     ],
     "faqs": [
@@ -11509,10 +11509,10 @@
     "expression": "driven / driving",
     "examples": [
       {
-        "description": "Driven 40, driving 20 → 2"
+        "description": "Driven 40, driving 20 \u2192 2"
       },
       {
-        "description": "Driven 18, driving 12 → 1.5"
+        "description": "Driven 18, driving 12 \u2192 1.5"
       }
     ],
     "faqs": [
@@ -11557,10 +11557,10 @@
     "expression": "capacity / load",
     "examples": [
       {
-        "description": "5 Ah battery at 1 A load → 5 h"
+        "description": "5 Ah battery at 1 A load \u2192 5 h"
       },
       {
-        "description": "2 Ah battery at 0.5 A load → 4 h"
+        "description": "2 Ah battery at 0.5 A load \u2192 4 h"
       }
     ],
     "faqs": [
@@ -11605,10 +11605,10 @@
     "expression": "citations / pages",
     "examples": [
       {
-        "description": "20 citations over 10 pages → 2 citations per page"
+        "description": "20 citations over 10 pages \u2192 2 citations per page"
       },
       {
-        "description": "45 citations over 15 pages → 3 citations per page"
+        "description": "45 citations over 15 pages \u2192 3 citations per page"
       }
     ],
     "faqs": [
@@ -11653,16 +11653,16 @@
     "expression": "incidents * 200000 / hours",
     "examples": [
       {
-        "description": "3 incidents over 400,000 hours → 1.5"
+        "description": "3 incidents over 400,000 hours \u2192 1.5"
       },
       {
-        "description": "1 incident over 50,000 hours → 4"
+        "description": "1 incident over 50,000 hours \u2192 4"
       }
     ],
     "faqs": [
       {
         "question": "What does 200,000 represent?",
-        "answer": "The annual hours for 100 workers (40h × 50w)."
+        "answer": "The annual hours for 100 workers (40h \u00d7 50w)."
       },
       {
         "question": "Are near-misses included?",
@@ -11686,7 +11686,7 @@
     "title": "GPM to LPS Converter",
     "cluster": "Conversions",
     "description": "Convert gallons per minute to liters per second.",
-    "intro": "Quickly convert flow rates from US gallons per minute to liters per second—handy for plumbing and irrigation setups.",
+    "intro": "Quickly convert flow rates from US gallons per minute to liters per second\u2014handy for plumbing and irrigation setups.",
     "inputs": [
       {
         "name": "gpm",
@@ -11700,13 +11700,13 @@
     "unit": "L/s",
     "examples": [
       {
-        "description": "10 gpm ⇒ 0.63 L/s"
+        "description": "10 gpm \u21d2 0.63 L/s"
       },
       {
-        "description": "25 gpm ⇒ 1.58 L/s"
+        "description": "25 gpm \u21d2 1.58 L/s"
       },
       {
-        "description": "40 gpm ⇒ 2.52 L/s"
+        "description": "40 gpm \u21d2 2.52 L/s"
       }
     ],
     "faqs": [
@@ -11745,13 +11745,13 @@
     "unit": "ECTS",
     "examples": [
       {
-        "description": "3 credit hours ⇒ 6 ECTS"
+        "description": "3 credit hours \u21d2 6 ECTS"
       },
       {
-        "description": "9 credit hours ⇒ 18 ECTS"
+        "description": "9 credit hours \u21d2 18 ECTS"
       },
       {
-        "description": "12 credit hours ⇒ 24 ECTS"
+        "description": "12 credit hours \u21d2 24 ECTS"
       }
     ],
     "faqs": [
@@ -11825,13 +11825,13 @@
     "unit": "week",
     "examples": [
       {
-        "description": "Start 2025-01-15, date 2025-02-12 ⇒ 5"
+        "description": "Start 2025-01-15, date 2025-02-12 \u21d2 5"
       },
       {
-        "description": "Start 2025-08-25, date 2025-08-25 ⇒ 1"
+        "description": "Start 2025-08-25, date 2025-08-25 \u21d2 1"
       },
       {
-        "description": "Start 2025-08-25, date 2025-12-10 ⇒ 16"
+        "description": "Start 2025-08-25, date 2025-12-10 \u21d2 16"
       }
     ],
     "faqs": [
@@ -11877,13 +11877,13 @@
     "unit": "hour",
     "examples": [
       {
-        "description": "Start 8, cure 4 ⇒ 12"
+        "description": "Start 8, cure 4 \u21d2 12"
       },
       {
-        "description": "Start 15, cure 16 ⇒ 7"
+        "description": "Start 15, cure 16 \u21d2 7"
       },
       {
-        "description": "Start 22, cure 2 ⇒ 0"
+        "description": "Start 22, cure 2 \u21d2 0"
       }
     ],
     "faqs": [
@@ -11929,13 +11929,13 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$50,000 with 15% ⇒ $42,500"
+        "description": "$50,000 with 15% \u21d2 $42,500"
       },
       {
-        "description": "$100,000 with 40% ⇒ $60,000"
+        "description": "$100,000 with 40% \u21d2 $60,000"
       },
       {
-        "description": "$20,000 with 10% ⇒ $18,000"
+        "description": "$20,000 with 10% \u21d2 $18,000"
       }
     ],
     "faqs": [
@@ -11995,13 +11995,13 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "50 ft, $2/ft, $60/hr, 0.05 h/ft ⇒ $250"
+        "description": "50 ft, $2/ft, $60/hr, 0.05 h/ft \u21d2 $250"
       },
       {
-        "description": "80 ft, $3/ft, $55/hr, 0.06 h/ft ⇒ $504"
+        "description": "80 ft, $3/ft, $55/hr, 0.06 h/ft \u21d2 $504"
       },
       {
-        "description": "30 ft, $1.5/ft, $40/hr, 0.04 h/ft ⇒ $93"
+        "description": "30 ft, $1.5/ft, $40/hr, 0.04 h/ft \u21d2 $93"
       }
     ],
     "faqs": [
@@ -12044,7 +12044,7 @@
       },
       {
         "name": "temperature",
-        "label": "Temp (°C)",
+        "label": "Temp (\u00b0C)",
         "type": "number",
         "step": "any",
         "placeholder": "30"
@@ -12054,13 +12054,13 @@
     "unit": "L",
     "examples": [
       {
-        "description": "70 kg, 2 h, 30°C ⇒ 5.39 L"
+        "description": "70 kg, 2 h, 30\u00b0C \u21d2 5.39 L"
       },
       {
-        "description": "80 kg, 1 h, 25°C ⇒ 2.80 L"
+        "description": "80 kg, 1 h, 25\u00b0C \u21d2 2.80 L"
       },
       {
-        "description": "60 kg, 3 h, 20°C ⇒ 6.30 L"
+        "description": "60 kg, 3 h, 20\u00b0C \u21d2 6.30 L"
       }
     ],
     "faqs": [
@@ -12084,7 +12084,7 @@
     "disclaimer": "Stay within personal limits and consult health professionals when needed.",
     "info": [
       "Formula uses 35 mL of water per kg per hour as a base rate.",
-      "Higher temperatures increase recommended intake by 2% per °C above 25."
+      "Higher temperatures increase recommended intake by 2% per \u00b0C above 25."
     ]
   },
   {
@@ -12113,13 +12113,13 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "UV 8, skin 2 ⇒ 5 min"
+        "description": "UV 8, skin 2 \u21d2 5 min"
       },
       {
-        "description": "UV 5, skin 4 ⇒ 13.33 min"
+        "description": "UV 5, skin 4 \u21d2 13.33 min"
       },
       {
-        "description": "UV 3, skin 6 ⇒ 66.67 min"
+        "description": "UV 3, skin 6 \u21d2 66.67 min"
       }
     ],
     "faqs": [
@@ -12179,13 +12179,13 @@
     "unit": "C:N",
     "examples": [
       {
-        "description": "10 kg greens (17), 5 kg browns (60) ⇒ 31.33 C:N"
+        "description": "10 kg greens (17), 5 kg browns (60) \u21d2 31.33 C:N"
       },
       {
-        "description": "5 kg greens (20), 15 kg browns (80) ⇒ 65 C:N"
+        "description": "5 kg greens (20), 15 kg browns (80) \u21d2 65 C:N"
       },
       {
-        "description": "8 kg greens (15), 8 kg browns (40) ⇒ 27.5 C:N"
+        "description": "8 kg greens (15), 8 kg browns (40) \u21d2 27.5 C:N"
       }
     ],
     "faqs": [
@@ -12231,13 +12231,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "50 ft run, 12 in drop ⇒ 2 %"
+        "description": "50 ft run, 12 in drop \u21d2 2 %"
       },
       {
-        "description": "40 ft run, 6 in drop ⇒ 1.25 %"
+        "description": "40 ft run, 6 in drop \u21d2 1.25 %"
       },
       {
-        "description": "80 ft run, 20 in drop ⇒ 2.08 %"
+        "description": "80 ft run, 20 in drop \u21d2 2.08 %"
       }
     ],
     "faqs": [
@@ -12247,7 +12247,7 @@
       },
       {
         "question": "What slope is typical?",
-        "answer": "Most drains require 1–2% slope for flow."
+        "answer": "Most drains require 1\u20132% slope for flow."
       },
       {
         "question": "Does pipe diameter matter?",
@@ -12261,8 +12261,8 @@
     "slug": "determinant-3x3-matrix",
     "title": "3x3 Determinant Calculator",
     "cluster": "Math",
-    "description": "Compute the determinant of a 3×3 matrix.",
-    "intro": "Evaluate the determinant of a 3×3 matrix—useful for linear algebra tasks.",
+    "description": "Compute the determinant of a 3\u00d73 matrix.",
+    "intro": "Evaluate the determinant of a 3\u00d73 matrix\u2014useful for linear algebra tasks.",
     "inputs": [
       {
         "name": "a11",
@@ -12332,13 +12332,13 @@
     "unit": "determinant",
     "examples": [
       {
-        "description": "[[1,2,3],[4,5,6],[7,8,9]] ⇒ 0"
+        "description": "[[1,2,3],[4,5,6],[7,8,9]] \u21d2 0"
       },
       {
-        "description": "[[2,0,1],[3,0,0],[5,1,1]] ⇒ 3"
+        "description": "[[2,0,1],[3,0,0],[5,1,1]] \u21d2 3"
       },
       {
-        "description": "[[6,1,1],[4,-2,5],[2,8,7]] ⇒ -306"
+        "description": "[[6,1,1],[4,-2,5],[2,8,7]] \u21d2 -306"
       }
     ],
     "faqs": [
@@ -12367,7 +12367,7 @@
     "inputs": [
       {
         "name": "lambda",
-        "label": "λ (rate)",
+        "label": "\u03bb (rate)",
         "type": "number",
         "step": "any",
         "placeholder": "2"
@@ -12384,18 +12384,18 @@
     "unit": "",
     "examples": [
       {
-        "description": "λ=2, k=3 ⇒ 0.18"
+        "description": "\u03bb=2, k=3 \u21d2 0.18"
       },
       {
-        "description": "λ=4, k=1 ⇒ 0.07"
+        "description": "\u03bb=4, k=1 \u21d2 0.07"
       },
       {
-        "description": "λ=1, k=0 ⇒ 0.37"
+        "description": "\u03bb=1, k=0 \u21d2 0.37"
       }
     ],
     "faqs": [
       {
-        "question": "What does λ represent?",
+        "question": "What does \u03bb represent?",
         "answer": "The average number of events in a given interval."
       },
       {
@@ -12443,13 +12443,13 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "5000 mAh, 10 A, 0 kg ⇒ 30 min"
+        "description": "5000 mAh, 10 A, 0 kg \u21d2 30 min"
       },
       {
-        "description": "6000 mAh, 12 A, 1 kg ⇒ 27.3 min"
+        "description": "6000 mAh, 12 A, 1 kg \u21d2 27.3 min"
       },
       {
-        "description": "8000 mAh, 15 A, 2 kg ⇒ 26.7 min"
+        "description": "8000 mAh, 15 A, 2 kg \u21d2 26.7 min"
       }
     ],
     "faqs": [
@@ -12502,13 +12502,13 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "100 mm, 0.2 mm, 50 mm/s ⇒ 600 min"
+        "description": "100 mm, 0.2 mm, 50 mm/s \u21d2 600 min"
       },
       {
-        "description": "50 mm, 0.25 mm, 60 mm/s ⇒ 200 min"
+        "description": "50 mm, 0.25 mm, 60 mm/s \u21d2 200 min"
       },
       {
-        "description": "200 mm, 0.3 mm, 40 mm/s ⇒ 1000 min"
+        "description": "200 mm, 0.3 mm, 40 mm/s \u21d2 1000 min"
       }
     ],
     "faqs": [
@@ -12554,13 +12554,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "3 applications at 20% ⇒ 48.8 %"
+        "description": "3 applications at 20% \u21d2 48.8 %"
       },
       {
-        "description": "5 applications at 10% ⇒ 40.95 %"
+        "description": "5 applications at 10% \u21d2 40.95 %"
       },
       {
-        "description": "1 application at 30% ⇒ 30 %"
+        "description": "1 application at 30% \u21d2 30 %"
       }
     ],
     "faqs": [
@@ -12599,13 +12599,13 @@
     "unit": "pt",
     "examples": [
       {
-        "description": "1 m ⇒ 14.17 pt"
+        "description": "1 m \u21d2 14.17 pt"
       },
       {
-        "description": "1.5 m ⇒ 21.26 pt"
+        "description": "1.5 m \u21d2 21.26 pt"
       },
       {
-        "description": "2 m ⇒ 28.34 pt"
+        "description": "2 m \u21d2 28.34 pt"
       }
     ],
     "faqs": [
@@ -12653,13 +12653,13 @@
     "intro": "Assess how efficiently a business manages inventory by calculating how many times it sells and replaces stock during a period.",
     "examples": [
       {
-        "description": "COGS 50,000 and average inventory 10,000 ⇒ 5 times"
+        "description": "COGS 50,000 and average inventory 10,000 \u21d2 5 times"
       },
       {
-        "description": "COGS 120,000 and average inventory 30,000 ⇒ 4 times"
+        "description": "COGS 120,000 and average inventory 30,000 \u21d2 4 times"
       },
       {
-        "description": "COGS 75,000 and average inventory 15,000 ⇒ 5 times"
+        "description": "COGS 75,000 and average inventory 15,000 \u21d2 5 times"
       }
     ],
     "faqs": [
@@ -12707,13 +12707,13 @@
     "intro": "Determine what percentage of your income you set aside each year.",
     "examples": [
       {
-        "description": "Income 50,000 and savings 10,000 ⇒ 20%"
+        "description": "Income 50,000 and savings 10,000 \u21d2 20%"
       },
       {
-        "description": "Income 40,000 and savings 4,000 ⇒ 10%"
+        "description": "Income 40,000 and savings 4,000 \u21d2 10%"
       },
       {
-        "description": "Income 60,000 and savings 9,000 ⇒ 15%"
+        "description": "Income 60,000 and savings 9,000 \u21d2 15%"
       }
     ],
     "faqs": [
@@ -12761,13 +12761,13 @@
     "intro": "Compute your average running pace per kilometer from distance and time.",
     "examples": [
       {
-        "description": "5 km in 25 min ⇒ 5 min/km"
+        "description": "5 km in 25 min \u21d2 5 min/km"
       },
       {
-        "description": "10 km in 45 min ⇒ 4.5 min/km"
+        "description": "10 km in 45 min \u21d2 4.5 min/km"
       },
       {
-        "description": "1 km in 4 min ⇒ 4 min/km"
+        "description": "1 km in 4 min \u21d2 4 min/km"
       }
     ],
     "faqs": [
@@ -12815,13 +12815,13 @@
     "intro": "Find the number of ordered arrangements of r items selected from n distinct items.",
     "examples": [
       {
-        "description": "n=5, r=2 ⇒ 20 ways"
+        "description": "n=5, r=2 \u21d2 20 ways"
       },
       {
-        "description": "n=6, r=3 ⇒ 120 ways"
+        "description": "n=6, r=3 \u21d2 120 ways"
       },
       {
-        "description": "n=10, r=0 ⇒ 1 way"
+        "description": "n=10, r=0 \u21d2 1 way"
       }
     ],
     "faqs": [
@@ -12861,13 +12861,13 @@
     "intro": "Convert volume in cups to tablespoons using the US customary system.",
     "examples": [
       {
-        "description": "1 cup ⇒ 16 tbsp"
+        "description": "1 cup \u21d2 16 tbsp"
       },
       {
-        "description": "0.5 cup ⇒ 8 tbsp"
+        "description": "0.5 cup \u21d2 8 tbsp"
       },
       {
-        "description": "2.25 cups ⇒ 36 tbsp"
+        "description": "2.25 cups \u21d2 36 tbsp"
       }
     ],
     "faqs": [
@@ -12925,13 +12925,13 @@
     "intro": "Determine the day number within the year for a given date, accounting for leap years.",
     "examples": [
       {
-        "description": "2024-01-01 ⇒ 1"
+        "description": "2024-01-01 \u21d2 1"
       },
       {
-        "description": "2024-12-31 ⇒ 366"
+        "description": "2024-12-31 \u21d2 366"
       },
       {
-        "description": "2025-03-01 ⇒ 60"
+        "description": "2025-03-01 \u21d2 60"
       }
     ],
     "faqs": [
@@ -12979,13 +12979,13 @@
     "intro": "Compute your grade point average by dividing total quality points by total credits attempted.",
     "examples": [
       {
-        "description": "36 points over 12 credits ⇒ 3.0 GPA"
+        "description": "36 points over 12 credits \u21d2 3.0 GPA"
       },
       {
-        "description": "45 points over 15 credits ⇒ 3.0 GPA"
+        "description": "45 points over 15 credits \u21d2 3.0 GPA"
       },
       {
-        "description": "50 points over 16 credits ⇒ 3.125 GPA"
+        "description": "50 points over 16 credits \u21d2 3.125 GPA"
       }
     ],
     "faqs": [
@@ -13033,13 +13033,13 @@
     "intro": "Calculate the resonant frequency where inductive and capacitive reactances cancel in an LC circuit.",
     "examples": [
       {
-        "description": "L=0.002 H, C=1e-6 F ⇒ 3558.5 Hz"
+        "description": "L=0.002 H, C=1e-6 F \u21d2 3558.5 Hz"
       },
       {
-        "description": "L=0.001 H, C=1e-9 F ⇒ 159154.9 Hz"
+        "description": "L=0.001 H, C=1e-9 F \u21d2 159154.9 Hz"
       },
       {
-        "description": "L=1 H, C=1e-6 F ⇒ 159.15 Hz"
+        "description": "L=1 H, C=1e-6 F \u21d2 159.15 Hz"
       }
     ],
     "faqs": [
@@ -13087,13 +13087,13 @@
     "intro": "Estimate CPU utilization percentage from measured busy time over total time.",
     "examples": [
       {
-        "description": "Busy 30 ms, total 100 ms ⇒ 30%"
+        "description": "Busy 30 ms, total 100 ms \u21d2 30%"
       },
       {
-        "description": "Busy 5 ms, total 20 ms ⇒ 25%"
+        "description": "Busy 5 ms, total 20 ms \u21d2 25%"
       },
       {
-        "description": "Busy 200 ms, total 500 ms ⇒ 40%"
+        "description": "Busy 200 ms, total 500 ms \u21d2 40%"
       }
     ],
     "faqs": [
@@ -13149,13 +13149,13 @@
     "intro": "Estimate how much a paint project will cost based on area, paint coverage and price per gallon.",
     "examples": [
       {
-        "description": "400 sq ft, 350 coverage, $25 ⇒ $28.57"
+        "description": "400 sq ft, 350 coverage, $25 \u21d2 $28.57"
       },
       {
-        "description": "1000 sq ft, 400 coverage, $30 ⇒ $75"
+        "description": "1000 sq ft, 400 coverage, $30 \u21d2 $75"
       },
       {
-        "description": "600 sq ft, 300 coverage, $20 ⇒ $40"
+        "description": "600 sq ft, 300 coverage, $20 \u21d2 $40"
       }
     ],
     "faqs": [
@@ -13203,13 +13203,13 @@
     "intro": "Calculate how many rest stops are needed on a road trip based on your maximum comfortable driving distance per leg.",
     "examples": [
       {
-        "description": "600 km with 150 km legs ⇒ 3 stops"
+        "description": "600 km with 150 km legs \u21d2 3 stops"
       },
       {
-        "description": "500 km with 200 km legs ⇒ 2 stops"
+        "description": "500 km with 200 km legs \u21d2 2 stops"
       },
       {
-        "description": "100 km with 300 km legs ⇒ 0 stops"
+        "description": "100 km with 300 km legs \u21d2 0 stops"
       }
     ],
     "faqs": [
@@ -13257,13 +13257,13 @@
     "intro": "Determine the percentage of impressions that result in clicks for an ad or email campaign.",
     "examples": [
       {
-        "description": "50 clicks, 1000 impressions ⇒ 5%"
+        "description": "50 clicks, 1000 impressions \u21d2 5%"
       },
       {
-        "description": "120 clicks, 4000 impressions ⇒ 3%"
+        "description": "120 clicks, 4000 impressions \u21d2 3%"
       },
       {
-        "description": "200 clicks, 2000 impressions ⇒ 10%"
+        "description": "200 clicks, 2000 impressions \u21d2 10%"
       }
     ],
     "faqs": [
@@ -13300,10 +13300,10 @@
     "expression": "mb/1024",
     "examples": [
       {
-        "description": "2048 MB ⇒ 2 GB"
+        "description": "2048 MB \u21d2 2 GB"
       },
       {
-        "description": "5120 MB ⇒ 5 GB"
+        "description": "5120 MB \u21d2 5 GB"
       }
     ],
     "faqs": [
@@ -13332,10 +13332,10 @@
     "expression": "percent/100",
     "examples": [
       {
-        "description": "25% ⇒ 0.25"
+        "description": "25% \u21d2 0.25"
       },
       {
-        "description": "150% ⇒ 1.5"
+        "description": "150% \u21d2 1.5"
       }
     ],
     "faqs": [
@@ -13364,10 +13364,10 @@
     "expression": "decimal*100",
     "examples": [
       {
-        "description": "0.85 ⇒ 85%"
+        "description": "0.85 \u21d2 85%"
       },
       {
-        "description": "1.2 ⇒ 120%"
+        "description": "1.2 \u21d2 120%"
       }
     ],
     "faqs": [
@@ -13400,10 +13400,10 @@
     "expression": "(meeting/workday)*100",
     "examples": [
       {
-        "description": "90 min of 480 ⇒ 18.75%"
+        "description": "90 min of 480 \u21d2 18.75%"
       },
       {
-        "description": "30 min of 300 ⇒ 10%"
+        "description": "30 min of 300 \u21d2 10%"
       }
     ],
     "faqs": [
@@ -13432,10 +13432,10 @@
     "expression": "(hours/2)*15",
     "examples": [
       {
-        "description": "8 h ⇒ 60 min"
+        "description": "8 h \u21d2 60 min"
       },
       {
-        "description": "5 h ⇒ 37.5 min"
+        "description": "5 h \u21d2 37.5 min"
       }
     ],
     "faqs": [
@@ -13468,10 +13468,10 @@
     "expression": "hours/day",
     "examples": [
       {
-        "description": "40 h at 8 ⇒ 5 days"
+        "description": "40 h at 8 \u21d2 5 days"
       },
       {
-        "description": "60 h at 7.5 ⇒ 8 days"
+        "description": "60 h at 7.5 \u21d2 8 days"
       }
     ],
     "faqs": [
@@ -13508,10 +13508,10 @@
     "expression": "rate*hours*weeks",
     "examples": [
       {
-        "description": "$25,40h,52w ⇒ $52000"
+        "description": "$25,40h,52w \u21d2 $52000"
       },
       {
-        "description": "$30,35h,48w ⇒ $50400"
+        "description": "$30,35h,48w \u21d2 $50400"
       }
     ],
     "faqs": [
@@ -13544,10 +13544,10 @@
     "expression": "((actual-budget)/budget)*100",
     "examples": [
       {
-        "description": "$1200 vs $1000 ⇒ 20%"
+        "description": "$1200 vs $1000 \u21d2 20%"
       },
       {
-        "description": "$900 vs $1000 ⇒ -10%"
+        "description": "$900 vs $1000 \u21d2 -10%"
       }
     ],
     "faqs": [
@@ -13580,10 +13580,10 @@
     "expression": "net/(1-tax/100)",
     "examples": [
       {
-        "description": "$1000 net at 30% ⇒ $1428.57"
+        "description": "$1000 net at 30% \u21d2 $1428.57"
       },
       {
-        "description": "$500 net at 25% ⇒ $666.67"
+        "description": "$500 net at 25% \u21d2 $666.67"
       }
     ],
     "faqs": [
@@ -13617,10 +13617,10 @@
     "expression": "(standing/total)*100",
     "examples": [
       {
-        "description": "120 of 960 ⇒ 12.5%"
+        "description": "120 of 960 \u21d2 12.5%"
       },
       {
-        "description": "240 of 600 ⇒ 40%"
+        "description": "240 of 600 \u21d2 40%"
       }
     ],
     "faqs": [
@@ -13660,10 +13660,10 @@
     "expression": "weight*3",
     "examples": [
       {
-        "description": "70 kg ⇒ 210 mg"
+        "description": "70 kg \u21d2 210 mg"
       },
       {
-        "description": "90 kg ⇒ 270 mg"
+        "description": "90 kg \u21d2 270 mg"
       }
     ],
     "faqs": [
@@ -13692,10 +13692,10 @@
     "expression": "(hours*60)/20",
     "examples": [
       {
-        "description": "6 h ⇒ 18 breaks"
+        "description": "6 h \u21d2 18 breaks"
       },
       {
-        "description": "3 h ⇒ 9 breaks"
+        "description": "3 h \u21d2 9 breaks"
       }
     ],
     "faqs": [
@@ -13740,13 +13740,13 @@
       }
     ],
     "expression": "length * width * height",
-    "unit": "m³",
+    "unit": "m\u00b3",
     "examples": [
       {
-        "description": "0.5×0.4×0.3 m ⇒ 0.06 m³"
+        "description": "0.5\u00d70.4\u00d70.3 m \u21d2 0.06 m\u00b3"
       },
       {
-        "description": "1×0.5×0.5 m ⇒ 0.25 m³"
+        "description": "1\u00d70.5\u00d70.5 m \u21d2 0.25 m\u00b3"
       }
     ],
     "faqs": [
@@ -13769,7 +13769,7 @@
     ],
     "disclaimer": "For informational purposes only.",
     "info": [
-      "Volume = length × width × height.",
+      "Volume = length \u00d7 width \u00d7 height.",
       "One cubic meter equals 1000 liters."
     ]
   },
@@ -13791,10 +13791,10 @@
     "expression": "window*fullness",
     "examples": [
       {
-        "description": "150 cm at 2× ⇒ 300 cm"
+        "description": "150 cm at 2\u00d7 \u21d2 300 cm"
       },
       {
-        "description": "120 cm at 1.5× ⇒ 180 cm"
+        "description": "120 cm at 1.5\u00d7 \u21d2 180 cm"
       }
     ],
     "faqs": [
@@ -13835,10 +13835,10 @@
     "expression": "((old-new)*hours*30/1000)*rate",
     "examples": [
       {
-        "description": "60→9W,5h,$0.15 ⇒ $6.84"
+        "description": "60\u21929W,5h,$0.15 \u21d2 $6.84"
       },
       {
-        "description": "75→10W,3h,$0.20 ⇒ $11.70"
+        "description": "75\u219210W,3h,$0.20 \u21d2 $11.70"
       }
     ],
     "faqs": [
@@ -13887,10 +13887,10 @@
     "expression": "(v1*w1+v2*w2+v3*w3)/(w1+w2+w3)",
     "examples": [
       {
-        "description": "80,90,75 with 1,2,1 ⇒ 83.75"
+        "description": "80,90,75 with 1,2,1 \u21d2 83.75"
       },
       {
-        "description": "10,20,30 with 1,1,1 ⇒ 20"
+        "description": "10,20,30 with 1,1,1 \u21d2 20"
       }
     ],
     "faqs": [
@@ -13927,10 +13927,10 @@
     "expression": "(((a-((a+b+c)/3))^2+(b-((a+b+c)/3))^2+(c-((a+b+c)/3))^2)/2)^0.5",
     "examples": [
       {
-        "description": "10,12,15 ⇒ 2.52"
+        "description": "10,12,15 \u21d2 2.52"
       },
       {
-        "description": "5,5,5 ⇒ 0"
+        "description": "5,5,5 \u21d2 0"
       }
     ],
     "faqs": [
@@ -13963,10 +13963,10 @@
     "expression": "(part/total)*100",
     "examples": [
       {
-        "description": "30 of 200 ⇒ 15%"
+        "description": "30 of 200 \u21d2 15%"
       },
       {
-        "description": "50 of 80 ⇒ 62.5%"
+        "description": "50 of 80 \u21d2 62.5%"
       }
     ],
     "faqs": [
@@ -13999,10 +13999,10 @@
     "expression": "(load/capacity)*100",
     "examples": [
       {
-        "description": "300 W on 500 W ⇒ 60%"
+        "description": "300 W on 500 W \u21d2 60%"
       },
       {
-        "description": "450 W on 600 W ⇒ 75%"
+        "description": "450 W on 600 W \u21d2 75%"
       }
     ],
     "faqs": [
@@ -14035,10 +14035,10 @@
     "expression": "data*rate",
     "examples": [
       {
-        "description": "100 GB at $0.02 ⇒ $2"
+        "description": "100 GB at $0.02 \u21d2 $2"
       },
       {
-        "description": "250 GB at $0.015 ⇒ $3.75"
+        "description": "250 GB at $0.015 \u21d2 $3.75"
       }
     ],
     "faqs": [
@@ -14071,10 +14071,10 @@
     "expression": "price/yield",
     "examples": [
       {
-        "description": "$40 and 2000 pages ⇒ $0.02"
+        "description": "$40 and 2000 pages \u21d2 $0.02"
       },
       {
-        "description": "$25 and 500 pages ⇒ $0.05"
+        "description": "$25 and 500 pages \u21d2 $0.05"
       }
     ],
     "faqs": [
@@ -14103,10 +14103,10 @@
     "expression": "500/pages",
     "examples": [
       {
-        "description": "100 pages/day ⇒ 5 days"
+        "description": "100 pages/day \u21d2 5 days"
       },
       {
-        "description": "25 pages/day ⇒ 20 days"
+        "description": "25 pages/day \u21d2 20 days"
       }
     ],
     "faqs": [
@@ -14125,7 +14125,7 @@
     "slug": "printing-carbon-footprint",
     "title": "Printing Carbon Footprint",
     "cluster": "Other",
-    "intro": "Approximate CO₂ emissions using 0.0044 kg per printed page.",
+    "intro": "Approximate CO\u2082 emissions using 0.0044 kg per printed page.",
     "inputs": [
       {
         "name": "pages",
@@ -14135,10 +14135,10 @@
     "expression": "pages*0.0044",
     "examples": [
       {
-        "description": "500 pages ⇒ 2.2 kg CO₂"
+        "description": "500 pages \u21d2 2.2 kg CO\u2082"
       },
       {
-        "description": "100 pages ⇒ 0.44 kg CO₂"
+        "description": "100 pages \u21d2 0.44 kg CO\u2082"
       }
     ],
     "faqs": [
@@ -14161,7 +14161,7 @@
     "inputs": [
       {
         "name": "area",
-        "hint": "Total area (m²)"
+        "hint": "Total area (m\u00b2)"
       },
       {
         "name": "people",
@@ -14171,16 +14171,16 @@
     "expression": "area/people",
     "examples": [
       {
-        "description": "200 m² & 10 ⇒ 20 m²/person"
+        "description": "200 m\u00b2 & 10 \u21d2 20 m\u00b2/person"
       },
       {
-        "description": "90 m² & 15 ⇒ 6 m²/person"
+        "description": "90 m\u00b2 & 15 \u21d2 6 m\u00b2/person"
       }
     ],
     "faqs": [
       {
         "question": "Recommended area?",
-        "answer": "Often 10–15 m² per person."
+        "answer": "Often 10\u201315 m\u00b2 per person."
       },
       {
         "question": "Include common areas?",
@@ -14215,13 +14215,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$20,000 revenue, $12,000 COGS ⇒ 40%"
+        "description": "$20,000 revenue, $12,000 COGS \u21d2 40%"
       },
       {
-        "description": "$8,000 revenue, $4,000 COGS ⇒ 50%"
+        "description": "$8,000 revenue, $4,000 COGS \u21d2 50%"
       },
       {
-        "description": "$1,000 revenue, $800 COGS ⇒ 20%"
+        "description": "$1,000 revenue, $800 COGS \u21d2 20%"
       }
     ],
     "faqs": [
@@ -14267,13 +14267,13 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$300,000 price at 20% ⇒ $60,000"
+        "description": "$300,000 price at 20% \u21d2 $60,000"
       },
       {
-        "description": "$20,000 price at 10% ⇒ $2,000"
+        "description": "$20,000 price at 10% \u21d2 $2,000"
       },
       {
-        "description": "$15,000 price at 15% ⇒ $2,250"
+        "description": "$15,000 price at 15% \u21d2 $2,250"
       }
     ],
     "faqs": [
@@ -14319,13 +14319,13 @@
     "unit": "ml/kg/min",
     "examples": [
       {
-        "description": "Age 30, 60 bpm ⇒ 47.5 ml/kg/min"
+        "description": "Age 30, 60 bpm \u21d2 47.5 ml/kg/min"
       },
       {
-        "description": "Age 40, 70 bpm ⇒ 38.6 ml/kg/min"
+        "description": "Age 40, 70 bpm \u21d2 38.6 ml/kg/min"
       },
       {
-        "description": "Age 25, 55 bpm ⇒ 53.6 ml/kg/min"
+        "description": "Age 25, 55 bpm \u21d2 53.6 ml/kg/min"
       }
     ],
     "faqs": [
@@ -14371,13 +14371,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "SD 5, mean 50 ⇒ 10%"
+        "description": "SD 5, mean 50 \u21d2 10%"
       },
       {
-        "description": "SD 4, mean 80 ⇒ 5%"
+        "description": "SD 4, mean 80 \u21d2 5%"
       },
       {
-        "description": "SD 3, mean 10 ⇒ 30%"
+        "description": "SD 3, mean 10 \u21d2 30%"
       }
     ],
     "faqs": [
@@ -14423,13 +14423,13 @@
     "unit": "Wh",
     "examples": [
       {
-        "description": "10 Ah at 12 V ⇒ 120 Wh"
+        "description": "10 Ah at 12 V \u21d2 120 Wh"
       },
       {
-        "description": "5 Ah at 24 V ⇒ 120 Wh"
+        "description": "5 Ah at 24 V \u21d2 120 Wh"
       },
       {
-        "description": "2 Ah at 3.7 V ⇒ 7.4 Wh"
+        "description": "2 Ah at 3.7 V \u21d2 7.4 Wh"
       }
     ],
     "faqs": [
@@ -14475,13 +14475,13 @@
     "unit": "hours",
     "examples": [
       {
-        "description": "2 h 30 m ⇒ 2.5 hours"
+        "description": "2 h 30 m \u21d2 2.5 hours"
       },
       {
-        "description": "1 h 45 m ⇒ 1.75 hours"
+        "description": "1 h 45 m \u21d2 1.75 hours"
       },
       {
-        "description": "0 h 15 m ⇒ 0.25 hours"
+        "description": "0 h 15 m \u21d2 0.25 hours"
       }
     ],
     "faqs": [
@@ -14527,13 +14527,13 @@
     "unit": "pages/day",
     "examples": [
       {
-        "description": "300 pages in 30 days ⇒ 10 pages/day"
+        "description": "300 pages in 30 days \u21d2 10 pages/day"
       },
       {
-        "description": "150 pages in 5 days ⇒ 30 pages/day"
+        "description": "150 pages in 5 days \u21d2 30 pages/day"
       },
       {
-        "description": "500 pages in 20 days ⇒ 25 pages/day"
+        "description": "500 pages in 20 days \u21d2 25 pages/day"
       }
     ],
     "faqs": [
@@ -14586,13 +14586,13 @@
     "unit": "g",
     "examples": [
       {
-        "description": "100 g with 5 y half-life after 5 y ⇒ 50 g"
+        "description": "100 g with 5 y half-life after 5 y \u21d2 50 g"
       },
       {
-        "description": "80 g with 2 y half-life after 6 y ⇒ 10 g"
+        "description": "80 g with 2 y half-life after 6 y \u21d2 10 g"
       },
       {
-        "description": "1 g with 3 d half-life after 9 d ⇒ 0.125 g"
+        "description": "1 g with 3 d half-life after 9 d \u21d2 0.125 g"
       }
     ],
     "faqs": [
@@ -14631,13 +14631,13 @@
     "unit": "addresses",
     "examples": [
       {
-        "description": "/64 ⇒ 18,446,744,073,709,551,616 addresses"
+        "description": "/64 \u21d2 18,446,744,073,709,551,616 addresses"
       },
       {
-        "description": "/48 ⇒ 1,208,925,819,614,629,174,706,176 addresses"
+        "description": "/48 \u21d2 1,208,925,819,614,629,174,706,176 addresses"
       },
       {
-        "description": "/32 ⇒ 79,228,162,514,264,337,593,543,950,336 addresses"
+        "description": "/32 \u21d2 79,228,162,514,264,337,593,543,950,336 addresses"
       }
     ],
     "faqs": [
@@ -14683,13 +14683,13 @@
     "unit": "kg",
     "examples": [
       {
-        "description": "50 kg per shelf × 4 shelves ⇒ 200 kg"
+        "description": "50 kg per shelf \u00d7 4 shelves \u21d2 200 kg"
       },
       {
-        "description": "30 kg per shelf × 5 shelves ⇒ 150 kg"
+        "description": "30 kg per shelf \u00d7 5 shelves \u21d2 150 kg"
       },
       {
-        "description": "100 kg per shelf × 3 shelves ⇒ 300 kg"
+        "description": "100 kg per shelf \u00d7 3 shelves \u21d2 300 kg"
       }
     ],
     "faqs": [
@@ -14735,13 +14735,13 @@
     "unit": "stops",
     "examples": [
       {
-        "description": "800 km trip, 400 km range ⇒ 1 stop"
+        "description": "800 km trip, 400 km range \u21d2 1 stop"
       },
       {
-        "description": "1500 km trip, 500 km range ⇒ 2 stops"
+        "description": "1500 km trip, 500 km range \u21d2 2 stops"
       },
       {
-        "description": "300 km trip, 600 km range ⇒ 0 stops"
+        "description": "300 km trip, 600 km range \u21d2 0 stops"
       }
     ],
     "faqs": [
@@ -14787,13 +14787,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "50 conversions, 1000 visitors ⇒ 5%"
+        "description": "50 conversions, 1000 visitors \u21d2 5%"
       },
       {
-        "description": "200 conversions, 4000 visitors ⇒ 5%"
+        "description": "200 conversions, 4000 visitors \u21d2 5%"
       },
       {
-        "description": "120 conversions, 1500 visitors ⇒ 8%"
+        "description": "120 conversions, 1500 visitors \u21d2 8%"
       }
     ],
     "faqs": [
@@ -14816,7 +14816,7 @@
     ],
     "disclaimer": "Use accurate analytics data for business decisions.",
     "info": [
-      "Conversion rate = (conversions / visitors) × 100.",
+      "Conversion rate = (conversions / visitors) \u00d7 100.",
       "Express results as a percentage for easier comparison."
     ]
   },
@@ -14846,13 +14846,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$50,000 income and $200,000 revenue ⇒ 25%"
+        "description": "$50,000 income and $200,000 revenue \u21d2 25%"
       },
       {
-        "description": "$120,000 income and $600,000 revenue ⇒ 20%"
+        "description": "$120,000 income and $600,000 revenue \u21d2 20%"
       },
       {
-        "description": "$80,000 income and $400,000 revenue ⇒ 20%"
+        "description": "$80,000 income and $400,000 revenue \u21d2 20%"
       }
     ],
     "faqs": [
@@ -14898,13 +14898,13 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$2,000 expenses for 3 months ⇒ $6,000"
+        "description": "$2,000 expenses for 3 months \u21d2 $6,000"
       },
       {
-        "description": "$2,500 expenses for 6 months ⇒ $15,000"
+        "description": "$2,500 expenses for 6 months \u21d2 $15,000"
       },
       {
-        "description": "$1,800 expenses for 4 months ⇒ $7,200"
+        "description": "$1,800 expenses for 4 months \u21d2 $7,200"
       }
     ],
     "faqs": [
@@ -14950,13 +14950,13 @@
     "unit": "days",
     "examples": [
       {
-        "description": "10 lb goal with 500 calorie deficit ⇒ 70 days"
+        "description": "10 lb goal with 500 calorie deficit \u21d2 70 days"
       },
       {
-        "description": "5 lb goal with 750 calorie deficit ⇒ 23.33 days"
+        "description": "5 lb goal with 750 calorie deficit \u21d2 23.33 days"
       },
       {
-        "description": "15 lb goal with 600 calorie deficit ⇒ 87.5 days"
+        "description": "15 lb goal with 600 calorie deficit \u21d2 87.5 days"
       }
     ],
     "faqs": [
@@ -15008,13 +15008,13 @@
     "expression": "3 / (1/a + 1/b + 1/c)",
     "examples": [
       {
-        "description": "1, 2, 4 ⇒ 1.71"
+        "description": "1, 2, 4 \u21d2 1.71"
       },
       {
-        "description": "10, 15, 20 ⇒ 14.40"
+        "description": "10, 15, 20 \u21d2 14.40"
       },
       {
-        "description": "5, 7, 9 ⇒ 6.77"
+        "description": "5, 7, 9 \u21d2 6.77"
       }
     ],
     "faqs": [
@@ -15067,13 +15067,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Current 85%, final 40%, target 90% ⇒ 97.5%"
+        "description": "Current 85%, final 40%, target 90% \u21d2 97.5%"
       },
       {
-        "description": "Current 78%, final 30%, target 80% ⇒ 86.67%"
+        "description": "Current 78%, final 30%, target 80% \u21d2 86.67%"
       },
       {
-        "description": "Current 92%, final 50%, target 95% ⇒ 98%"
+        "description": "Current 92%, final 50%, target 95% \u21d2 98%"
       }
     ],
     "faqs": [
@@ -15098,11 +15098,11 @@
     "title": "Hydrostatic Pressure Calculator",
     "cluster": "science",
     "description": "Calculate pressure at a depth in a fluid.",
-    "intro": "Determine the pressure exerted by a static fluid at a given depth using ρ g h.",
+    "intro": "Determine the pressure exerted by a static fluid at a given depth using \u03c1 g h.",
     "inputs": [
       {
         "name": "density",
-        "label": "Fluid density (kg/m³)",
+        "label": "Fluid density (kg/m\u00b3)",
         "type": "number",
         "step": "any",
         "placeholder": "1000"
@@ -15119,19 +15119,19 @@
     "unit": "Pa",
     "examples": [
       {
-        "description": "1000 kg/m³ at 5 m ⇒ 49,050 Pa"
+        "description": "1000 kg/m\u00b3 at 5 m \u21d2 49,050 Pa"
       },
       {
-        "description": "1025 kg/m³ at 10 m ⇒ 100,552.5 Pa"
+        "description": "1025 kg/m\u00b3 at 10 m \u21d2 100,552.5 Pa"
       },
       {
-        "description": "850 kg/m³ at 3 m ⇒ 25,011.5 Pa"
+        "description": "850 kg/m\u00b3 at 3 m \u21d2 25,011.5 Pa"
       }
     ],
     "faqs": [
       {
         "question": "What constant is used for gravity?",
-        "answer": "This calculation uses 9.81 m/s² for gravitational acceleration."
+        "answer": "This calculation uses 9.81 m/s\u00b2 for gravitational acceleration."
       },
       {
         "question": "Does it include atmospheric pressure?",
@@ -15162,13 +15162,13 @@
     "expression": "parseInt(binary, 2)",
     "examples": [
       {
-        "description": "1010 ⇒ 10"
+        "description": "1010 \u21d2 10"
       },
       {
-        "description": "11111111 ⇒ 255"
+        "description": "11111111 \u21d2 255"
       },
       {
-        "description": "100000 ⇒ 32"
+        "description": "100000 \u21d2 32"
       }
     ],
     "faqs": [
@@ -15214,13 +15214,13 @@
     "unit": "posts",
     "examples": [
       {
-        "description": "30 m fence, 2.5 m spacing ⇒ 13 posts"
+        "description": "30 m fence, 2.5 m spacing \u21d2 13 posts"
       },
       {
-        "description": "20 m fence, 3 m spacing ⇒ 7 posts"
+        "description": "20 m fence, 3 m spacing \u21d2 7 posts"
       },
       {
-        "description": "25 m fence, 2 m spacing ⇒ 13 posts"
+        "description": "25 m fence, 2 m spacing \u21d2 13 posts"
       }
     ],
     "faqs": [
@@ -15266,13 +15266,13 @@
     "unit": "USD/day",
     "examples": [
       {
-        "description": "$2,000 over 5 days ⇒ $400/day"
+        "description": "$2,000 over 5 days \u21d2 $400/day"
       },
       {
-        "description": "$1,500 over 7 days ⇒ $214.29/day"
+        "description": "$1,500 over 7 days \u21d2 $214.29/day"
       },
       {
-        "description": "$3,000 over 10 days ⇒ $300/day"
+        "description": "$3,000 over 10 days \u21d2 $300/day"
       }
     ],
     "faqs": [
@@ -15318,13 +15318,13 @@
     "unit": "%",
     "examples": [
       {
-        "description": "500 opened of 1000 sent ⇒ 50%"
+        "description": "500 opened of 1000 sent \u21d2 50%"
       },
       {
-        "description": "750 opened of 1500 sent ⇒ 50%"
+        "description": "750 opened of 1500 sent \u21d2 50%"
       },
       {
-        "description": "200 opened of 800 sent ⇒ 25%"
+        "description": "200 opened of 800 sent \u21d2 25%"
       }
     ],
     "faqs": [
@@ -15363,13 +15363,13 @@
     "unit": "cups",
     "examples": [
       {
-        "description": "16 fl oz ⇒ 2 cups"
+        "description": "16 fl oz \u21d2 2 cups"
       },
       {
-        "description": "10 fl oz ⇒ 1.25 cups"
+        "description": "10 fl oz \u21d2 1.25 cups"
       },
       {
-        "description": "32 fl oz ⇒ 4 cups"
+        "description": "32 fl oz \u21d2 4 cups"
       }
     ],
     "faqs": [
@@ -15408,13 +15408,13 @@
     "unit": "hours",
     "examples": [
       {
-        "description": "30 years ⇒ 262,800 hours"
+        "description": "30 years \u21d2 262,800 hours"
       },
       {
-        "description": "25 years ⇒ 219,000 hours"
+        "description": "25 years \u21d2 219,000 hours"
       },
       {
-        "description": "40 years ⇒ 350,400 hours"
+        "description": "40 years \u21d2 350,400 hours"
       }
     ],
     "faqs": [
@@ -15465,10 +15465,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "50,000 assets and 25,000 liabilities ⇒ 2"
+        "description": "50,000 assets and 25,000 liabilities \u21d2 2"
       },
       {
-        "description": "80,000 assets and 60,000 liabilities ⇒ 1.33"
+        "description": "80,000 assets and 60,000 liabilities \u21d2 1.33"
       }
     ],
     "faqs": [
@@ -15520,7 +15520,7 @@
     "expression": "(loan * rate/100) / 12",
     "examples": [
       {
-        "description": "200,000 loan at 0.5% ⇒ 83.33"
+        "description": "200,000 loan at 0.5% \u21d2 83.33"
       }
     ],
     "faqs": [
@@ -15565,7 +15565,7 @@
     "expression": "(new Date(year, month-1, day + 280)).toISOString().slice(0,10)",
     "examples": [
       {
-        "description": "LMP 2025-01-01 ⇒ 2025-10-08"
+        "description": "LMP 2025-01-01 \u21d2 2025-10-08"
       }
     ],
     "faqs": [
@@ -15607,7 +15607,7 @@
     "expression": "((Math.abs(a-((a+b+c)/3)) + Math.abs(b-((a+b+c)/3)) + Math.abs(c-((a+b+c)/3)))/3)",
     "examples": [
       {
-        "description": "2, 4, 7 ⇒ 1.78"
+        "description": "2, 4, 7 \u21d2 1.78"
       }
     ],
     "faqs": [
@@ -15636,7 +15636,7 @@
     "expression": "mph * 1.60934",
     "examples": [
       {
-        "description": "60 mph ⇒ 96.56 km/h"
+        "description": "60 mph \u21d2 96.56 km/h"
       }
     ],
     "faqs": [
@@ -15681,7 +15681,7 @@
     "expression": "Date.UTC(year, month-1, day)/1000",
     "examples": [
       {
-        "description": "1970-01-01 ⇒ 0"
+        "description": "1970-01-01 \u21d2 0"
       }
     ],
     "faqs": [
@@ -15718,7 +15718,7 @@
     "expression": "(attended / total) * 100",
     "examples": [
       {
-        "description": "18 attended of 20 ⇒ 90%"
+        "description": "18 attended of 20 \u21d2 90%"
       }
     ],
     "faqs": [
@@ -15733,8 +15733,8 @@
     "slug": "spring-force",
     "title": "Spring Force Calculator",
     "cluster": "Science & Engineering",
-    "description": "Compute force using Hooke's Law (F = k × x).",
-    "intro": "Compute the restoring force of a spring using Hooke's Law (F = k × x).",
+    "description": "Compute force using Hooke's Law (F = k \u00d7 x).",
+    "intro": "Compute the restoring force of a spring using Hooke's Law (F = k \u00d7 x).",
     "inputs": [
       {
         "name": "k",
@@ -15756,10 +15756,10 @@
     "unit": "N",
     "examples": [
       {
-        "description": "k=200 N/m, x=0.1 m ⇒ 20 N"
+        "description": "k=200 N/m, x=0.1 m \u21d2 20 N"
       },
       {
-        "description": "k=150 N/m, x=0.2 m ⇒ 30 N"
+        "description": "k=150 N/m, x=0.2 m \u21d2 30 N"
       }
     ],
     "faqs": [
@@ -15801,7 +15801,7 @@
     "expression": "parseInt(hex, 16)",
     "examples": [
       {
-        "description": "FF ⇒ 255"
+        "description": "FF \u21d2 255"
       }
     ],
     "faqs": [
@@ -15830,7 +15830,7 @@
     "expression": "area <= 75 ? 36 : area <= 144 ? 42 : area <= 225 ? 50 : area <= 400 ? 54 : 56",
     "examples": [
       {
-        "description": "150 sq ft ⇒ 50 in"
+        "description": "150 sq ft \u21d2 50 in"
       }
     ],
     "faqs": [
@@ -15867,7 +15867,7 @@
     "expression": "(map * scale) / 100000",
     "examples": [
       {
-        "description": "5 cm at 1:50,000 ⇒ 2.5 km"
+        "description": "5 cm at 1:50,000 \u21d2 2.5 km"
       }
     ],
     "faqs": [
@@ -15878,7 +15878,7 @@
     ],
     "info": [
       "Relies on a constant map scale and doesn't account for projection distortions or terrain.",
-      "Outputs distance in kilometers—convert to miles or other units if preferred."
+      "Outputs distance in kilometers\u2014convert to miles or other units if preferred."
     ]
   },
   {
@@ -15907,7 +15907,7 @@
     "expression": "(bounces / visits) * 100",
     "examples": [
       {
-        "description": "25 bounces out of 100 visits ⇒ 25%"
+        "description": "25 bounces out of 100 visits \u21d2 25%"
       }
     ],
     "faqs": [
@@ -15942,10 +15942,10 @@
     "expression": "investment / cashflow",
     "examples": [
       {
-        "description": "$10,000 investment with $2,500 inflow ⇒ 4 years"
+        "description": "$10,000 investment with $2,500 inflow \u21d2 4 years"
       },
       {
-        "description": "$5,000 investment with $1,000 inflow ⇒ 5 years"
+        "description": "$5,000 investment with $1,000 inflow \u21d2 5 years"
       }
     ],
     "faqs": [
@@ -15985,10 +15985,10 @@
     "expression": "(expenses / revenue) * 100",
     "examples": [
       {
-        "description": "Expenses $200k on $500k revenue ⇒ 40%"
+        "description": "Expenses $200k on $500k revenue \u21d2 40%"
       },
       {
-        "description": "Expenses $50k on $100k revenue ⇒ 50%"
+        "description": "Expenses $50k on $100k revenue \u21d2 50%"
       }
     ],
     "faqs": [
@@ -16035,10 +16035,10 @@
     "expression": "(function(balance,apr,payment){const r=apr/100/12;return Math.log(payment/(payment-r*balance))/Math.log(1+r);})(balance,apr,payment)",
     "examples": [
       {
-        "description": "$1,000 at 18% APR with $50 payment ⇒ 24 months"
+        "description": "$1,000 at 18% APR with $50 payment \u21d2 24 months"
       },
       {
-        "description": "$5,000 at 20% APR with $200 payment ⇒ 33 months"
+        "description": "$5,000 at 20% APR with $200 payment \u21d2 33 months"
       }
     ],
     "faqs": [
@@ -16092,10 +16092,10 @@
     "expression": "(function(p,rate,years,extra){const r=rate/100/12;const n=years*12;const pay=p*r*Math.pow(1+r,n)/(Math.pow(1+r,n)-1);const newPay=pay+extra;const newN=Math.log(newPay/(newPay - r*p))/Math.log(1+r);return n-newN;})(principal,rate,termYears,extra)",
     "examples": [
       {
-        "description": "$200k at 5% for 30y with $200 extra ⇒ 51 months saved"
+        "description": "$200k at 5% for 30y with $200 extra \u21d2 51 months saved"
       },
       {
-        "description": "$100k at 4% for 15y with $100 extra ⇒ 19 months saved"
+        "description": "$100k at 4% for 15y with $100 extra \u21d2 19 months saved"
       }
     ],
     "faqs": [
@@ -16135,10 +16135,10 @@
     "expression": "(hip / Math.pow(height/100, 1.5)) - 18",
     "examples": [
       {
-        "description": "Hip 100cm, height 170cm ⇒ 27%"
+        "description": "Hip 100cm, height 170cm \u21d2 27%"
       },
       {
-        "description": "Hip 90cm, height 165cm ⇒ 25%"
+        "description": "Hip 90cm, height 165cm \u21d2 25%"
       }
     ],
     "faqs": [
@@ -16178,10 +16178,10 @@
     "expression": "before - after",
     "examples": [
       {
-        "description": "70kg before, 69kg after ⇒ 1 liter"
+        "description": "70kg before, 69kg after \u21d2 1 liter"
       },
       {
-        "description": "80kg before, 79.2kg after ⇒ 0.8 liters"
+        "description": "80kg before, 79.2kg after \u21d2 0.8 liters"
       }
     ],
     "faqs": [
@@ -16228,10 +16228,10 @@
     "expression": "(function(a,b,c){a=Math.abs(Math.floor(a));b=Math.abs(Math.floor(b));c=Math.abs(Math.floor(c));function g(x,y){while(y){[x,y]=[y,x%y];}return x;}const l=a*b/g(a,b);return l*c/g(l,c);})(a,b,c)",
     "examples": [
       {
-        "description": "LCM of 4, 6, 8 ⇒ 24"
+        "description": "LCM of 4, 6, 8 \u21d2 24"
       },
       {
-        "description": "LCM of 5, 7, 9 ⇒ 315"
+        "description": "LCM of 5, 7, 9 \u21d2 315"
       }
     ],
     "faqs": [
@@ -16271,10 +16271,10 @@
     "expression": "(function(n,r){n=Math.floor(n);r=Math.floor(r);if(r<0||n<0||r>n)return 0;let num=1,den=1;for(let i=1;i<=r;i++){num*=n-(i-1);den*=i;}return num/den;})(n,r)",
     "examples": [
       {
-        "description": "5 choose 2 ⇒ 10"
+        "description": "5 choose 2 \u21d2 10"
       },
       {
-        "description": "10 choose 3 ⇒ 120"
+        "description": "10 choose 3 \u21d2 120"
       }
     ],
     "faqs": [
@@ -16307,10 +16307,10 @@
     "expression": "(f - 32) * 5/9 + 273.15",
     "examples": [
       {
-        "description": "32°F ⇒ 273.15 K"
+        "description": "32\u00b0F \u21d2 273.15 K"
       },
       {
-        "description": "212°F ⇒ 373.15 K"
+        "description": "212\u00b0F \u21d2 373.15 K"
       }
     ],
     "faqs": [
@@ -16343,10 +16343,10 @@
     "expression": "mm / 25.4",
     "examples": [
       {
-        "description": "50 mm ⇒ 1.97 in"
+        "description": "50 mm \u21d2 1.97 in"
       },
       {
-        "description": "100 mm ⇒ 3.94 in"
+        "description": "100 mm \u21d2 3.94 in"
       }
     ],
     "faqs": [
@@ -16386,10 +16386,10 @@
     "expression": "(function(y,w){const first=new Date(y,0,4);const day=(first.getDay()+6)%7;const monday=new Date(first);monday.setDate(first.getDate()-day);const target=new Date(monday);target.setDate(monday.getDate()+(w-1)*7);return target.toISOString().split('T')[0];})(year,week)",
     "examples": [
       {
-        "description": "2024 week 1 ⇒ 2024-01-01"
+        "description": "2024 week 1 \u21d2 2024-01-01"
       },
       {
-        "description": "2024 week 10 ⇒ 2024-03-04"
+        "description": "2024 week 10 \u21d2 2024-03-04"
       }
     ],
     "faqs": [
@@ -16443,10 +16443,10 @@
     "expression": "(function(y,m,d,days){let date=new Date(y,m-1,d);let added=0;while(added<days){date.setDate(date.getDate()+1);const day=date.getDay();if(day!==0&&day!==6)added++;}return date.toISOString().split('T')[0];})(y,m,d,days)",
     "examples": [
       {
-        "description": "Start 2024-06-03 +5 business days ⇒ 2024-06-10"
+        "description": "Start 2024-06-03 +5 business days \u21d2 2024-06-10"
       },
       {
-        "description": "Start 2024-12-29 +1 business day ⇒ 2024-12-31"
+        "description": "Start 2024-12-29 +1 business day \u21d2 2024-12-31"
       }
     ],
     "faqs": [
@@ -16488,10 +16488,10 @@
     "unit": "classes",
     "examples": [
       {
-        "description": "30 total classes with 80% required ⇒ 6 classes can be missed"
+        "description": "30 total classes with 80% required \u21d2 6 classes can be missed"
       },
       {
-        "description": "40 total classes with 75% required ⇒ 10 classes can be missed"
+        "description": "40 total classes with 75% required \u21d2 10 classes can be missed"
       }
     ],
     "faqs": [
@@ -16553,10 +16553,10 @@
     "expression": "(target*(creditsCompleted+newCredits) - current*creditsCompleted) / newCredits",
     "examples": [
       {
-        "description": "Current 3.0 over 60 credits aiming 3.2 with 15 credits ⇒ 4.0 GPA needed"
+        "description": "Current 3.0 over 60 credits aiming 3.2 with 15 credits \u21d2 4.0 GPA needed"
       },
       {
-        "description": "Current 3.5 over 45 credits aiming 3.6 with 15 credits ⇒ 3.9 GPA needed"
+        "description": "Current 3.5 over 45 credits aiming 3.6 with 15 credits \u21d2 3.9 GPA needed"
       }
     ],
     "faqs": [
@@ -16596,10 +16596,10 @@
     "expression": "Math.sqrt((2 * 6.674e-11 * mass) / radius)",
     "examples": [
       {
-        "description": "Earth ⇒ 11186 m/s"
+        "description": "Earth \u21d2 11186 m/s"
       },
       {
-        "description": "Moon ⇒ 2376 m/s"
+        "description": "Moon \u21d2 2376 m/s"
       }
     ],
     "faqs": [
@@ -16646,16 +16646,16 @@
     "expression": "(n * 0.082057 * temperature) / volume",
     "examples": [
       {
-        "description": "1 mol at 300K in 24L ⇒ 1.03 atm"
+        "description": "1 mol at 300K in 24L \u21d2 1.03 atm"
       },
       {
-        "description": "2 mol at 350K in 30L ⇒ 1.91 atm"
+        "description": "2 mol at 350K in 30L \u21d2 1.91 atm"
       }
     ],
     "faqs": [
       {
         "question": "What constant is used?",
-        "answer": "R = 0.082057 L·atm/(mol·K)."
+        "answer": "R = 0.082057 L\u00b7atm/(mol\u00b7K)."
       },
       {
         "question": "Does it work for real gases?",
@@ -16689,10 +16689,10 @@
     "expression": "Math.pow(2, entropy) / (2 * guesses) / 3600 / 24 / 365",
     "examples": [
       {
-        "description": "Entropy 40 with 1e6 guesses/sec ⇒ 0.017 years"
+        "description": "Entropy 40 with 1e6 guesses/sec \u21d2 0.017 years"
       },
       {
-        "description": "Entropy 60 with 1e9 guesses/sec ⇒ 18 years"
+        "description": "Entropy 60 with 1e9 guesses/sec \u21d2 18 years"
       }
     ],
     "faqs": [
@@ -16739,10 +16739,10 @@
     "expression": "(capacity - current) / monthlyGrowth",
     "examples": [
       {
-        "description": "50GB now, +5GB/mo to 200GB ⇒ 30 months"
+        "description": "50GB now, +5GB/mo to 200GB \u21d2 30 months"
       },
       {
-        "description": "20GB now, +2GB/mo to 50GB ⇒ 15 months"
+        "description": "20GB now, +2GB/mo to 50GB \u21d2 15 months"
       }
     ],
     "faqs": [
@@ -16780,7 +16780,7 @@
       },
       {
         "name": "density",
-        "label": "Snow Density (lb/ft³)",
+        "label": "Snow Density (lb/ft\u00b3)",
         "type": "number",
         "step": "any",
         "placeholder": "20"
@@ -16789,10 +16789,10 @@
     "expression": "area * depth * density",
     "examples": [
       {
-        "description": "1000 sq ft, 2 ft depth at 20 lb/ft³ ⇒ 40,000 lbs"
+        "description": "1000 sq ft, 2 ft depth at 20 lb/ft\u00b3 \u21d2 40,000 lbs"
       },
       {
-        "description": "500 sq ft, 1 ft depth at 15 lb/ft³ ⇒ 7,500 lbs"
+        "description": "500 sq ft, 1 ft depth at 15 lb/ft\u00b3 \u21d2 7,500 lbs"
       }
     ],
     "faqs": [
@@ -16846,10 +16846,10 @@
     "expression": "2*(length + width) - doors - windows",
     "examples": [
       {
-        "description": "20×15 room minus 6ft doors and 8ft windows ⇒ 56 ft"
+        "description": "20\u00d715 room minus 6ft doors and 8ft windows \u21d2 56 ft"
       },
       {
-        "description": "12×10 room minus 3ft doors and 6ft windows ⇒ 35 ft"
+        "description": "12\u00d710 room minus 3ft doors and 6ft windows \u21d2 35 ft"
       }
     ],
     "faqs": [
@@ -16889,10 +16889,10 @@
     "expression": "budget / nightly",
     "examples": [
       {
-        "description": "$1000 budget at $120/night ⇒ 8.33 nights"
+        "description": "$1000 budget at $120/night \u21d2 8.33 nights"
       },
       {
-        "description": "$600 budget at $75/night ⇒ 8 nights"
+        "description": "$600 budget at $75/night \u21d2 8 nights"
       }
     ],
     "faqs": [
@@ -16939,16 +16939,16 @@
     "expression": "(length * width * height) / 5000",
     "examples": [
       {
-        "description": "50×40×20 cm ⇒ 8 kg"
+        "description": "50\u00d740\u00d720 cm \u21d2 8 kg"
       },
       {
-        "description": "80×50×30 cm ⇒ 24 kg"
+        "description": "80\u00d750\u00d730 cm \u21d2 24 kg"
       }
     ],
     "faqs": [
       {
         "question": "Why divide by 5000?",
-        "answer": "Airlines often use 5000 to convert cm³ to kg for volume weight."
+        "answer": "Airlines often use 5000 to convert cm\u00b3 to kg for volume weight."
       },
       {
         "question": "Do all airlines use this factor?",
@@ -16982,10 +16982,10 @@
     "expression": "cost / clicks",
     "examples": [
       {
-        "description": "$200 cost for 1000 clicks ⇒ $0.20 CPC"
+        "description": "$200 cost for 1000 clicks \u21d2 $0.20 CPC"
       },
       {
-        "description": "$50 cost for 200 clicks ⇒ $0.25 CPC"
+        "description": "$50 cost for 200 clicks \u21d2 $0.25 CPC"
       }
     ],
     "faqs": [
@@ -17025,10 +17025,10 @@
     "expression": "(revenue / adspend) * 100",
     "examples": [
       {
-        "description": "$5,000 revenue on $1,000 spend ⇒ 500% ROAS"
+        "description": "$5,000 revenue on $1,000 spend \u21d2 500% ROAS"
       },
       {
-        "description": "$3,000 revenue on $1,500 spend ⇒ 200% ROAS"
+        "description": "$3,000 revenue on $1,500 spend \u21d2 200% ROAS"
       }
     ],
     "faqs": [
@@ -17070,10 +17070,10 @@
     "unit": "times",
     "examples": [
       {
-        "description": "500000 sales and 62500 receivables ⇒ 8 times"
+        "description": "500000 sales and 62500 receivables \u21d2 8 times"
       },
       {
-        "description": "200000 sales and 40000 receivables ⇒ 5 times"
+        "description": "200000 sales and 40000 receivables \u21d2 5 times"
       }
     ],
     "faqs": [
@@ -17123,10 +17123,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "Assets $150,000 and liabilities $90,000 ⇒ $60,000"
+        "description": "Assets $150,000 and liabilities $90,000 \u21d2 $60,000"
       },
       {
-        "description": "Assets $100,000 and liabilities $120,000 ⇒ -$20,000"
+        "description": "Assets $100,000 and liabilities $120,000 \u21d2 -$20,000"
       }
     ],
     "faqs": [
@@ -17176,10 +17176,10 @@
     "unit": "L",
     "examples": [
       {
-        "description": "Male 80 kg ⇒ 5.6 L"
+        "description": "Male 80 kg \u21d2 5.6 L"
       },
       {
-        "description": "Female 60 kg ⇒ 3.9 L"
+        "description": "Female 60 kg \u21d2 3.9 L"
       }
     ],
     "faqs": [
@@ -17236,10 +17236,10 @@
     "unit": "z",
     "examples": [
       {
-        "description": "Value 85, mean 70, SD 10 ⇒ 1.5 z"
+        "description": "Value 85, mean 70, SD 10 \u21d2 1.5 z"
       },
       {
-        "description": "Value 60, mean 50, SD 5 ⇒ 2 z"
+        "description": "Value 60, mean 50, SD 5 \u21d2 2 z"
       }
     ],
     "faqs": [
@@ -17282,13 +17282,13 @@
       }
     ],
     "expression": "kelvin * 1.8",
-    "unit": "°R",
+    "unit": "\u00b0R",
     "examples": [
       {
-        "description": "273.15 K ⇒ 491.67 °R"
+        "description": "273.15 K \u21d2 491.67 \u00b0R"
       },
       {
-        "description": "400 K ⇒ 720 °R"
+        "description": "400 K \u21d2 720 \u00b0R"
       }
     ],
     "faqs": [
@@ -17331,10 +17331,10 @@
     "unit": "quarter",
     "examples": [
       {
-        "description": "Month 2 ⇒ Q1"
+        "description": "Month 2 \u21d2 Q1"
       },
       {
-        "description": "Month 11 ⇒ Q4"
+        "description": "Month 11 \u21d2 Q4"
       }
     ],
     "faqs": [
@@ -17384,10 +17384,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "40 of 50 cards correct ⇒ 80%"
+        "description": "40 of 50 cards correct \u21d2 80%"
       },
       {
-        "description": "24 of 30 cards correct ⇒ 80%"
+        "description": "24 of 30 cards correct \u21d2 80%"
       }
     ],
     "faqs": [
@@ -17441,13 +17441,13 @@
       }
     ],
     "expression": "(supply_voltage - forward_voltage) / (current_mA / 1000)",
-    "unit": "Ω",
+    "unit": "\u03a9",
     "examples": [
       {
-        "description": "9V supply, 2V LED, 20mA ⇒ 350 Ω"
+        "description": "9V supply, 2V LED, 20mA \u21d2 350 \u03a9"
       },
       {
-        "description": "5V supply, 3.2V LED, 25mA ⇒ 72 Ω"
+        "description": "5V supply, 3.2V LED, 25mA \u21d2 72 \u03a9"
       }
     ],
     "faqs": [
@@ -17497,10 +17497,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Sent 1000, received 995 ⇒ 0.5% loss"
+        "description": "Sent 1000, received 995 \u21d2 0.5% loss"
       },
       {
-        "description": "Sent 500, received 475 ⇒ 5% loss"
+        "description": "Sent 500, received 475 \u21d2 5% loss"
       }
     ],
     "faqs": [
@@ -17550,10 +17550,10 @@
     "unit": "lb",
     "examples": [
       {
-        "description": "200 sq ft at 0.5 in ⇒ 550 lb"
+        "description": "200 sq ft at 0.5 in \u21d2 550 lb"
       },
       {
-        "description": "120 sq ft at 0.625 in ⇒ 412.5 lb"
+        "description": "120 sq ft at 0.625 in \u21d2 412.5 lb"
       }
     ],
     "faqs": [
@@ -17603,10 +17603,10 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "Burn time 10 min, SPF 30 ⇒ 300 min"
+        "description": "Burn time 10 min, SPF 30 \u21d2 300 min"
       },
       {
-        "description": "Burn time 15 min, SPF 20 ⇒ 300 min"
+        "description": "Burn time 15 min, SPF 20 \u21d2 300 min"
       }
     ],
     "faqs": [
@@ -17663,10 +17663,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Start 1000, end 1500 over 6 months ⇒ 6.99%"
+        "description": "Start 1000, end 1500 over 6 months \u21d2 6.99%"
       },
       {
-        "description": "Start 2000, end 2600 over 12 months ⇒ 2.41%"
+        "description": "Start 2000, end 2600 over 12 months \u21d2 2.41%"
       }
     ],
     "faqs": [
@@ -17718,10 +17718,10 @@
     "unit": "USD/employee",
     "examples": [
       {
-        "description": "$1,000,000 revenue with 50 employees ⇒ $20000 per employee"
+        "description": "$1,000,000 revenue with 50 employees \u21d2 $20000 per employee"
       },
       {
-        "description": "$500,000 revenue with 10 employees ⇒ $50000 per employee"
+        "description": "$500,000 revenue with 10 employees \u21d2 $50000 per employee"
       }
     ],
     "faqs": [
@@ -17773,10 +17773,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$1,200 rent from $4,000 income ⇒ 30%"
+        "description": "$1,200 rent from $4,000 income \u21d2 30%"
       },
       {
-        "description": "$800 rent from $2,400 income ⇒ 33.33%"
+        "description": "$800 rent from $2,400 income \u21d2 33.33%"
       }
     ],
     "faqs": [
@@ -17828,10 +17828,10 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "5 km at 5 min/km ⇒ 25 minutes"
+        "description": "5 km at 5 min/km \u21d2 25 minutes"
       },
       {
-        "description": "10 km at 6 min/km ⇒ 60 minutes"
+        "description": "10 km at 6 min/km \u21d2 60 minutes"
       }
     ],
     "faqs": [
@@ -17875,10 +17875,10 @@
     "unit": "value",
     "examples": [
       {
-        "description": "n = 7 ⇒ 13"
+        "description": "n = 7 \u21d2 13"
       },
       {
-        "description": "n = 10 ⇒ 55"
+        "description": "n = 10 \u21d2 55"
       }
     ],
     "faqs": [
@@ -17922,10 +17922,10 @@
     "unit": "mmHg",
     "examples": [
       {
-        "description": "1333.22 Pa ⇒ 10 mmHg"
+        "description": "1333.22 Pa \u21d2 10 mmHg"
       },
       {
-        "description": "101325 Pa ⇒ 760 mmHg"
+        "description": "101325 Pa \u21d2 760 mmHg"
       }
     ],
     "faqs": [
@@ -18003,10 +18003,10 @@
     "unit": "weeks",
     "examples": [
       {
-        "description": "Jan 1, 2024 to Feb 12, 2024 ⇒ 6 weeks"
+        "description": "Jan 1, 2024 to Feb 12, 2024 \u21d2 6 weeks"
       },
       {
-        "description": "Jul 1, 2024 to Aug 26, 2024 ⇒ 8 weeks"
+        "description": "Jul 1, 2024 to Aug 26, 2024 \u21d2 8 weeks"
       }
     ],
     "faqs": [
@@ -18058,10 +18058,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "4-day interval with 2.5 ease ⇒ 10 days"
+        "description": "4-day interval with 2.5 ease \u21d2 10 days"
       },
       {
-        "description": "10-day interval with 1.5 ease ⇒ 15 days"
+        "description": "10-day interval with 1.5 ease \u21d2 15 days"
       }
     ],
     "faqs": [
@@ -18113,10 +18113,10 @@
     "unit": "N",
     "examples": [
       {
-        "description": "10 kg with 2 m/s^2 ⇒ 20 N"
+        "description": "10 kg with 2 m/s^2 \u21d2 20 N"
       },
       {
-        "description": "5 kg with 9.81 m/s^2 ⇒ 49.05 N"
+        "description": "5 kg with 9.81 m/s^2 \u21d2 49.05 N"
       }
     ],
     "faqs": [
@@ -18176,10 +18176,10 @@
     "unit": "MB",
     "examples": [
       {
-        "description": "1920×1080 at 24-bit ⇒ 5.93 MB"
+        "description": "1920\u00d71080 at 24-bit \u21d2 5.93 MB"
       },
       {
-        "description": "800×600 at 8-bit ⇒ 0.46 MB"
+        "description": "800\u00d7600 at 8-bit \u21d2 0.46 MB"
       }
     ],
     "faqs": [
@@ -18239,10 +18239,10 @@
     "unit": "sq ft",
     "examples": [
       {
-        "description": "30 ft × 20 ft with 6 pitch ⇒ 670.82 sq ft"
+        "description": "30 ft \u00d7 20 ft with 6 pitch \u21d2 670.82 sq ft"
       },
       {
-        "description": "40 ft × 30 ft with 8 pitch ⇒ 1442.22 sq ft"
+        "description": "40 ft \u00d7 30 ft with 8 pitch \u21d2 1442.22 sq ft"
       }
     ],
     "faqs": [
@@ -18294,10 +18294,10 @@
     "unit": "USD/point",
     "examples": [
       {
-        "description": "50,000 points for $700 stay ⇒ $0.014 per point"
+        "description": "50,000 points for $700 stay \u21d2 $0.014 per point"
       },
       {
-        "description": "40,000 points for $500 stay ⇒ $0.0125 per point"
+        "description": "40,000 points for $500 stay \u21d2 $0.0125 per point"
       }
     ],
     "faqs": [
@@ -18368,10 +18368,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "500 likes, 60 comments, 40 shares, 10,000 followers ⇒ 6%"
+        "description": "500 likes, 60 comments, 40 shares, 10,000 followers \u21d2 6%"
       },
       {
-        "description": "100 likes, 10 comments, 5 shares, 5,000 followers ⇒ 2.3%"
+        "description": "100 likes, 10 comments, 5 shares, 5,000 followers \u21d2 2.3%"
       }
     ],
     "faqs": [
@@ -18435,10 +18435,10 @@
     "unit": "USD/hour",
     "examples": [
       {
-        "description": "$52,000 salary + $8,000 benefits + $7,000 overhead over 2,080 hours ⇒ $32.21 per hour"
+        "description": "$52,000 salary + $8,000 benefits + $7,000 overhead over 2,080 hours \u21d2 $32.21 per hour"
       },
       {
-        "description": "$60,000 salary + $10,000 benefits + $9,000 overhead over 2,000 hours ⇒ $39.50 per hour"
+        "description": "$60,000 salary + $10,000 benefits + $9,000 overhead over 2,000 hours \u21d2 $39.50 per hour"
       }
     ],
     "faqs": [
@@ -18498,10 +18498,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$250,000 at 5% for 30 years ⇒ $619.11 biweekly"
+        "description": "$250,000 at 5% for 30 years \u21d2 $619.11 biweekly"
       },
       {
-        "description": "$400,000 at 4.5% for 20 years ⇒ $1,167.24 biweekly"
+        "description": "$400,000 at 4.5% for 20 years \u21d2 $1,167.24 biweekly"
       }
     ],
     "faqs": [
@@ -18561,10 +18561,10 @@
     "unit": "bpm",
     "examples": [
       {
-        "description": "Age 30, resting 60 bpm at 70% ⇒ 151 bpm"
+        "description": "Age 30, resting 60 bpm at 70% \u21d2 151 bpm"
       },
       {
-        "description": "Age 45, resting 55 bpm at 60% ⇒ 127 bpm"
+        "description": "Age 45, resting 55 bpm at 60% \u21d2 127 bpm"
       }
     ],
     "faqs": [
@@ -18578,7 +18578,7 @@
       },
       {
         "question": "What intensity should I use?",
-        "answer": "Use 50–85% depending on workout goals and fitness."
+        "answer": "Use 50\u201385% depending on workout goals and fitness."
       },
       {
         "question": "Is this accurate for everyone?",
@@ -18614,7 +18614,7 @@
       },
       {
         "name": "falsePos",
-        "label": "False Positive P(B|¬A) (%)",
+        "label": "False Positive P(B|\u00acA) (%)",
         "type": "number",
         "step": "any",
         "placeholder": "5"
@@ -18624,10 +18624,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Prior 1%, likelihood 90%, false positive 5% ⇒ 15.38%"
+        "description": "Prior 1%, likelihood 90%, false positive 5% \u21d2 15.38%"
       },
       {
-        "description": "Prior 20%, likelihood 80%, false positive 10% ⇒ 66.67%"
+        "description": "Prior 20%, likelihood 80%, false positive 10% \u21d2 66.67%"
       }
     ],
     "faqs": [
@@ -18670,7 +18670,7 @@
       },
       {
         "name": "area",
-        "label": "Area (m²)",
+        "label": "Area (m\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "20"
@@ -18680,10 +18680,10 @@
     "unit": "lumens",
     "examples": [
       {
-        "description": "500 lux over 20 m² ⇒ 10,000 lumens"
+        "description": "500 lux over 20 m\u00b2 \u21d2 10,000 lumens"
       },
       {
-        "description": "300 lux over 10 m² ⇒ 3,000 lumens"
+        "description": "300 lux over 10 m\u00b2 \u21d2 3,000 lumens"
       }
     ],
     "faqs": [
@@ -18700,14 +18700,14 @@
         "answer": "This calculation assumes uniform reflection and ignores color."
       },
       {
-        "question": "Can I use feet²?",
-        "answer": "Convert feet² to m² before using this calculator."
+        "question": "Can I use feet\u00b2?",
+        "answer": "Convert feet\u00b2 to m\u00b2 before using this calculator."
       }
     ],
     "disclaimer": "Assumes even light distribution across the area.",
     "info": [
-      "1 lumen equals 1 candela·steradian.",
-      "Typical office lighting ranges from 300–500 lux."
+      "1 lumen equals 1 candela\u00b7steradian.",
+      "Typical office lighting ranges from 300\u2013500 lux."
     ]
   },
   {
@@ -18740,10 +18740,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "December 1, 2024 ⇒ 31 days"
+        "description": "December 1, 2024 \u21d2 31 days"
       },
       {
-        "description": "July 1, 2024 ⇒ 184 days"
+        "description": "July 1, 2024 \u21d2 184 days"
       }
     ],
     "faqs": [
@@ -18789,10 +18789,10 @@
     "unit": "CPM",
     "examples": [
       {
-        "description": "40 WPM ⇒ 200 CPM"
+        "description": "40 WPM \u21d2 200 CPM"
       },
       {
-        "description": "70 WPM ⇒ 350 CPM"
+        "description": "70 WPM \u21d2 350 CPM"
       }
     ],
     "faqs": [
@@ -18824,7 +18824,7 @@
     "title": "Specific Heat Energy Calculator",
     "cluster": "Science & Engineering",
     "description": "Estimate heat energy required using mass, specific heat, and temperature change.",
-    "intro": "Calculate the heat energy required to change the temperature of a substance using Q = m·c·ΔT.",
+    "intro": "Calculate the heat energy required to change the temperature of a substance using Q = m\u00b7c\u00b7\u0394T.",
     "inputs": [
       {
         "name": "mass",
@@ -18835,14 +18835,14 @@
       },
       {
         "name": "c",
-        "label": "Specific Heat (J/kg°C)",
+        "label": "Specific Heat (J/kg\u00b0C)",
         "type": "number",
         "step": "any",
         "placeholder": "4186"
       },
       {
         "name": "delta",
-        "label": "Temperature Change (°C)",
+        "label": "Temperature Change (\u00b0C)",
         "type": "number",
         "step": "any",
         "placeholder": "10"
@@ -18852,16 +18852,16 @@
     "unit": "J",
     "examples": [
       {
-        "description": "2 kg with c=4186 J/kg°C and ΔT=10°C ⇒ 83,720 J"
+        "description": "2 kg with c=4186 J/kg\u00b0C and \u0394T=10\u00b0C \u21d2 83,720 J"
       },
       {
-        "description": "0.5 kg with c=900 J/kg°C and ΔT=30°C ⇒ 13,500 J"
+        "description": "0.5 kg with c=900 J/kg\u00b0C and \u0394T=30\u00b0C \u21d2 13,500 J"
       }
     ],
     "faqs": [
       {
         "question": "What is specific heat?",
-        "answer": "The energy needed to raise 1 kg of a substance by 1°C."
+        "answer": "The energy needed to raise 1 kg of a substance by 1\u00b0C."
       },
       {
         "question": "Can c vary?",
@@ -18878,7 +18878,7 @@
     ],
     "disclaimer": "Assumes no heat loss to the environment.",
     "info": [
-      "Water has a high specific heat of about 4186 J/kg°C.",
+      "Water has a high specific heat of about 4186 J/kg\u00b0C.",
       "Metal objects typically have lower specific heats than water."
     ]
   },
@@ -18902,10 +18902,10 @@
     "unit": "bits",
     "examples": [
       {
-        "description": "15 ⇒ 4 bits"
+        "description": "15 \u21d2 4 bits"
       },
       {
-        "description": "1023 ⇒ 10 bits"
+        "description": "1023 \u21d2 10 bits"
       }
     ],
     "faqs": [
@@ -18962,7 +18962,7 @@
       },
       {
         "name": "coverage",
-        "label": "Coverage (m² per gallon)",
+        "label": "Coverage (m\u00b2 per gallon)",
         "type": "number",
         "step": "any",
         "placeholder": "35"
@@ -18972,10 +18972,10 @@
     "unit": "gallons",
     "examples": [
       {
-        "description": "5 m × 4 m, 2 coats, 35 m²/gal ⇒ 1.14 gallons"
+        "description": "5 m \u00d7 4 m, 2 coats, 35 m\u00b2/gal \u21d2 1.14 gallons"
       },
       {
-        "description": "6 m × 3 m, 1 coat, 40 m²/gal ⇒ 0.45 gallons"
+        "description": "6 m \u00d7 3 m, 1 coat, 40 m\u00b2/gal \u21d2 0.45 gallons"
       }
     ],
     "faqs": [
@@ -18998,7 +18998,7 @@
     ],
     "disclaimer": "Estimates only; actual coverage depends on surface conditions.",
     "info": [
-      "Standard ceiling paint coverage ranges 30–40 m² per gallon.",
+      "Standard ceiling paint coverage ranges 30\u201340 m\u00b2 per gallon.",
       "Include primer requirements separately if needed."
     ]
   },
@@ -19028,10 +19028,10 @@
     "unit": "hours",
     "examples": [
       {
-        "description": "10 km with 600 m gain ⇒ 3 hours"
+        "description": "10 km with 600 m gain \u21d2 3 hours"
       },
       {
-        "description": "15 km with 300 m gain ⇒ 3.5 hours"
+        "description": "15 km with 300 m gain \u21d2 3.5 hours"
       }
     ],
     "faqs": [
@@ -19084,10 +19084,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "1000 start, 950 end ⇒ 5% churn"
+        "description": "1000 start, 950 end \u21d2 5% churn"
       },
       {
-        "description": "5000 start, 4700 end ⇒ 6% churn"
+        "description": "5000 start, 4700 end \u21d2 6% churn"
       }
     ],
     "faqs": [
@@ -19133,10 +19133,10 @@
     "unit": "gpg",
     "examples": [
       {
-        "description": "180 ppm ⇒ 10.52 gpg"
+        "description": "180 ppm \u21d2 10.52 gpg"
       },
       {
-        "description": "60 ppm ⇒ 3.51 gpg"
+        "description": "60 ppm \u21d2 3.51 gpg"
       }
     ],
     "faqs": [
@@ -19189,10 +19189,10 @@
     "unit": "months",
     "examples": [
       {
-        "description": "$100000 at $2000/mo ⇒ 50 months"
+        "description": "$100000 at $2000/mo \u21d2 50 months"
       },
       {
-        "description": "$50000 at $1500/mo ⇒ 33.33 months"
+        "description": "$50000 at $1500/mo \u21d2 33.33 months"
       }
     ],
     "faqs": [
@@ -19249,10 +19249,10 @@
     "unit": "days",
     "examples": [
       {
-        "description": "60 pills at 2/day ⇒ 30 days"
+        "description": "60 pills at 2/day \u21d2 30 days"
       },
       {
-        "description": "45 pills at 3/day ⇒ 15 days"
+        "description": "45 pills at 3/day \u21d2 15 days"
       }
     ],
     "faqs": [
@@ -19288,7 +19288,7 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (ft²)",
+        "label": "Area (ft\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "500"
@@ -19302,16 +19302,16 @@
       }
     ],
     "expression": "(area * depth / 12) / 27",
-    "unit": "yd³",
+    "unit": "yd\u00b3",
     "examples": [
       {
-        "description": "Area 500 ft², depth 3 in ⇒ 4.63 yd³"
+        "description": "Area 500 ft\u00b2, depth 3 in \u21d2 4.63 yd\u00b3"
       },
       {
-        "description": "Area 200 ft², depth 2 in ⇒ 1.23 yd³"
+        "description": "Area 200 ft\u00b2, depth 2 in \u21d2 1.23 yd\u00b3"
       },
       {
-        "description": "Area 1000 ft², depth 4 in ⇒ 12.35 yd³"
+        "description": "Area 1000 ft\u00b2, depth 4 in \u21d2 12.35 yd\u00b3"
       }
     ],
     "faqs": [
@@ -19335,7 +19335,7 @@
     "disclaimer": "Educational purposes only. Not professional advice.",
     "info": [
       "27 cubic feet equal 1 cubic yard.",
-      "Mulch depth of 2–4 inches is common for garden beds."
+      "Mulch depth of 2\u20134 inches is common for garden beds."
     ]
   },
   {
@@ -19357,13 +19357,13 @@
     "unit": "1=yes",
     "examples": [
       {
-        "description": "2024 ⇒ 1"
+        "description": "2024 \u21d2 1"
       },
       {
-        "description": "1900 ⇒ 0"
+        "description": "1900 \u21d2 0"
       },
       {
-        "description": "2000 ⇒ 1"
+        "description": "2000 \u21d2 1"
       }
     ],
     "faqs": [
@@ -19416,13 +19416,13 @@
     "unit": "hours",
     "examples": [
       {
-        "description": "200 g candle at 5 g/hr ⇒ 40 hrs"
+        "description": "200 g candle at 5 g/hr \u21d2 40 hrs"
       },
       {
-        "description": "150 g candle at 6 g/hr ⇒ 25 hrs"
+        "description": "150 g candle at 6 g/hr \u21d2 25 hrs"
       },
       {
-        "description": "100 g candle at 4 g/hr ⇒ 25 hrs"
+        "description": "100 g candle at 4 g/hr \u21d2 25 hrs"
       }
     ],
     "faqs": [
@@ -19458,7 +19458,7 @@
     "inputs": [
       {
         "name": "c",
-        "label": "Celsius (°C)",
+        "label": "Celsius (\u00b0C)",
         "type": "number",
         "step": "any",
         "placeholder": "25"
@@ -19468,13 +19468,13 @@
     "unit": "K",
     "examples": [
       {
-        "description": "0 °C ⇒ 273.15 K"
+        "description": "0 \u00b0C \u21d2 273.15 K"
       },
       {
-        "description": "25 °C ⇒ 298.15 K"
+        "description": "25 \u00b0C \u21d2 298.15 K"
       },
       {
-        "description": "-10 °C ⇒ 263.15 K"
+        "description": "-10 \u00b0C \u21d2 263.15 K"
       }
     ],
     "faqs": [
@@ -19488,11 +19488,11 @@
       },
       {
         "question": "What is absolute zero in Kelvin?",
-        "answer": "Absolute zero is 0 K, equal to -273.15 °C."
+        "answer": "Absolute zero is 0 K, equal to -273.15 \u00b0C."
       },
       {
         "question": "Why add 273.15?",
-        "answer": "The Kelvin scale starts at absolute zero, 273.15 degrees below 0 °C."
+        "answer": "The Kelvin scale starts at absolute zero, 273.15 degrees below 0 \u00b0C."
       }
     ],
     "disclaimer": "Educational purposes only. Not professional advice.",
@@ -19520,13 +19520,13 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "2 hours standing ⇒ 18 kcal"
+        "description": "2 hours standing \u21d2 18 kcal"
       },
       {
-        "description": "4 hours standing ⇒ 36 kcal"
+        "description": "4 hours standing \u21d2 36 kcal"
       },
       {
-        "description": "6 hours standing ⇒ 54 kcal"
+        "description": "6 hours standing \u21d2 54 kcal"
       }
     ],
     "faqs": [
@@ -19569,16 +19569,16 @@
       }
     ],
     "expression": "100 - altitude / 300",
-    "unit": "°C",
+    "unit": "\u00b0C",
     "examples": [
       {
-        "description": "0 m ⇒ 100 °C"
+        "description": "0 m \u21d2 100 \u00b0C"
       },
       {
-        "description": "1,000 m ⇒ 96.7 °C"
+        "description": "1,000 m \u21d2 96.7 \u00b0C"
       },
       {
-        "description": "2,500 m ⇒ 91.7 °C"
+        "description": "2,500 m \u21d2 91.7 \u00b0C"
       }
     ],
     "faqs": [
@@ -19588,7 +19588,7 @@
       },
       {
         "question": "Can I enter altitude in feet?",
-        "answer": "Convert feet to meters first (1 ft ≈ 0.3048 m) before using the calculator."
+        "answer": "Convert feet to meters first (1 ft \u2248 0.3048 m) before using the calculator."
       },
       {
         "question": "How accurate is this formula?",
@@ -19601,8 +19601,8 @@
     ],
     "disclaimer": "Results are estimates based on standard atmospheric conditions; local pressure variations can change boiling temperatures.",
     "info": [
-      "Water boils at 100°C at sea level under standard atmospheric pressure.",
-      "Boiling point drops roughly 1°C for every 300 m increase in altitude."
+      "Water boils at 100\u00b0C at sea level under standard atmospheric pressure.",
+      "Boiling point drops roughly 1\u00b0C for every 300 m increase in altitude."
     ]
   },
   {
@@ -19638,10 +19638,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "20 units/day, 10 days lead, 100 safety ⇒ 300 units"
+        "description": "20 units/day, 10 days lead, 100 safety \u21d2 300 units"
       },
       {
-        "description": "50 units/day, 5 days lead, 200 safety ⇒ 450 units"
+        "description": "50 units/day, 5 days lead, 200 safety \u21d2 450 units"
       }
     ],
     "faqs": [
@@ -19694,10 +19694,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$10,000 at 5% ⇒ $41.67"
+        "description": "$10,000 at 5% \u21d2 $41.67"
       },
       {
-        "description": "$25,000 at 7% ⇒ $145.83"
+        "description": "$25,000 at 7% \u21d2 $145.83"
       }
     ],
     "faqs": [
@@ -19757,10 +19757,10 @@
     "unit": "lb",
     "examples": [
       {
-        "description": "180 lb at 25% to 15% ⇒ 158.82 lb"
+        "description": "180 lb at 25% to 15% \u21d2 158.82 lb"
       },
       {
-        "description": "200 lb at 30% to 20% ⇒ 175 lb"
+        "description": "200 lb at 30% to 20% \u21d2 175 lb"
       }
     ],
     "faqs": [
@@ -19791,7 +19791,7 @@
     "slug": "sum-of-squares",
     "title": "Sum of Squares Calculator",
     "cluster": "Math & Statistics",
-    "description": "Compute 1² + 2² + ... + n².",
+    "description": "Compute 1\u00b2 + 2\u00b2 + ... + n\u00b2.",
     "intro": "Compute the sum of the squares of the first n natural numbers.",
     "inputs": [
       {
@@ -19806,10 +19806,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "n = 3 ⇒ 14"
+        "description": "n = 3 \u21d2 14"
       },
       {
-        "description": "n = 5 ⇒ 55"
+        "description": "n = 5 \u21d2 55"
       }
     ],
     "faqs": [
@@ -19855,10 +19855,10 @@
     "unit": "acres",
     "examples": [
       {
-        "description": "1 ha ⇒ 2.47 acres"
+        "description": "1 ha \u21d2 2.47 acres"
       },
       {
-        "description": "5 ha ⇒ 12.36 acres"
+        "description": "5 ha \u21d2 12.36 acres"
       }
     ],
     "faqs": [
@@ -19911,20 +19911,20 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "22:30 ⇒ 90 minutes"
+        "description": "22:30 \u21d2 90 minutes"
       },
       {
-        "description": "00:15 ⇒ 1425 minutes"
+        "description": "00:15 \u21d2 1425 minutes"
       }
     ],
     "faqs": [
       {
         "question": "Is time entered in 24-hour format?",
-        "answer": "Yes, use 0–23 for hours."
+        "answer": "Yes, use 0\u201323 for hours."
       },
       {
         "question": "What if minutes exceed 59?",
-        "answer": "The calculation assumes 0–59; adjust as needed."
+        "answer": "The calculation assumes 0\u201359; adjust as needed."
       },
       {
         "question": "Can result be zero?",
@@ -19967,10 +19967,10 @@
     "unit": "words",
     "examples": [
       {
-        "description": "Goal 1500, current 600 ⇒ 900 words remaining"
+        "description": "Goal 1500, current 600 \u21d2 900 words remaining"
       },
       {
-        "description": "Goal 1000, current 1000 ⇒ 0 words remaining"
+        "description": "Goal 1000, current 1000 \u21d2 0 words remaining"
       }
     ],
     "faqs": [
@@ -20002,11 +20002,11 @@
     "title": "RC Time Constant Calculator",
     "cluster": "Science & Engineering",
     "description": "Compute the time constant of an RC circuit.",
-    "intro": "Find the RC time constant (τ) by multiplying resistance and capacitance.",
+    "intro": "Find the RC time constant (\u03c4) by multiplying resistance and capacitance.",
     "inputs": [
       {
         "name": "resistance",
-        "label": "Resistance (Ω)",
+        "label": "Resistance (\u03a9)",
         "type": "number",
         "step": "any",
         "placeholder": "1000"
@@ -20023,10 +20023,10 @@
     "unit": "seconds",
     "examples": [
       {
-        "description": "1000 Ω & 0.001 F ⇒ 1 s"
+        "description": "1000 \u03a9 & 0.001 F \u21d2 1 s"
       },
       {
-        "description": "4700 Ω & 0.00047 F ⇒ 2.21 s"
+        "description": "4700 \u03a9 & 0.00047 F \u21d2 2.21 s"
       }
     ],
     "faqs": [
@@ -20043,14 +20043,14 @@
         "answer": "No, it applies only to RC circuits."
       },
       {
-        "question": "Why is τ important?",
+        "question": "Why is \u03c4 important?",
         "answer": "It predicts charging and discharging speed of capacitors."
       }
     ],
     "disclaimer": "Ideal RC circuit assumption; real components may vary.",
     "info": [
       "Higher resistance or capacitance increases the time constant.",
-      "After 5τ, charging is over 99% complete."
+      "After 5\u03c4, charging is over 99% complete."
     ]
   },
   {
@@ -20073,10 +20073,10 @@
     "unit": "steps",
     "examples": [
       {
-        "description": "n = 1000 ⇒ 10 steps"
+        "description": "n = 1000 \u21d2 10 steps"
       },
       {
-        "description": "n = 32 ⇒ 5 steps"
+        "description": "n = 32 \u21d2 5 steps"
       }
     ],
     "faqs": [
@@ -20126,7 +20126,7 @@
       },
       {
         "name": "coverage",
-        "label": "Paint Coverage (m² per liter)",
+        "label": "Paint Coverage (m\u00b2 per liter)",
         "type": "number",
         "step": "any",
         "placeholder": "10"
@@ -20136,10 +20136,10 @@
     "unit": "liters",
     "examples": [
       {
-        "description": "30 m × 2 m with 10 m²/L ⇒ 6 liters"
+        "description": "30 m \u00d7 2 m with 10 m\u00b2/L \u21d2 6 liters"
       },
       {
-        "description": "15 m × 1.8 m with 8 m²/L ⇒ 3.38 liters"
+        "description": "15 m \u00d7 1.8 m with 8 m\u00b2/L \u21d2 3.38 liters"
       }
     ],
     "faqs": [
@@ -20192,10 +20192,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "70 kg body, 10 kg pack ⇒ 14.29%"
+        "description": "70 kg body, 10 kg pack \u21d2 14.29%"
       },
       {
-        "description": "80 kg body, 20 kg pack ⇒ 25%"
+        "description": "80 kg body, 20 kg pack \u21d2 25%"
       }
     ],
     "faqs": [
@@ -20248,10 +20248,10 @@
     "unit": "USD per lead",
     "examples": [
       {
-        "description": "$500 spend, 25 leads ⇒ $20/lead"
+        "description": "$500 spend, 25 leads \u21d2 $20/lead"
       },
       {
-        "description": "$1200 spend, 100 leads ⇒ $12/lead"
+        "description": "$1200 spend, 100 leads \u21d2 $12/lead"
       }
     ],
     "faqs": [
@@ -20318,10 +20318,10 @@
     "unit": "",
     "examples": [
       {
-        "description": "Cash 20000, Marketable Securities 5000, Accounts Receivable 15000, Current Liabilities 40000 ⇒ 1"
+        "description": "Cash 20000, Marketable Securities 5000, Accounts Receivable 15000, Current Liabilities 40000 \u21d2 1"
       },
       {
-        "description": "Cash 10000, Marketable Securities 2000, Accounts Receivable 8000, Current Liabilities 30000 ⇒ 0.67"
+        "description": "Cash 10000, Marketable Securities 2000, Accounts Receivable 8000, Current Liabilities 30000 \u21d2 0.67"
       }
     ],
     "faqs": [
@@ -20381,10 +20381,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "Balance 1000 USD, Rate 2%, Min Payment 25 USD ⇒ 25 USD"
+        "description": "Balance 1000 USD, Rate 2%, Min Payment 25 USD \u21d2 25 USD"
       },
       {
-        "description": "Balance 5000 USD, Rate 1.5%, Min Payment 25 USD ⇒ 75 USD"
+        "description": "Balance 5000 USD, Rate 1.5%, Min Payment 25 USD \u21d2 75 USD"
       }
     ],
     "faqs": [
@@ -20407,7 +20407,7 @@
     ],
     "disclaimer": "Results are estimates; check with your card issuer for exact payment requirements.",
     "info": [
-      "Many cards charge 1–3% of the balance as the minimum payment.",
+      "Many cards charge 1\u20133% of the balance as the minimum payment.",
       "Paying more than the minimum reduces interest costs."
     ]
   },
@@ -20437,10 +20437,10 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "Distance 5 km, Weight 70 kg ⇒ 362.6 kcal"
+        "description": "Distance 5 km, Weight 70 kg \u21d2 362.6 kcal"
       },
       {
-        "description": "Distance 3 km, Weight 80 kg ⇒ 248.64 kcal"
+        "description": "Distance 3 km, Weight 80 kg \u21d2 248.64 kcal"
       }
     ],
     "faqs": [
@@ -20485,10 +20485,10 @@
     "unit": "chars",
     "examples": [
       {
-        "description": "Hello ⇒ 5"
+        "description": "Hello \u21d2 5"
       },
       {
-        "description": "Spaces count too ⇒ 16"
+        "description": "Spaces count too \u21d2 16"
       }
     ],
     "faqs": [
@@ -20541,10 +20541,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Total Words 500, Keyword Occurrences 10 ⇒ 2%"
+        "description": "Total Words 500, Keyword Occurrences 10 \u21d2 2%"
       },
       {
-        "description": "Total Words 800, Keyword Occurrences 24 ⇒ 3%"
+        "description": "Total Words 800, Keyword Occurrences 24 \u21d2 3%"
       }
     ],
     "faqs": [
@@ -20604,16 +20604,16 @@
     "unit": "m",
     "examples": [
       {
-        "description": "20 m/s at 45° with gravity 9.81 ⇒ 40.77 m"
+        "description": "20 m/s at 45\u00b0 with gravity 9.81 \u21d2 40.77 m"
       },
       {
-        "description": "30 m/s at 30° with gravity 9.81 ⇒ 79.45 m"
+        "description": "30 m/s at 30\u00b0 with gravity 9.81 \u21d2 79.45 m"
       }
     ],
     "faqs": [
       {
-        "question": "Why is 45° the optimal angle for maximum range?",
-        "answer": "In a vacuum, 45° maximizes sin(2θ), giving the longest range."
+        "question": "Why is 45\u00b0 the optimal angle for maximum range?",
+        "answer": "In a vacuum, 45\u00b0 maximizes sin(2\u03b8), giving the longest range."
       },
       {
         "question": "Can I change gravity for other planets?",
@@ -20630,7 +20630,7 @@
     ],
     "disclaimer": "Idealized physics model; real-world ranges vary with conditions.",
     "info": [
-      "Gravity on Mars is about 3.71 m/s²."
+      "Gravity on Mars is about 3.71 m/s\u00b2."
     ]
   },
   {
@@ -20680,10 +20680,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$5,000 income, $500 debts, 5% rate, 30 years, 36% DTI ⇒ $242,166.10"
+        "description": "$5,000 income, $500 debts, 5% rate, 30 years, 36% DTI \u21d2 $242,166.10"
       },
       {
-        "description": "$7,000 income, $1,000 debts, 4% rate, 25 years, 30% DTI ⇒ $208,397.73"
+        "description": "$7,000 income, $1,000 debts, 4% rate, 25 years, 30% DTI \u21d2 $208,397.73"
       }
     ],
     "faqs": [
@@ -20742,10 +20742,10 @@
     "unit": "kg CO2",
     "examples": [
       {
-        "description": "500 km, 8 L/100km, 2.31 kg/L ⇒ 92.4 kg CO2"
+        "description": "500 km, 8 L/100km, 2.31 kg/L \u21d2 92.4 kg CO2"
       },
       {
-        "description": "350 km, 6.5 L/100km, 2.31 kg/L ⇒ 52.55 kg CO2"
+        "description": "350 km, 6.5 L/100km, 2.31 kg/L \u21d2 52.55 kg CO2"
       }
     ],
     "faqs": [
@@ -20804,10 +20804,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1,000 yearly, 5% rate, 5 periods ⇒ $4,329.48"
+        "description": "$1,000 yearly, 5% rate, 5 periods \u21d2 $4,329.48"
       },
       {
-        "description": "$2,000 yearly, 7% rate, 3 periods ⇒ $5,285.05"
+        "description": "$2,000 yearly, 7% rate, 3 periods \u21d2 $5,285.05"
       }
     ],
     "faqs": [
@@ -20884,10 +20884,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "85@20%, 90@30%, 80@50% ⇒ 84.5%"
+        "description": "85@20%, 90@30%, 80@50% \u21d2 84.5%"
       },
       {
-        "description": "70@25%, 80@25%, 90@50% ⇒ 82.5%"
+        "description": "70@25%, 80@25%, 90@50% \u21d2 82.5%"
       }
     ],
     "faqs": [
@@ -20929,10 +20929,10 @@
     "unit": "pH",
     "examples": [
       {
-        "description": "1e-3 mol/L ⇒ pH 3"
+        "description": "1e-3 mol/L \u21d2 pH 3"
       },
       {
-        "description": "2e-7 mol/L ⇒ pH 6.70"
+        "description": "2e-7 mol/L \u21d2 pH 6.70"
       }
     ],
     "faqs": [
@@ -20952,7 +20952,7 @@
     "disclaimer": "For dilute aqueous solutions; actual pH may vary with activity coefficients.",
     "info": [
       "pH is the negative base-10 logarithm of hydrogen ion concentration.",
-      "Pure water at 25°C has a pH close to 7."
+      "Pure water at 25\u00b0C has a pH close to 7."
     ]
   },
   {
@@ -20988,10 +20988,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$25,000 at 5% for 60 months ⇒ $471.78"
+        "description": "$25,000 at 5% for 60 months \u21d2 $471.78"
       },
       {
-        "description": "$18,000 at 3.5% for 48 months ⇒ $402.62"
+        "description": "$18,000 at 3.5% for 48 months \u21d2 $402.62"
       }
     ],
     "faqs": [
@@ -21033,10 +21033,10 @@
     "unit": "nmi",
     "examples": [
       {
-        "description": "10 km ⇒ 5.40 nmi"
+        "description": "10 km \u21d2 5.40 nmi"
       },
       {
-        "description": "100 km ⇒ 54.05 nmi"
+        "description": "100 km \u21d2 54.05 nmi"
       }
     ],
     "faqs": [
@@ -21050,7 +21050,7 @@
       },
       {
         "question": "Can I convert nautical miles to kilometers?",
-        "answer": "Use the reciprocal: km = nmi × 1.852."
+        "answer": "Use the reciprocal: km = nmi \u00d7 1.852."
       }
     ],
     "disclaimer": "Approximate conversion; round as needed for navigation.",
@@ -21075,7 +21075,7 @@
       },
       {
         "name": "volume",
-        "label": "Room Volume (ft³)",
+        "label": "Room Volume (ft\u00b3)",
         "type": "number",
         "step": "any",
         "placeholder": "1200"
@@ -21085,16 +21085,16 @@
     "unit": "ACH",
     "examples": [
       {
-        "description": "200 CFM in 1200 ft³ ⇒ 10 ACH"
+        "description": "200 CFM in 1200 ft\u00b3 \u21d2 10 ACH"
       },
       {
-        "description": "400 CFM in 1600 ft³ ⇒ 15 ACH"
+        "description": "400 CFM in 1600 ft\u00b3 \u21d2 15 ACH"
       }
     ],
     "faqs": [
       {
         "question": "What is a good ACH?",
-        "answer": "Living spaces often aim for 4–6 ACH; hospitals require higher rates."
+        "answer": "Living spaces often aim for 4\u20136 ACH; hospitals require higher rates."
       },
       {
         "question": "Does ceiling height matter?",
@@ -21107,7 +21107,7 @@
     ],
     "disclaimer": "Estimates only; consult HVAC professionals for precise requirements.",
     "info": [
-      "ACH = (CFM × 60) ÷ room volume.",
+      "ACH = (CFM \u00d7 60) \u00f7 room volume.",
       "Higher ACH improves air quality by removing pollutants."
     ]
   },
@@ -21116,7 +21116,7 @@
     "title": "Arithmetic Series Sum Calculator",
     "cluster": "Math",
     "description": "Sum the first n terms of an arithmetic series.",
-    "intro": "Find the sum of the first n terms in an arithmetic series using the formula S = n/2 × (2a₁ + (n−1)d).",
+    "intro": "Find the sum of the first n terms in an arithmetic series using the formula S = n/2 \u00d7 (2a\u2081 + (n\u22121)d).",
     "inputs": [
       {
         "name": "a1",
@@ -21144,10 +21144,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "a₁=1, d=1, n=100 ⇒ 5050"
+        "description": "a\u2081=1, d=1, n=100 \u21d2 5050"
       },
       {
-        "description": "a₁=3, d=2, n=5 ⇒ 35"
+        "description": "a\u2081=3, d=2, n=5 \u21d2 35"
       }
     ],
     "faqs": [
@@ -21196,10 +21196,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1200 with 4 travelers ⇒ $300 each"
+        "description": "$1200 with 4 travelers \u21d2 $300 each"
       },
       {
-        "description": "$750 with 3 travelers ⇒ $250 each"
+        "description": "$750 with 3 travelers \u21d2 $250 each"
       }
     ],
     "faqs": [
@@ -21248,10 +21248,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "50 GB at $0.10/GB ⇒ $5.00"
+        "description": "50 GB at $0.10/GB \u21d2 $5.00"
       },
       {
-        "description": "200 GB at $0.05/GB ⇒ $10.00"
+        "description": "200 GB at $0.05/GB \u21d2 $10.00"
       }
     ],
     "faqs": [
@@ -21321,10 +21321,10 @@
     "unit": "kcal/day",
     "examples": [
       {
-        "description": "70kg,175cm,30y,male,1.55 ⇒ 2556.6 kcal/day"
+        "description": "70kg,175cm,30y,male,1.55 \u21d2 2556.6 kcal/day"
       },
       {
-        "description": "60kg,160cm,25y,female,1.375 ⇒ 1843.8 kcal/day"
+        "description": "60kg,160cm,25y,female,1.375 \u21d2 1843.8 kcal/day"
       }
     ],
     "faqs": [
@@ -21387,10 +21387,10 @@
     "unit": "date",
     "examples": [
       {
-        "description": "2025-01-01 plus 4 weeks ⇒ 2025-01-29"
+        "description": "2025-01-01 plus 4 weeks \u21d2 2025-01-29"
       },
       {
-        "description": "2024-12-15 plus 6 weeks ⇒ 2025-01-26"
+        "description": "2024-12-15 plus 6 weeks \u21d2 2025-01-26"
       }
     ],
     "faqs": [
@@ -21439,10 +21439,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$500 cost, 200,000 impressions ⇒ $2.50"
+        "description": "$500 cost, 200,000 impressions \u21d2 $2.50"
       },
       {
-        "description": "$120 cost, 30,000 impressions ⇒ $4.00"
+        "description": "$120 cost, 30,000 impressions \u21d2 $4.00"
       }
     ],
     "faqs": [
@@ -21498,10 +21498,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "(3,4,12) ⇒ 13"
+        "description": "(3,4,12) \u21d2 13"
       },
       {
-        "description": "(1,2,2) ⇒ 3"
+        "description": "(1,2,2) \u21d2 3"
       }
     ],
     "faqs": [
@@ -21543,10 +21543,10 @@
     "unit": "kn",
     "examples": [
       {
-        "description": "10 m/s ⇒ 19.44 kn"
+        "description": "10 m/s \u21d2 19.44 kn"
       },
       {
-        "description": "15 m/s ⇒ 29.16 kn"
+        "description": "15 m/s \u21d2 29.16 kn"
       }
     ],
     "faqs": [
@@ -21602,10 +21602,10 @@
     "unit": "week",
     "examples": [
       {
-        "description": "June 15, 2025 ⇒ Week 3"
+        "description": "June 15, 2025 \u21d2 Week 3"
       },
       {
-        "description": "May 26, 2025 ⇒ Week 5"
+        "description": "May 26, 2025 \u21d2 Week 5"
       }
     ],
     "faqs": [
@@ -21654,16 +21654,16 @@
     "unit": "slides/min",
     "examples": [
       {
-        "description": "30 slides over 10 min ⇒ 3 slides/min"
+        "description": "30 slides over 10 min \u21d2 3 slides/min"
       },
       {
-        "description": "20 slides over 15 min ⇒ 1.33 slides/min"
+        "description": "20 slides over 15 min \u21d2 1.33 slides/min"
       }
     ],
     "faqs": [
       {
         "question": "What is a good slide pace?",
-        "answer": "Many presenters aim for 1–2 slides per minute."
+        "answer": "Many presenters aim for 1\u20132 slides per minute."
       },
       {
         "question": "Can I include transition time?",
@@ -21706,10 +21706,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "$500,000 sales with $250,000 assets ⇒ 2"
+        "description": "$500,000 sales with $250,000 assets \u21d2 2"
       },
       {
-        "description": "$750,000 sales with $300,000 assets ⇒ 2.5"
+        "description": "$750,000 sales with $300,000 assets \u21d2 2.5"
       }
     ],
     "faqs": [
@@ -21755,13 +21755,13 @@
       }
     ],
     "expression": "0.024265 * weight ** 0.5378 * height ** 0.3964",
-    "unit": "m²",
+    "unit": "m\u00b2",
     "examples": [
       {
-        "description": "70 kg & 175 cm ⇒ 1.85 m²"
+        "description": "70 kg & 175 cm \u21d2 1.85 m\u00b2"
       },
       {
-        "description": "50 kg & 160 cm ⇒ 1.49 m²"
+        "description": "50 kg & 160 cm \u21d2 1.49 m\u00b2"
       }
     ],
     "faqs": [
@@ -21810,16 +21810,16 @@
     "unit": "BTU/h",
     "examples": [
       {
-        "description": "300 sq ft at 30 BTU/sq ft ⇒ 9,000 BTU/h"
+        "description": "300 sq ft at 30 BTU/sq ft \u21d2 9,000 BTU/h"
       },
       {
-        "description": "500 sq ft at 25 BTU/sq ft ⇒ 12,500 BTU/h"
+        "description": "500 sq ft at 25 BTU/sq ft \u21d2 12,500 BTU/h"
       }
     ],
     "faqs": [
       {
         "question": "What BTU factor should I use?",
-        "answer": "Typical homes use 20–40 BTU per square foot depending on climate."
+        "answer": "Typical homes use 20\u201340 BTU per square foot depending on climate."
       },
       {
         "question": "Does ceiling height matter?",
@@ -21862,10 +21862,10 @@
     "unit": "nights",
     "examples": [
       {
-        "description": "50,000 points at 15,000/night ⇒ 3.33 nights"
+        "description": "50,000 points at 15,000/night \u21d2 3.33 nights"
       },
       {
-        "description": "120,000 points at 25,000/night ⇒ 4.8 nights"
+        "description": "120,000 points at 25,000/night \u21d2 4.8 nights"
       }
     ],
     "faqs": [
@@ -21907,10 +21907,10 @@
     "unit": "subsets",
     "examples": [
       {
-        "description": "3 elements ⇒ 8 subsets"
+        "description": "3 elements \u21d2 8 subsets"
       },
       {
-        "description": "5 elements ⇒ 32 subsets"
+        "description": "5 elements \u21d2 32 subsets"
       }
     ],
     "faqs": [
@@ -21959,10 +21959,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$200,000 liabilities & $500,000 assets ⇒ 40%"
+        "description": "$200,000 liabilities & $500,000 assets \u21d2 40%"
       },
       {
-        "description": "$150,000 liabilities & $300,000 assets ⇒ 50%"
+        "description": "$150,000 liabilities & $300,000 assets \u21d2 50%"
       }
     ],
     "faqs": [
@@ -22018,10 +22018,10 @@
     "unit": "J",
     "examples": [
       {
-        "description": "10 kg at 5 m ⇒ 490.5 J"
+        "description": "10 kg at 5 m \u21d2 490.5 J"
       },
       {
-        "description": "2 kg at 2 m ⇒ 39.24 J"
+        "description": "2 kg at 2 m \u21d2 39.24 J"
       }
     ],
     "faqs": [
@@ -22070,10 +22070,10 @@
     "unit": "MP",
     "examples": [
       {
-        "description": "4000 × 3000 ⇒ 12 MP"
+        "description": "4000 \u00d7 3000 \u21d2 12 MP"
       },
       {
-        "description": "8000 × 6000 ⇒ 48 MP"
+        "description": "8000 \u00d7 6000 \u21d2 48 MP"
       }
     ],
     "faqs": [
@@ -22122,10 +22122,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "150 clicks, 1000 opens ⇒ 15%"
+        "description": "150 clicks, 1000 opens \u21d2 15%"
       },
       {
-        "description": "60 clicks, 800 opens ⇒ 7.5%"
+        "description": "60 clicks, 800 opens \u21d2 7.5%"
       }
     ],
     "faqs": [
@@ -22164,13 +22164,13 @@
       }
     ],
     "expression": "radians * 180 / 3.141592653589793",
-    "unit": "°",
+    "unit": "\u00b0",
     "examples": [
       {
-        "description": "1 rad ⇒ 57.2958 °"
+        "description": "1 rad \u21d2 57.2958 \u00b0"
       },
       {
-        "description": "3.1416 rad ⇒ 180 °"
+        "description": "3.1416 rad \u21d2 180 \u00b0"
       }
     ],
     "faqs": [
@@ -22189,7 +22189,7 @@
     ],
     "disclaimer": "For simple angle conversions; rounding may occur.",
     "info": [
-      "There are 2π radians in a full circle.",
+      "There are 2\u03c0 radians in a full circle.",
       "Degrees and radians are common angle units."
     ]
   },
@@ -22219,10 +22219,10 @@
     "unit": "hours",
     "examples": [
       {
-        "description": "Bed 22, wake 6 ⇒ 8 hours"
+        "description": "Bed 22, wake 6 \u21d2 8 hours"
       },
       {
-        "description": "Bed 23, wake 7 ⇒ 8 hours"
+        "description": "Bed 23, wake 7 \u21d2 8 hours"
       }
     ],
     "faqs": [
@@ -22271,10 +22271,10 @@
     "unit": "wpm",
     "examples": [
       {
-        "description": "3000 words in 15 min ⇒ 200 wpm"
+        "description": "3000 words in 15 min \u21d2 200 wpm"
       },
       {
-        "description": "1500 words in 10 min ⇒ 150 wpm"
+        "description": "1500 words in 10 min \u21d2 150 wpm"
       }
     ],
     "faqs": [
@@ -22323,10 +22323,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "$5000 revenue, $3500 expenses ⇒ 30 %"
+        "description": "$5000 revenue, $3500 expenses \u21d2 30 %"
       },
       {
-        "description": "$10000 revenue, $7500 expenses ⇒ 25 %"
+        "description": "$10000 revenue, $7500 expenses \u21d2 25 %"
       }
     ],
     "faqs": [
@@ -22372,13 +22372,13 @@
       }
     ],
     "expression": "weight / ((height/100)^3)",
-    "unit": "kg/m³",
+    "unit": "kg/m\u00b3",
     "examples": [
       {
-        "description": "70 kg, 175 cm ⇒ 13.3 kg/m³"
+        "description": "70 kg, 175 cm \u21d2 13.3 kg/m\u00b3"
       },
       {
-        "description": "60 kg, 160 cm ⇒ 14.6 kg/m³"
+        "description": "60 kg, 160 cm \u21d2 14.6 kg/m\u00b3"
       }
     ],
     "faqs": [
@@ -22434,10 +22434,10 @@
     "unit": "L",
     "examples": [
       {
-        "description": "4 posts, 30 cm × 80 cm ⇒ 226 L"
+        "description": "4 posts, 30 cm \u00d7 80 cm \u21d2 226 L"
       },
       {
-        "description": "6 posts, 20 cm × 60 cm ⇒ 113 L"
+        "description": "6 posts, 20 cm \u00d7 60 cm \u21d2 113 L"
       }
     ],
     "faqs": [
@@ -22486,10 +22486,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1500 budget over 10 days ⇒ $150 per day"
+        "description": "$1500 budget over 10 days \u21d2 $150 per day"
       },
       {
-        "description": "$800 budget over 5 days ⇒ $160 per day"
+        "description": "$800 budget over 5 days \u21d2 $160 per day"
       }
     ],
     "faqs": [
@@ -22542,13 +22542,13 @@
       }
     ],
     "expression": "0.5 * base * height * length",
-    "unit": "m³",
+    "unit": "m\u00b3",
     "examples": [
       {
-        "description": "Base 3 m, height 2 m, length 5 m ⇒ 15 m³"
+        "description": "Base 3 m, height 2 m, length 5 m \u21d2 15 m\u00b3"
       },
       {
-        "description": "Base 1.5 m, height 4 m, length 2 m ⇒ 6 m³"
+        "description": "Base 1.5 m, height 4 m, length 2 m \u21d2 6 m\u00b3"
       }
     ],
     "faqs": [
@@ -22604,10 +22604,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$5000 goal, 12 months, $1000 saved ⇒ $333.33 per month"
+        "description": "$5000 goal, 12 months, $1000 saved \u21d2 $333.33 per month"
       },
       {
-        "description": "$10000 goal, 24 months, $2000 saved ⇒ $333.33 per month"
+        "description": "$10000 goal, 24 months, $2000 saved \u21d2 $333.33 per month"
       }
     ],
     "faqs": [
@@ -22656,16 +22656,16 @@
     "unit": "W",
     "examples": [
       {
-        "description": "R=6.96e8 m, T=5778 K ⇒ 3.85e26 W"
+        "description": "R=6.96e8 m, T=5778 K \u21d2 3.85e26 W"
       },
       {
-        "description": "R=1e8 m, T=3000 K ⇒ 5.77e23 W"
+        "description": "R=1e8 m, T=3000 K \u21d2 5.77e23 W"
       }
     ],
     "faqs": [
       {
         "question": "What constant is used?",
-        "answer": "The calculation uses the Stefan–Boltzmann constant 5.670374419×10⁻⁸."
+        "answer": "The calculation uses the Stefan\u2013Boltzmann constant 5.670374419\u00d710\u207b\u2078."
       },
       {
         "question": "Are inputs in SI units?",
@@ -22708,10 +22708,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "720 uptime, 730 total ⇒ 98.63 %"
+        "description": "720 uptime, 730 total \u21d2 98.63 %"
       },
       {
-        "description": "99 uptime, 100 total ⇒ 99 %"
+        "description": "99 uptime, 100 total \u21d2 99 %"
       }
     ],
     "faqs": [
@@ -22760,10 +22760,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$5000 spend, 200 customers ⇒ $25"
+        "description": "$5000 spend, 200 customers \u21d2 $25"
       },
       {
-        "description": "$1200 spend, 60 customers ⇒ $20"
+        "description": "$1200 spend, 60 customers \u21d2 $20"
       }
     ],
     "faqs": [
@@ -22833,10 +22833,10 @@
     "unit": "years",
     "examples": [
       {
-        "description": "$50,000 savings, $10,000 yearly contribution, $30,000 expenses, 7% return, 2% inflation ⇒ 27.65 years"
+        "description": "$50,000 savings, $10,000 yearly contribution, $30,000 expenses, 7% return, 2% inflation \u21d2 27.65 years"
       },
       {
-        "description": "$200,000 savings, $20,000 yearly contribution, $40,000 expenses, 8% return, 3% inflation ⇒ 17.64 years"
+        "description": "$200,000 savings, $20,000 yearly contribution, $40,000 expenses, 8% return, 3% inflation \u21d2 17.64 years"
       }
     ],
     "faqs": [
@@ -22920,10 +22920,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$200,000 loan, 3.5% for 5y then 5% for 25y, $800 insurance, $10,000 prepayment ⇒ $499,000"
+        "description": "$200,000 loan, 3.5% for 5y then 5% for 25y, $800 insurance, $10,000 prepayment \u21d2 $499,000"
       },
       {
-        "description": "$150,000 loan, 4% for 3y then 6% for 27y, $600 insurance, $5,000 prepayment ⇒ $424,000"
+        "description": "$150,000 loan, 4% for 3y then 6% for 27y, $600 insurance, $5,000 prepayment \u21d2 $424,000"
       }
     ],
     "faqs": [
@@ -22993,10 +22993,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Age 50, TC 200, SBP 120, HDL 50, non-smoker ⇒ 10.4 %"
+        "description": "Age 50, TC 200, SBP 120, HDL 50, non-smoker \u21d2 10.4 %"
       },
       {
-        "description": "Age 60, TC 250, SBP 140, HDL 40, smoker ⇒ 18 %"
+        "description": "Age 60, TC 250, SBP 140, HDL 40, smoker \u21d2 18 %"
       }
     ],
     "faqs": [
@@ -23045,16 +23045,16 @@
     "unit": "kg",
     "examples": [
       {
-        "description": "80 kg for 5 reps ⇒ 90 kg"
+        "description": "80 kg for 5 reps \u21d2 90 kg"
       },
       {
-        "description": "100 kg for 10 reps ⇒ 133.33 kg"
+        "description": "100 kg for 10 reps \u21d2 133.33 kg"
       }
     ],
     "faqs": [
       {
         "question": "What is the Brzycki formula?",
-        "answer": "It estimates 1RM as weight × 36 ÷ (37 − reps)."
+        "answer": "It estimates 1RM as weight \u00d7 36 \u00f7 (37 \u2212 reps)."
       },
       {
         "question": "Is it accurate for high reps?",
@@ -23097,10 +23097,10 @@
     "unit": "minutes",
     "examples": [
       {
-        "description": "500 kcal at 10 kcal/min ⇒ 50 minutes"
+        "description": "500 kcal at 10 kcal/min \u21d2 50 minutes"
       },
       {
-        "description": "300 kcal at 8 kcal/min ⇒ 37.5 minutes"
+        "description": "300 kcal at 8 kcal/min \u21d2 37.5 minutes"
       }
     ],
     "faqs": [
@@ -23191,10 +23191,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Midterms 80% & 70%, project 90%, weights 30/20/20, final 30%, target 85% ⇒ 96.67 %"
+        "description": "Midterms 80% & 70%, project 90%, weights 30/20/20, final 30%, target 85% \u21d2 96.67 %"
       },
       {
-        "description": "Midterms 85% & 80%, project 90%, weights 25/25/20, final 30%, target 88% ⇒ 95.83 %"
+        "description": "Midterms 85% & 80%, project 90%, weights 25/25/20, final 30%, target 88% \u21d2 95.83 %"
       }
     ],
     "faqs": [
@@ -23250,10 +23250,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "Allowed 20 kg, actual 25 kg, $50 per kg ⇒ $250"
+        "description": "Allowed 20 kg, actual 25 kg, $50 per kg \u21d2 $250"
       },
       {
-        "description": "Allowed 23 kg, actual 22 kg, $100 per kg ⇒ $0"
+        "description": "Allowed 23 kg, actual 22 kg, $100 per kg \u21d2 $0"
       }
     ],
     "faqs": [
@@ -23285,21 +23285,21 @@
     "inputs": [
       {
         "name": "area",
-        "label": "Area (m²)",
+        "label": "Area (m\u00b2)",
         "type": "number",
         "step": "any",
         "placeholder": "50"
       },
       {
         "name": "material_cost",
-        "label": "Material cost per m² (USD)",
+        "label": "Material cost per m\u00b2 (USD)",
         "type": "number",
         "step": "any",
         "placeholder": "100"
       },
       {
         "name": "labor_cost",
-        "label": "Labor cost per m² (USD)",
+        "label": "Labor cost per m\u00b2 (USD)",
         "type": "number",
         "step": "any",
         "placeholder": "80"
@@ -23316,10 +23316,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "50 m², $100 material, $80 labor, 10% contingency ⇒ $9,900"
+        "description": "50 m\u00b2, $100 material, $80 labor, 10% contingency \u21d2 $9,900"
       },
       {
-        "description": "80 m², $150 material, $90 labor, 15% contingency ⇒ $22,080"
+        "description": "80 m\u00b2, $150 material, $90 labor, 15% contingency \u21d2 $22,080"
       }
     ],
     "faqs": [
@@ -23338,7 +23338,7 @@
     ],
     "disclaimer": "Rough estimate; obtain contractor quotes for accuracy.",
     "info": [
-      "A 10–20% contingency is common for remodeling projects.",
+      "A 10\u201320% contingency is common for remodeling projects.",
       "Material quality greatly impacts total cost."
     ]
   },
@@ -23375,10 +23375,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "$5,000 fixed costs, $50 price, $30 cost ⇒ 250 units"
+        "description": "$5,000 fixed costs, $50 price, $30 cost \u21d2 250 units"
       },
       {
-        "description": "$10,000 fixed costs, $80 price, $45 cost ⇒ 285.71 units"
+        "description": "$10,000 fixed costs, $80 price, $45 cost \u21d2 285.71 units"
       }
     ],
     "faqs": [
@@ -23434,10 +23434,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "2 h, 5 participants, $50/h ⇒ $500"
+        "description": "2 h, 5 participants, $50/h \u21d2 $500"
       },
       {
-        "description": "1 h, 10 participants, $40/h ⇒ $400"
+        "description": "1 h, 10 participants, $40/h \u21d2 $400"
       }
     ],
     "faqs": [
@@ -23486,10 +23486,10 @@
     "unit": "L",
     "examples": [
       {
-        "description": "150 L direct + 3000 L indirect ⇒ 3150 L"
+        "description": "150 L direct + 3000 L indirect \u21d2 3150 L"
       },
       {
-        "description": "200 L direct + 2500 L indirect ⇒ 2700 L"
+        "description": "200 L direct + 2500 L indirect \u21d2 2700 L"
       }
     ],
     "faqs": [
@@ -23538,10 +23538,10 @@
     "unit": "probability",
     "examples": [
       {
-        "description": "49 numbers, 6 drawn ⇒ 7.15e-8 probability"
+        "description": "49 numbers, 6 drawn \u21d2 7.15e-8 probability"
       },
       {
-        "description": "10 numbers, 3 drawn ⇒ 0.00833 probability"
+        "description": "10 numbers, 3 drawn \u21d2 0.00833 probability"
       }
     ],
     "faqs": [
@@ -23592,10 +23592,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "$50,000 income ÷ $40,000 debt ⇒ 1.25 ratio"
+        "description": "$50,000 income \u00f7 $40,000 debt \u21d2 1.25 ratio"
       },
       {
-        "description": "$80,000 income ÷ $60,000 debt ⇒ 1.33 ratio"
+        "description": "$80,000 income \u00f7 $60,000 debt \u21d2 1.33 ratio"
       }
     ],
     "faqs": [
@@ -23662,10 +23662,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$1,200 rent, $250,000 home, 4% for 5 years ⇒ $22,000"
+        "description": "$1,200 rent, $250,000 home, 4% for 5 years \u21d2 $22,000"
       },
       {
-        "description": "$900 rent, $400,000 home, 6% for 5 years ⇒ -$66,000"
+        "description": "$900 rent, $400,000 home, 6% for 5 years \u21d2 -$66,000"
       }
     ],
     "faqs": [
@@ -23732,10 +23732,10 @@
     "unit": "g",
     "examples": [
       {
-        "description": "2000 kcal with 30% protein, 40% carbs, 30% fat ⇒ Protein: 150 g, Carbs: 200 g, Fat: 66.7 g"
+        "description": "2000 kcal with 30% protein, 40% carbs, 30% fat \u21d2 Protein: 150 g, Carbs: 200 g, Fat: 66.7 g"
       },
       {
-        "description": "1800 kcal with 25% protein, 50% carbs, 25% fat ⇒ Protein: 112.5 g, Carbs: 225 g, Fat: 50 g"
+        "description": "1800 kcal with 25% protein, 50% carbs, 25% fat \u21d2 Protein: 112.5 g, Carbs: 225 g, Fat: 50 g"
       }
     ],
     "faqs": [
@@ -23809,13 +23809,13 @@
       }
     ],
     "expression": "(o1-e1)*(o1-e1)/e1 + (o2-e2)*(o2-e2)/e2 + (o3-e3)*(o3-e3)/e3",
-    "unit": "χ²",
+    "unit": "\u03c7\u00b2",
     "examples": [
       {
-        "description": "Observed [20,30,50], Expected [25,35,40] ⇒ 4.21 χ²"
+        "description": "Observed [20,30,50], Expected [25,35,40] \u21d2 4.21 \u03c7\u00b2"
       },
       {
-        "description": "Observed [10,20,30], Expected [10,15,25] ⇒ 2.67 χ²"
+        "description": "Observed [10,20,30], Expected [10,15,25] \u21d2 2.67 \u03c7\u00b2"
       }
     ],
     "faqs": [
@@ -23858,10 +23858,10 @@
     "unit": "g",
     "examples": [
       {
-        "description": "1 cup ⇒ 120 g"
+        "description": "1 cup \u21d2 120 g"
       },
       {
-        "description": "2.5 cups ⇒ 300 g"
+        "description": "2.5 cups \u21d2 300 g"
       }
     ],
     "faqs": [
@@ -23919,10 +23919,10 @@
     "unit": "hour",
     "examples": [
       {
-        "description": "9:00 at UTC-5 to UTC+0 ⇒ 14:00"
+        "description": "9:00 at UTC-5 to UTC+0 \u21d2 14:00"
       },
       {
-        "description": "15:00 at UTC+0 to UTC+9 ⇒ 0:00"
+        "description": "15:00 at UTC+0 to UTC+9 \u21d2 0:00"
       }
     ],
     "faqs": [
@@ -23981,10 +23981,10 @@
     "unit": "grade level",
     "examples": [
       {
-        "description": "250 words, 10 sentences, 400 syllables ⇒ 13.04 grade"
+        "description": "250 words, 10 sentences, 400 syllables \u21d2 13.04 grade"
       },
       {
-        "description": "100 words, 5 sentences, 120 syllables ⇒ 6.37 grade"
+        "description": "100 words, 5 sentences, 120 syllables \u21d2 6.37 grade"
       }
     ],
     "faqs": [
@@ -24049,10 +24049,10 @@
     "unit": "Hz",
     "examples": [
       {
-        "description": "500 Hz, observer 10 m/s, source 20 m/s ⇒ 546.44 Hz"
+        "description": "500 Hz, observer 10 m/s, source 20 m/s \u21d2 546.44 Hz"
       },
       {
-        "description": "1000 Hz, observer 0 m/s, source 30 m/s ⇒ 1095.85 Hz"
+        "description": "1000 Hz, observer 0 m/s, source 30 m/s \u21d2 1095.85 Hz"
       }
     ],
     "faqs": [
@@ -24141,10 +24141,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "Black (0,0,0) vs White (255,255,255) ⇒ 21.00:1"
+        "description": "Black (0,0,0) vs White (255,255,255) \u21d2 21.00:1"
       },
       {
-        "description": "#123456 vs #ABCDEF ⇒ 7.70:1"
+        "description": "#123456 vs #ABCDEF \u21d2 7.70:1"
       }
     ],
     "faqs": [
@@ -24211,10 +24211,10 @@
     "unit": "USD/year",
     "examples": [
       {
-        "description": "5 h, 300 W, 10 panels, $0.12/kWh ⇒ $657/year"
+        "description": "5 h, 300 W, 10 panels, $0.12/kWh \u21d2 $657/year"
       },
       {
-        "description": "4 h, 400 W, 8 panels, $0.15/kWh ⇒ $700.80/year"
+        "description": "4 h, 400 W, 8 panels, $0.15/kWh \u21d2 $700.80/year"
       }
     ],
     "faqs": [
@@ -24257,10 +24257,10 @@
     "unit": "km",
     "examples": [
       {
-        "description": "2 m ⇒ 5.05 km"
+        "description": "2 m \u21d2 5.05 km"
       },
       {
-        "description": "100 m ⇒ 35.70 km"
+        "description": "100 m \u21d2 35.70 km"
       }
     ],
     "faqs": [
@@ -24281,60 +24281,6 @@
     "info": [
       "Formula uses Earth's mean radius of about 6,371 km.",
       "Result gives distance to the geometric horizon in kilometers."
-    ]
-  },
-  {
-    "slug": "ab-test-sample-size",
-    "title": "A/B Test Sample Size Calculator",
-    "cluster": "Web & Marketing",
-    "description": "Determine visitors needed per variant for an A/B test.",
-    "intro": "Provide a baseline conversion rate and desired lift to estimate the required sample size per variant.",
-    "inputs": [
-      {
-        "name": "base",
-        "label": "Baseline Conversion Rate (%)",
-        "type": "number",
-        "min": 0,
-        "step": "any",
-        "placeholder": "5"
-      },
-      {
-        "name": "mde",
-        "label": "Desired Lift (%)",
-        "type": "number",
-        "min": 0,
-        "step": "any",
-        "placeholder": "1"
-      }
-    ],
-    "expression": "(function(base,mde){const p1=base/100;const p2=(base+mde)/100;const pbar=(p1+p2)/2;const z1=1.96;const z2=0.84;return Math.ceil(((z1*Math.sqrt(2*pbar*(1-pbar))+z2*Math.sqrt(p1*(1-p1)+p2*(1-p2)))**2)/((p1-p2)**2));})(base,mde)",
-    "unit": "visitors",
-    "examples": [
-      {
-        "description": "5% baseline, 1% lift ⇒ 8149 visitors"
-      },
-      {
-        "description": "10% baseline, 2% lift ⇒ 3837 visitors"
-      }
-    ],
-    "faqs": [
-      {
-        "question": "What confidence and power are assumed?",
-        "answer": "The formula uses 95% confidence (z=1.96) and 80% power (z=0.84)."
-      },
-      {
-        "question": "Is sample size per variant or total?",
-        "answer": "Results represent the required visitors per variant."
-      },
-      {
-        "question": "Can I change confidence levels?",
-        "answer": "Adjust the z-scores in the formula for different confidence or power."
-      }
-    ],
-    "disclaimer": "For planning experiments; real-world tests may require adjustments for variance and behavior.",
-    "info": [
-      "Useful for marketing and UX optimization experiments.",
-      "Higher baseline rates or smaller lifts require larger samples."
     ]
   },
   {
@@ -24373,10 +24319,10 @@
     "unit": "USD/share",
     "examples": [
       {
-        "description": "$1,000,000 net income, $50,000 dividends, 200,000 shares ⇒ $4.75 USD/share"
+        "description": "$1,000,000 net income, $50,000 dividends, 200,000 shares \u21d2 $4.75 USD/share"
       },
       {
-        "description": "$500,000 net income, $0 dividends, 100,000 shares ⇒ $5.00 USD/share"
+        "description": "$500,000 net income, $0 dividends, 100,000 shares \u21d2 $5.00 USD/share"
       }
     ],
     "faqs": [
@@ -24446,10 +24392,10 @@
     "unit": "USD",
     "examples": [
       {
-        "description": "$60,000 salary, 5% employee, 50% match up to 5% ⇒ $4,500 USD"
+        "description": "$60,000 salary, 5% employee, 50% match up to 5% \u21d2 $4,500 USD"
       },
       {
-        "description": "$80,000 salary, 8% employee, 100% match up to 3% ⇒ $8,800 USD"
+        "description": "$80,000 salary, 8% employee, 100% match up to 3% \u21d2 $8,800 USD"
       }
     ],
     "faqs": [
@@ -24516,10 +24462,10 @@
     "unit": "units",
     "examples": [
       {
-        "description": "Mean 50 units, SD 5, n 30, 95% ⇒ 48.21 to 51.79 units"
+        "description": "Mean 50 units, SD 5, n 30, 95% \u21d2 48.21 to 51.79 units"
       },
       {
-        "description": "Mean 120 units, SD 20, n 100, 90% ⇒ 116.71 to 123.29 units"
+        "description": "Mean 120 units, SD 20, n 100, 90% \u21d2 116.71 to 123.29 units"
       }
     ],
     "faqs": [
@@ -24562,10 +24508,10 @@
     "unit": "kWh",
     "examples": [
       {
-        "description": "10,000 BTU ⇒ 2.93 kWh"
+        "description": "10,000 BTU \u21d2 2.93 kWh"
       },
       {
-        "description": "5,000 BTU ⇒ 1.47 kWh"
+        "description": "5,000 BTU \u21d2 1.47 kWh"
       }
     ],
     "faqs": [
@@ -24616,10 +24562,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Rank 10 in class of 250 ⇒ 96.4%"
+        "description": "Rank 10 in class of 250 \u21d2 96.4%"
       },
       {
-        "description": "Rank 50 in class of 100 ⇒ 51.0%"
+        "description": "Rank 50 in class of 100 \u21d2 51.0%"
       }
     ],
     "faqs": [
@@ -24670,10 +24616,10 @@
     "unit": "ratio",
     "examples": [
       {
-        "description": "Thrust 100,000 N, weight 40,000 N ⇒ 2.5 ratio"
+        "description": "Thrust 100,000 N, weight 40,000 N \u21d2 2.5 ratio"
       },
       {
-        "description": "Thrust 500,000 N, weight 450,000 N ⇒ 1.11 ratio"
+        "description": "Thrust 500,000 N, weight 450,000 N \u21d2 1.11 ratio"
       }
     ],
     "faqs": [
@@ -24732,16 +24678,16 @@
     "unit": "kcal",
     "examples": [
       {
-        "description": "70 kg, 30 min, MET 8 ⇒ 294 kcal"
+        "description": "70 kg, 30 min, MET 8 \u21d2 294 kcal"
       },
       {
-        "description": "80 kg, 45 min, MET 10 ⇒ 630 kcal"
+        "description": "80 kg, 45 min, MET 10 \u21d2 630 kcal"
       }
     ],
     "faqs": [
       {
         "question": "What MET should I use?",
-        "answer": "Freestyle moderate ≈8, vigorous ≈10; breaststroke ≈10."
+        "answer": "Freestyle moderate \u22488, vigorous \u224810; breaststroke \u224810."
       },
       {
         "question": "Does this include rest periods?",
@@ -24787,16 +24733,16 @@
     "unit": "GL",
     "examples": [
       {
-        "description": "40 g carbs with GI 70 ⇒ 28 GL"
+        "description": "40 g carbs with GI 70 \u21d2 28 GL"
       },
       {
-        "description": "15 g carbs with GI 30 ⇒ 4.5 GL"
+        "description": "15 g carbs with GI 30 \u21d2 4.5 GL"
       }
     ],
     "faqs": [
       {
         "question": "What is considered low GL?",
-        "answer": "Less than 10 is low, 10–20 is medium, and over 20 is high."
+        "answer": "Less than 10 is low, 10\u201320 is medium, and over 20 is high."
       },
       {
         "question": "Can GI exceed 100?",
@@ -24849,10 +24795,10 @@
     "unit": "USD/mile",
     "examples": [
       {
-        "description": "$500 fare, 30,000 miles, $50 fees ⇒ $0.015 USD/mile"
+        "description": "$500 fare, 30,000 miles, $50 fees \u21d2 $0.015 USD/mile"
       },
       {
-        "description": "$750 fare, 45,000 miles, $80 fees ⇒ $0.0149 USD/mile"
+        "description": "$750 fare, 45,000 miles, $80 fees \u21d2 $0.0149 USD/mile"
       }
     ],
     "faqs": [
@@ -24862,7 +24808,7 @@
       },
       {
         "question": "What value is considered good?",
-        "answer": "Typical mile values range from 1¢ to 2¢ each."
+        "answer": "Typical mile values range from 1\u00a2 to 2\u00a2 each."
       },
       {
         "question": "Does this include miles earned on cash tickets?",
@@ -24911,10 +24857,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "Start 500, end 450, new 100 ⇒ 70.0%"
+        "description": "Start 500, end 450, new 100 \u21d2 70.0%"
       },
       {
-        "description": "Start 800, end 760, new 50 ⇒ 88.75%"
+        "description": "Start 800, end 760, new 50 \u21d2 88.75%"
       }
     ],
     "faqs": [
@@ -24965,10 +24911,10 @@
     "unit": "gallons/min",
     "examples": [
       {
-        "description": "40 gallons in 2 minutes ⇒ 20 gallons/min"
+        "description": "40 gallons in 2 minutes \u21d2 20 gallons/min"
       },
       {
-        "description": "25 gallons in 1 minute ⇒ 25 gallons/min"
+        "description": "25 gallons in 1 minute \u21d2 25 gallons/min"
       }
     ],
     "faqs": [
@@ -24987,7 +24933,7 @@
     ],
     "disclaimer": "Basic sizing; consult a professional for high-risk areas.",
     "info": [
-      "Typical household sump pumps range from 20–60 gallons per minute.",
+      "Typical household sump pumps range from 20\u201360 gallons per minute.",
       "Consider power outages and backup options for critical installations."
     ]
   },
@@ -25019,10 +24965,10 @@
     "unit": "%",
     "examples": [
       {
-        "description": "100,000 hashes, 32-bit hash ⇒ 68.8%"
+        "description": "100,000 hashes, 32-bit hash \u21d2 68.8%"
       },
       {
-        "description": "1,000,000 hashes, 64-bit hash ⇒ 0.0000027%"
+        "description": "1,000,000 hashes, 64-bit hash \u21d2 0.0000027%"
       }
     ],
     "faqs": [
@@ -25043,6 +24989,636 @@
     "info": [
       "Probability grows roughly with the square of the number of hashes.",
       "Cryptographic algorithms often use 256-bit hashes to minimize collisions."
+    ]
+  },
+  {
+    "slug": "decibel-to-power-percentage",
+    "title": "Decibel to Power Percentage Calculator",
+    "cluster": "Conversions & Units",
+    "description": "Convert decibel values to linear power percentages.",
+    "intro": "This tool converts a decibel (dB) value into a corresponding power percentage relative to the reference level. Enter a dB value to see the equivalent percent of power.",
+    "inputs": [
+      {
+        "name": "db",
+        "label": "Decibels (dB)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "3"
+      }
+    ],
+    "expression": "Math.pow(10, db/10) * 100",
+    "unit": "%",
+    "examples": [
+      {
+        "description": "3 dB \u21d2 199.53 %"
+      },
+      {
+        "description": "-10 dB \u21d2 10 %"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What does a negative dB value mean?",
+        "answer": "It indicates power lower than the reference level."
+      },
+      {
+        "question": "Is 0 dB equal to 100%?",
+        "answer": "Yes, 0 dB corresponds to the reference power."
+      },
+      {
+        "question": "Can this calculator handle fractional dB values?",
+        "answer": "Yes, decimals are supported for precise conversions."
+      }
+    ],
+    "disclaimer": "Verify critical audio or RF measurements with calibrated equipment.",
+    "info": [
+      "Uses formula 10^(dB/10)*100 to convert decibels to power percentage.",
+      "Common in audio engineering and signal processing."
+    ]
+  },
+  {
+    "slug": "next-full-moon",
+    "title": "Next Full Moon Calculator",
+    "cluster": "Date & Time",
+    "description": "Estimate days until the next full moon from a given date.",
+    "intro": "This calculator approximates the number of days until the next full moon. Enter a date to get an estimate based on the average lunar cycle.",
+    "inputs": [
+      {
+        "name": "year",
+        "label": "Year",
+        "type": "number",
+        "placeholder": "2024"
+      },
+      {
+        "name": "month",
+        "label": "Month",
+        "type": "number",
+        "placeholder": "5"
+      },
+      {
+        "name": "day",
+        "label": "Day",
+        "type": "number",
+        "placeholder": "1"
+      }
+    ],
+    "expression": "(() => { const d=Date.UTC(year,month-1,day)/86400000; const known=Date.UTC(2024,0,25)/86400000; const cycle=29.530588853; return Math.ceil((cycle - ((d - known) % cycle)) % cycle); })()",
+    "unit": "days",
+    "examples": [
+      {
+        "description": "2024-05-01 \u21d2 21 days"
+      },
+      {
+        "description": "2024-09-10 \u21d2 7 days"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "How accurate is this calculator?",
+        "answer": "It uses an average lunar cycle of 29.53 days, so results are approximate."
+      },
+      {
+        "question": "What time zone is used?",
+        "answer": "Dates are handled in UTC for simplicity."
+      },
+      {
+        "question": "Can I enter past dates?",
+        "answer": "Yes, it finds the next full moon after the given date."
+      }
+    ],
+    "disclaimer": "Approximate astronomical calculation; consult official lunar tables for precise times.",
+    "info": [
+      "The synodic month averages 29.530588853 days.",
+      "Full moon dates shift slightly due to orbital variations."
+    ]
+  },
+  {
+    "slug": "cefr-study-hours",
+    "title": "CEFR Study Hours Estimator",
+    "cluster": "Education & Learning",
+    "description": "Estimate hours needed to reach a target CEFR level.",
+    "intro": "Estimate additional study hours required to progress from your current CEFR language level to a target level. Use 0 for no level, 1 for A1 up to 6 for C2.",
+    "inputs": [
+      {
+        "name": "current",
+        "label": "Current Level (0-6)",
+        "type": "number",
+        "placeholder": "2"
+      },
+      {
+        "name": "target",
+        "label": "Target Level (1-6)",
+        "type": "number",
+        "placeholder": "4"
+      }
+    ],
+    "expression": "(() => { const h=[0,100,200,350,500,700,1000]; return Math.max(0, h[target]-h[current]); })()",
+    "unit": "hours",
+    "examples": [
+      {
+        "description": "Current A2 (2) to B2 (4) \u21d2 300 hours"
+      },
+      {
+        "description": "Current B1 (3) to C1 (5) \u21d2 350 hours"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What do the numeric levels mean?",
+        "answer": "Use 1 for A1 up to 6 for C2; 0 indicates no prior study."
+      },
+      {
+        "question": "Are these hours exact?",
+        "answer": "No, they are estimates based on common teaching guidelines."
+      },
+      {
+        "question": "Does the calculator account for language difficulty?",
+        "answer": "No, it uses general averages regardless of language."
+      }
+    ],
+    "disclaimer": "For study planning only; adjust based on personal progress.",
+    "info": [
+      "Estimates derived from CEFR self-study hour ranges.",
+      "Actual time needed varies with prior knowledge and exposure."
+    ]
+  },
+  {
+    "slug": "dividend-reinvestment",
+    "title": "Dividend Reinvestment Calculator",
+    "cluster": "Finance & Business",
+    "description": "Project investment value when dividends are reinvested.",
+    "intro": "Estimate the future value of an investment when dividends are reinvested and the stock price grows annually. Enter initial investment, dividend yield, growth rate, and years.",
+    "inputs": [
+      {
+        "name": "initial",
+        "label": "Initial Investment ($)",
+        "type": "number",
+        "placeholder": "5000"
+      },
+      {
+        "name": "yield",
+        "label": "Dividend Yield (%)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "3"
+      },
+      {
+        "name": "growth",
+        "label": "Price Growth (%)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "2"
+      },
+      {
+        "name": "years",
+        "label": "Years",
+        "type": "number",
+        "placeholder": "10"
+      }
+    ],
+    "expression": "initial * Math.pow(1 + (yield + growth)/100, years)",
+    "unit": "USD",
+    "examples": [
+      {
+        "description": "$5,000 at 3% yield and 2% growth for 10 years \u21d2 $8,144.47"
+      },
+      {
+        "description": "$2,000 at 3% yield and 4% growth for 5 years \u21d2 $2,805.10"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "Does the calculator include additional contributions?",
+        "answer": "No, it assumes only the initial investment with reinvested dividends."
+      },
+      {
+        "question": "Are taxes considered?",
+        "answer": "No, taxes and fees are excluded."
+      },
+      {
+        "question": "Can yields and growth rates change over time?",
+        "answer": "This tool assumes constant annual rates."
+      }
+    ],
+    "disclaimer": "Not investment advice; consult a financial professional.",
+    "info": [
+      "Assumes dividends and growth compound annually.",
+      "Useful for comparing dividend reinvestment strategies."
+    ]
+  },
+  {
+    "slug": "sleep-efficiency",
+    "title": "Sleep Efficiency Calculator",
+    "cluster": "Health & Fitness",
+    "description": "Measure the percentage of time in bed spent asleep.",
+    "intro": "Calculate sleep efficiency by comparing actual sleep time to total time spent in bed. Enter hours in bed and hours slept.",
+    "inputs": [
+      {
+        "name": "timeInBed",
+        "label": "Time in Bed (hours)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "8"
+      },
+      {
+        "name": "sleep",
+        "label": "Time Asleep (hours)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "6.5"
+      }
+    ],
+    "expression": "(sleep / timeInBed) * 100",
+    "unit": "%",
+    "examples": [
+      {
+        "description": "8 h in bed, 6.5 h asleep \u21d2 81.25 %"
+      },
+      {
+        "description": "7 h in bed, 7 h asleep \u21d2 100 %"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What is a good sleep efficiency?",
+        "answer": "Typically above 85% is considered healthy."
+      },
+      {
+        "question": "Can efficiency exceed 100%?",
+        "answer": "No, time asleep cannot exceed time in bed."
+      },
+      {
+        "question": "Should I track naps separately?",
+        "answer": "This calculator focuses on one sleep session; track naps separately."
+      }
+    ],
+    "disclaimer": "For educational purposes; consult a sleep specialist for health concerns.",
+    "info": [
+      "Sleep efficiency = (time asleep / time in bed) \u00d7 100.",
+      "Helpful for evaluating sleep quality."
+    ]
+  },
+  {
+    "slug": "grass-seed-coverage",
+    "title": "Grass Seed Coverage Calculator",
+    "cluster": "Home & DIY",
+    "description": "Estimate how much grass seed you need for a given area.",
+    "intro": "Determine the amount of grass seed required by dividing lawn area by the coverage rate provided on the seed bag.",
+    "inputs": [
+      {
+        "name": "area",
+        "label": "Lawn Area (m\u00b2)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "100"
+      },
+      {
+        "name": "coverage",
+        "label": "Coverage per kg (m\u00b2/kg)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "35"
+      }
+    ],
+    "expression": "area / coverage",
+    "unit": "kg",
+    "examples": [
+      {
+        "description": "100 m\u00b2 area, 35 m\u00b2/kg coverage \u21d2 2.86 kg"
+      },
+      {
+        "description": "50 m\u00b2 area, 25 m\u00b2/kg coverage \u21d2 2 kg"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What if my area is irregular?",
+        "answer": "Measure as accurately as possible or break it into smaller sections."
+      },
+      {
+        "question": "Does seed type affect coverage?",
+        "answer": "Yes, different seeds have different recommended rates."
+      },
+      {
+        "question": "Should I buy extra seed?",
+        "answer": "It's wise to buy slightly more to account for losses."
+      }
+    ],
+    "disclaimer": "Estimates only; consult product guidelines for precise coverage.",
+    "info": [
+      "Most seed bags list coverage in m\u00b2 per kg.",
+      "Include extra for overseeding or patch repairs."
+    ]
+  },
+  {
+    "slug": "travel-insurance-cost",
+    "title": "Travel Insurance Cost Estimator",
+    "cluster": "Lifestyle & Travel",
+    "description": "Approximate travel insurance premium based on trip details.",
+    "intro": "Get a rough estimate of travel insurance cost using trip price, traveler age, and trip length. This is a simplified model for planning purposes.",
+    "inputs": [
+      {
+        "name": "cost",
+        "label": "Trip Cost ($)",
+        "type": "number",
+        "placeholder": "2000"
+      },
+      {
+        "name": "age",
+        "label": "Traveler Age",
+        "type": "number",
+        "placeholder": "30"
+      },
+      {
+        "name": "days",
+        "label": "Trip Length (days)",
+        "type": "number",
+        "placeholder": "7"
+      }
+    ],
+    "expression": "(cost * 0.04) + (age * 1) + (days * 0.5)",
+    "unit": "USD",
+    "examples": [
+      {
+        "description": "$2,000 trip, age 30, 7 days \u21d2 $113.50"
+      },
+      {
+        "description": "$3,500 trip, age 50, 14 days \u21d2 $197.00"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "Does this include medical coverage specifics?",
+        "answer": "No, it's a general estimate and doesn't factor policy details."
+      },
+      {
+        "question": "Why does age affect cost?",
+        "answer": "Insurers often charge higher premiums for older travelers."
+      },
+      {
+        "question": "Are high-risk activities covered?",
+        "answer": "This estimator doesn't account for special activities; check policy terms."
+      }
+    ],
+    "disclaimer": "Rough estimate only; obtain quotes from insurance providers for actual premiums.",
+    "info": [
+      "Real insurers consider destination, coverage limits, and medical history.",
+      "Premiums typically range between 4%\u201310% of trip cost."
+    ]
+  },
+  {
+    "slug": "prime-factorization",
+    "title": "Prime Factorization Calculator",
+    "cluster": "Math & Statistics",
+    "description": "Break a number into its prime factors.",
+    "intro": "Enter an integer to see its prime factors expressed in a multiplication sequence.",
+    "inputs": [
+      {
+        "name": "number",
+        "label": "Number",
+        "type": "number",
+        "placeholder": "12"
+      }
+    ],
+    "expression": "",
+    "unit": "",
+    "examples": [
+      {
+        "description": "12 \u21d2 2 \u00d7 2 \u00d7 3"
+      },
+      {
+        "description": "97 \u21d2 97"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What numbers can I factor?",
+        "answer": "Enter positive integers up to JavaScript's safe limit."
+      },
+      {
+        "question": "Does the order of factors matter?",
+        "answer": "The calculator lists prime factors in ascending order."
+      },
+      {
+        "question": "Is 1 considered a prime factor?",
+        "answer": "No, 1 is not prime and is not included."
+      }
+    ],
+    "disclaimer": "Educational tool; verify large factorizations with specialized software.",
+    "info": [
+      "Prime factorization expresses a number as a product of prime numbers.",
+      "Useful for simplifying fractions and solving number theory problems."
+    ]
+  },
+  {
+    "slug": "bnpl-apr",
+    "title": "BNPL APR Calculator",
+    "cluster": "Personal Finance & Loans",
+    "description": "Convert buy now, pay later plans to an equivalent APR.",
+    "intro": "Estimate the annual percentage rate of a BNPL plan by comparing total fees to the purchase amount and repayment term.",
+    "inputs": [
+      {
+        "name": "amount",
+        "label": "Purchase Amount ($)",
+        "type": "number",
+        "placeholder": "600"
+      },
+      {
+        "name": "fees",
+        "label": "Total Fees ($)",
+        "type": "number",
+        "placeholder": "30"
+      },
+      {
+        "name": "months",
+        "label": "Months",
+        "type": "number",
+        "placeholder": "6"
+      }
+    ],
+    "expression": "((fees / amount) / months) * 12 * 100",
+    "unit": "%",
+    "examples": [
+      {
+        "description": "$600 purchase, $30 fees, 6 months \u21d2 10 %"
+      },
+      {
+        "description": "$1,200 purchase, $0 fees, 4 months \u21d2 0 %"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "Does this include late fees?",
+        "answer": "No, only the specified fees are included."
+      },
+      {
+        "question": "Why convert BNPL to APR?",
+        "answer": "It helps compare BNPL plans with traditional credit options."
+      },
+      {
+        "question": "What if there are no fees?",
+        "answer": "The APR will be 0%, indicating a zero-cost plan."
+      }
+    ],
+    "disclaimer": "Approximate APR; lender calculations may differ.",
+    "info": [
+      "Assumes equal payments and no interest beyond fees.",
+      "APR helps compare financing options on a yearly basis."
+    ]
+  },
+  {
+    "slug": "radiocarbon-dating",
+    "title": "Radiocarbon Dating Calculator",
+    "cluster": "Science & Engineering",
+    "description": "Estimate the age of organic material from remaining carbon-14.",
+    "intro": "Compute the approximate age of an organic sample using the remaining percentage of carbon-14 compared to a modern reference.",
+    "inputs": [
+      {
+        "name": "percent",
+        "label": "Carbon-14 Remaining (%)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "50"
+      }
+    ],
+    "expression": "-8033 * Math.log(percent/100)",
+    "unit": "years",
+    "examples": [
+      {
+        "description": "50% \u21d2 5,568 years"
+      },
+      {
+        "description": "10% \u21d2 18,497 years"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What half-life is assumed?",
+        "answer": "The calculation uses a mean life of 8,033 years (half-life \u2248 5,730 years)."
+      },
+      {
+        "question": "Does contamination affect results?",
+        "answer": "Yes, contamination can skew the carbon-14 percentage."
+      },
+      {
+        "question": "Is radiocarbon dating precise?",
+        "answer": "It provides an estimate; calibration improves accuracy."
+      }
+    ],
+    "disclaimer": "For archaeological estimation only; laboratory analysis required for precise dating.",
+    "info": [
+      "Based on exponential decay N_t/N_0 = e^{-t/8033}.",
+      "Valid for samples up to about 50,000 years old."
+    ]
+  },
+  {
+    "slug": "usb-voltage-drop",
+    "title": "USB Voltage Drop Calculator",
+    "cluster": "Technology & Coding",
+    "description": "Estimate voltage drop across a USB cable.",
+    "intro": "Calculate the expected voltage drop along a USB cable given its length, current draw, and wire gauge.",
+    "inputs": [
+      {
+        "name": "current",
+        "label": "Current (A)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "2"
+      },
+      {
+        "name": "length",
+        "label": "Cable Length (m)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "1"
+      },
+      {
+        "name": "awg",
+        "label": "Wire Gauge (AWG)",
+        "type": "number",
+        "placeholder": "28"
+      }
+    ],
+    "expression": "(() => { const r = awg==28?0.214:awg==24?0.0842:0.1339; return current * r * length * 2; })()",
+    "unit": "V",
+    "examples": [
+      {
+        "description": "2 A, 1 m, AWG 28 \u21d2 0.86 V"
+      },
+      {
+        "description": "1 A, 2 m, AWG 24 \u21d2 0.34 V"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "Why multiply by two for length?",
+        "answer": "Current travels to the device and back, doubling the resistance."
+      },
+      {
+        "question": "What if my gauge is different?",
+        "answer": "Use the closest AWG value; results are approximate."
+      },
+      {
+        "question": "Can voltage drop cause charging issues?",
+        "answer": "Yes, excessive drop can prevent devices from receiving sufficient power."
+      }
+    ],
+    "disclaimer": "Approximate calculation; check manufacturer specs for exact values.",
+    "info": [
+      "Based on ohmic resistance per conductor.",
+      "USB standards recommend keeping drop below 0.25 V for reliable operation."
+    ]
+  },
+  {
+    "slug": "ab-test-sample-size",
+    "title": "A/B Test Sample Size Calculator",
+    "cluster": "Web & Marketing",
+    "description": "Estimate required visitors per variant for an A/B test.",
+    "intro": "Determine the sample size needed for an A/B test using baseline conversion rate and minimum detectable effect. Assumes 95% confidence and 80% power.",
+    "inputs": [
+      {
+        "name": "base",
+        "label": "Baseline Rate (%)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "5"
+      },
+      {
+        "name": "mde",
+        "label": "MDE (%)",
+        "type": "number",
+        "step": "any",
+        "placeholder": "1"
+      }
+    ],
+    "expression": "(() => { const b=base/100; const m=(base+mde)/100; const p=(b+m)/2; return Math.ceil(((1.96*Math.sqrt(2*p*(1-p)) + 0.84*Math.sqrt(b*(1-b)+m*(1-m)))**2)/((m-b)**2)); })()",
+    "unit": "visitors",
+    "examples": [
+      {
+        "description": "Baseline 5%, MDE 1% \u21d2 8,149 visitors"
+      },
+      {
+        "description": "Baseline 10%, MDE 3% \u21d2 1,772 visitors"
+      }
+    ],
+    "faqs": [
+      {
+        "question": "What confidence level does this use?",
+        "answer": "It assumes a 95% confidence level."
+      },
+      {
+        "question": "What statistical power is assumed?",
+        "answer": "The calculation uses 80% power."
+      },
+      {
+        "question": "Can I change confidence or power?",
+        "answer": "This basic version fixes them; use advanced tools for custom values."
+      }
+    ],
+    "disclaimer": "For planning A/B tests; consult a statistician for critical experiments.",
+    "info": [
+      "Formula based on two-proportion z-test.",
+      "Sample size applies to each variant separately."
     ]
   }
 ]

--- a/meta/publish_log.json
+++ b/meta/publish_log.json
@@ -1600,10 +1600,6 @@
     "date": "2025-09-12"
   },
   {
-    "slug": "ab-test-sample-size",
-    "date": "2025-09-12"
-  },
-  {
     "slug": "return-on-ad-spend",
     "date": "2025-09-13"
   },
@@ -1761,6 +1757,54 @@
   },
   {
     "slug": "medication-supply-duration",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "decibel-to-power-percentage",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "next-full-moon",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "cefr-study-hours",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "dividend-reinvestment",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "sleep-efficiency",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "grass-seed-coverage",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "travel-insurance-cost",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "prime-factorization",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "bnpl-apr",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "radiocarbon-dating",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "usb-voltage-drop",
+    "date": "2025-09-13"
+  },
+  {
+    "slug": "ab-test-sample-size",
     "date": "2025-09-13"
   }
 ]

--- a/src/components/Calculator.astro
+++ b/src/components/Calculator.astro
@@ -556,6 +556,24 @@ const jsonLd = {
             value = days[m - 1] + d + (leap && m > 2 ? 1 : 0);
             break;
           }
+          case 'prime-factorization': {
+            const n = Math.floor(num(vars.number));
+            if (!isFinite(n) || n < 2) {
+              showMessage('error', 'Enter integer greater than 1');
+              return;
+            }
+            let temp = n;
+            const factors = [];
+            for (let i = 2; i * i <= temp; i++) {
+              while (temp % i === 0) {
+                factors.push(i);
+                temp /= i;
+              }
+            }
+            if (temp > 1) factors.push(temp);
+            value = factors.join(' × ');
+            break;
+          }
           default: {
             showMessage('error', 'Calculation not available.');
             return;

--- a/src/pages/calculators/ab-test-sample-size.mdx
+++ b/src/pages/calculators/ab-test-sample-size.mdx
@@ -1,0 +1,67 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "A/B Test Sample Size Calculator"
+description: "Determine the sample size needed for an A/B test using baseline conversion rate and minimum detectable effect. Assumes 95% confidence and 80% power."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Web & Marketing"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "ab-test-sample-size",
+  "title": "A/B Test Sample Size Calculator",
+  "cluster": "Web & Marketing",
+  "description": "Estimate required visitors per variant for an A/B test.",
+  "intro": "Determine the sample size needed for an A/B test using baseline conversion rate and minimum detectable effect. Assumes 95% confidence and 80% power.",
+  "inputs": [
+    {
+      "name": "base",
+      "label": "Baseline Rate (%)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "5"
+    },
+    {
+      "name": "mde",
+      "label": "MDE (%)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "1"
+    }
+  ],
+  "expression": "(() => { const b=base/100; const m=(base+mde)/100; const p=(b+m)/2; return Math.ceil(((1.96*Math.sqrt(2*p*(1-p)) + 0.84*Math.sqrt(b*(1-b)+m*(1-m)))**2)/((m-b)**2)); })()",
+  "unit": "visitors",
+  "examples": [
+    {
+      "description": "Baseline 5%, MDE 1% \u21d2 8,149 visitors"
+    },
+    {
+      "description": "Baseline 10%, MDE 3% \u21d2 1,772 visitors"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What confidence level does this use?",
+      "answer": "It assumes a 95% confidence level."
+    },
+    {
+      "question": "What statistical power is assumed?",
+      "answer": "The calculation uses 80% power."
+    },
+    {
+      "question": "Can I change confidence or power?",
+      "answer": "This basic version fixes them; use advanced tools for custom values."
+    }
+  ],
+  "disclaimer": "For planning A/B tests; consult a statistician for critical experiments.",
+  "info": [
+    "Formula based on two-proportion z-test.",
+    "Sample size applies to each variant separately."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/bnpl-apr.mdx
+++ b/src/pages/calculators/bnpl-apr.mdx
@@ -1,0 +1,71 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "BNPL APR Calculator"
+description: "Estimate the annual percentage rate of a BNPL plan by comparing total fees to the purchase amount and repayment term."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Personal Finance & Loans"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "bnpl-apr",
+  "title": "BNPL APR Calculator",
+  "cluster": "Personal Finance & Loans",
+  "description": "Convert buy now, pay later plans to an equivalent APR.",
+  "intro": "Estimate the annual percentage rate of a BNPL plan by comparing total fees to the purchase amount and repayment term.",
+  "inputs": [
+    {
+      "name": "amount",
+      "label": "Purchase Amount ($)",
+      "type": "number",
+      "placeholder": "600"
+    },
+    {
+      "name": "fees",
+      "label": "Total Fees ($)",
+      "type": "number",
+      "placeholder": "30"
+    },
+    {
+      "name": "months",
+      "label": "Months",
+      "type": "number",
+      "placeholder": "6"
+    }
+  ],
+  "expression": "((fees / amount) / months) * 12 * 100",
+  "unit": "%",
+  "examples": [
+    {
+      "description": "$600 purchase, $30 fees, 6 months \u21d2 10 %"
+    },
+    {
+      "description": "$1,200 purchase, $0 fees, 4 months \u21d2 0 %"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does this include late fees?",
+      "answer": "No, only the specified fees are included."
+    },
+    {
+      "question": "Why convert BNPL to APR?",
+      "answer": "It helps compare BNPL plans with traditional credit options."
+    },
+    {
+      "question": "What if there are no fees?",
+      "answer": "The APR will be 0%, indicating a zero-cost plan."
+    }
+  ],
+  "disclaimer": "Approximate APR; lender calculations may differ.",
+  "info": [
+    "Assumes equal payments and no interest beyond fees.",
+    "APR helps compare financing options on a yearly basis."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/cefr-study-hours.mdx
+++ b/src/pages/calculators/cefr-study-hours.mdx
@@ -1,0 +1,65 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "CEFR Study Hours Estimator"
+description: "Estimate additional study hours required to progress from your current CEFR language level to a target level. Use 0 for no level, 1 for A1 up to 6 for C2."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Education & Learning"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "cefr-study-hours",
+  "title": "CEFR Study Hours Estimator",
+  "cluster": "Education & Learning",
+  "description": "Estimate hours needed to reach a target CEFR level.",
+  "intro": "Estimate additional study hours required to progress from your current CEFR language level to a target level. Use 0 for no level, 1 for A1 up to 6 for C2.",
+  "inputs": [
+    {
+      "name": "current",
+      "label": "Current Level (0-6)",
+      "type": "number",
+      "placeholder": "2"
+    },
+    {
+      "name": "target",
+      "label": "Target Level (1-6)",
+      "type": "number",
+      "placeholder": "4"
+    }
+  ],
+  "expression": "(() => { const h=[0,100,200,350,500,700,1000]; return Math.max(0, h[target]-h[current]); })()",
+  "unit": "hours",
+  "examples": [
+    {
+      "description": "Current A2 (2) to B2 (4) \u21d2 300 hours"
+    },
+    {
+      "description": "Current B1 (3) to C1 (5) \u21d2 350 hours"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What do the numeric levels mean?",
+      "answer": "Use 1 for A1 up to 6 for C2; 0 indicates no prior study."
+    },
+    {
+      "question": "Are these hours exact?",
+      "answer": "No, they are estimates based on common teaching guidelines."
+    },
+    {
+      "question": "Does the calculator account for language difficulty?",
+      "answer": "No, it uses general averages regardless of language."
+    }
+  ],
+  "disclaimer": "For study planning only; adjust based on personal progress.",
+  "info": [
+    "Estimates derived from CEFR self-study hour ranges.",
+    "Actual time needed varies with prior knowledge and exposure."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/decibel-to-power-percentage.mdx
+++ b/src/pages/calculators/decibel-to-power-percentage.mdx
@@ -1,0 +1,60 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Decibel to Power Percentage Calculator"
+description: "This tool converts a decibel (dB) value into a corresponding power percentage relative to the reference level. Enter a dB value to see the equivalent percent of power."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Conversions & Units"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "decibel-to-power-percentage",
+  "title": "Decibel to Power Percentage Calculator",
+  "cluster": "Conversions & Units",
+  "description": "Convert decibel values to linear power percentages.",
+  "intro": "This tool converts a decibel (dB) value into a corresponding power percentage relative to the reference level. Enter a dB value to see the equivalent percent of power.",
+  "inputs": [
+    {
+      "name": "db",
+      "label": "Decibels (dB)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "3"
+    }
+  ],
+  "expression": "Math.pow(10, db/10) * 100",
+  "unit": "%",
+  "examples": [
+    {
+      "description": "3 dB \u21d2 199.53 %"
+    },
+    {
+      "description": "-10 dB \u21d2 10 %"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What does a negative dB value mean?",
+      "answer": "It indicates power lower than the reference level."
+    },
+    {
+      "question": "Is 0 dB equal to 100%?",
+      "answer": "Yes, 0 dB corresponds to the reference power."
+    },
+    {
+      "question": "Can this calculator handle fractional dB values?",
+      "answer": "Yes, decimals are supported for precise conversions."
+    }
+  ],
+  "disclaimer": "Verify critical audio or RF measurements with calibrated equipment.",
+  "info": [
+    "Uses formula 10^(dB/10)*100 to convert decibels to power percentage.",
+    "Common in audio engineering and signal processing."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/dividend-reinvestment.mdx
+++ b/src/pages/calculators/dividend-reinvestment.mdx
@@ -1,0 +1,79 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Dividend Reinvestment Calculator"
+description: "Estimate the future value of an investment when dividends are reinvested and the stock price grows annually. Enter initial investment, dividend yield, growth rate, and years."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Finance & Business"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "dividend-reinvestment",
+  "title": "Dividend Reinvestment Calculator",
+  "cluster": "Finance & Business",
+  "description": "Project investment value when dividends are reinvested.",
+  "intro": "Estimate the future value of an investment when dividends are reinvested and the stock price grows annually. Enter initial investment, dividend yield, growth rate, and years.",
+  "inputs": [
+    {
+      "name": "initial",
+      "label": "Initial Investment ($)",
+      "type": "number",
+      "placeholder": "5000"
+    },
+    {
+      "name": "yield",
+      "label": "Dividend Yield (%)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "3"
+    },
+    {
+      "name": "growth",
+      "label": "Price Growth (%)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "2"
+    },
+    {
+      "name": "years",
+      "label": "Years",
+      "type": "number",
+      "placeholder": "10"
+    }
+  ],
+  "expression": "initial * Math.pow(1 + (yield + growth)/100, years)",
+  "unit": "USD",
+  "examples": [
+    {
+      "description": "$5,000 at 3% yield and 2% growth for 10 years \u21d2 $8,144.47"
+    },
+    {
+      "description": "$2,000 at 3% yield and 4% growth for 5 years \u21d2 $2,805.10"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does the calculator include additional contributions?",
+      "answer": "No, it assumes only the initial investment with reinvested dividends."
+    },
+    {
+      "question": "Are taxes considered?",
+      "answer": "No, taxes and fees are excluded."
+    },
+    {
+      "question": "Can yields and growth rates change over time?",
+      "answer": "This tool assumes constant annual rates."
+    }
+  ],
+  "disclaimer": "Not investment advice; consult a financial professional.",
+  "info": [
+    "Assumes dividends and growth compound annually.",
+    "Useful for comparing dividend reinvestment strategies."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/grass-seed-coverage.mdx
+++ b/src/pages/calculators/grass-seed-coverage.mdx
@@ -1,0 +1,67 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Grass Seed Coverage Calculator"
+description: "Determine the amount of grass seed required by dividing lawn area by the coverage rate provided on the seed bag."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Home & DIY"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "grass-seed-coverage",
+  "title": "Grass Seed Coverage Calculator",
+  "cluster": "Home & DIY",
+  "description": "Estimate how much grass seed you need for a given area.",
+  "intro": "Determine the amount of grass seed required by dividing lawn area by the coverage rate provided on the seed bag.",
+  "inputs": [
+    {
+      "name": "area",
+      "label": "Lawn Area (m\u00b2)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "100"
+    },
+    {
+      "name": "coverage",
+      "label": "Coverage per kg (m\u00b2/kg)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "35"
+    }
+  ],
+  "expression": "area / coverage",
+  "unit": "kg",
+  "examples": [
+    {
+      "description": "100 m\u00b2 area, 35 m\u00b2/kg coverage \u21d2 2.86 kg"
+    },
+    {
+      "description": "50 m\u00b2 area, 25 m\u00b2/kg coverage \u21d2 2 kg"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What if my area is irregular?",
+      "answer": "Measure as accurately as possible or break it into smaller sections."
+    },
+    {
+      "question": "Does seed type affect coverage?",
+      "answer": "Yes, different seeds have different recommended rates."
+    },
+    {
+      "question": "Should I buy extra seed?",
+      "answer": "It's wise to buy slightly more to account for losses."
+    }
+  ],
+  "disclaimer": "Estimates only; consult product guidelines for precise coverage.",
+  "info": [
+    "Most seed bags list coverage in m\u00b2 per kg.",
+    "Include extra for overseeding or patch repairs."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/next-full-moon.mdx
+++ b/src/pages/calculators/next-full-moon.mdx
@@ -1,0 +1,71 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Next Full Moon Calculator"
+description: "This calculator approximates the number of days until the next full moon. Enter a date to get an estimate based on the average lunar cycle."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Date & Time"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "next-full-moon",
+  "title": "Next Full Moon Calculator",
+  "cluster": "Date & Time",
+  "description": "Estimate days until the next full moon from a given date.",
+  "intro": "This calculator approximates the number of days until the next full moon. Enter a date to get an estimate based on the average lunar cycle.",
+  "inputs": [
+    {
+      "name": "year",
+      "label": "Year",
+      "type": "number",
+      "placeholder": "2024"
+    },
+    {
+      "name": "month",
+      "label": "Month",
+      "type": "number",
+      "placeholder": "5"
+    },
+    {
+      "name": "day",
+      "label": "Day",
+      "type": "number",
+      "placeholder": "1"
+    }
+  ],
+  "expression": "(() => { const d=Date.UTC(year,month-1,day)/86400000; const known=Date.UTC(2024,0,25)/86400000; const cycle=29.530588853; return Math.ceil((cycle - ((d - known) % cycle)) % cycle); })()",
+  "unit": "days",
+  "examples": [
+    {
+      "description": "2024-05-01 \u21d2 21 days"
+    },
+    {
+      "description": "2024-09-10 \u21d2 7 days"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How accurate is this calculator?",
+      "answer": "It uses an average lunar cycle of 29.53 days, so results are approximate."
+    },
+    {
+      "question": "What time zone is used?",
+      "answer": "Dates are handled in UTC for simplicity."
+    },
+    {
+      "question": "Can I enter past dates?",
+      "answer": "Yes, it finds the next full moon after the given date."
+    }
+  ],
+  "disclaimer": "Approximate astronomical calculation; consult official lunar tables for precise times.",
+  "info": [
+    "The synodic month averages 29.530588853 days.",
+    "Full moon dates shift slightly due to orbital variations."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/prime-factorization.mdx
+++ b/src/pages/calculators/prime-factorization.mdx
@@ -1,0 +1,59 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Prime Factorization Calculator"
+description: "Enter an integer to see its prime factors expressed in a multiplication sequence."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Math & Statistics"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "prime-factorization",
+  "title": "Prime Factorization Calculator",
+  "cluster": "Math & Statistics",
+  "description": "Break a number into its prime factors.",
+  "intro": "Enter an integer to see its prime factors expressed in a multiplication sequence.",
+  "inputs": [
+    {
+      "name": "number",
+      "label": "Number",
+      "type": "number",
+      "placeholder": "12"
+    }
+  ],
+  "expression": "",
+  "unit": "",
+  "examples": [
+    {
+      "description": "12 \u21d2 2 \u00d7 2 \u00d7 3"
+    },
+    {
+      "description": "97 \u21d2 97"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What numbers can I factor?",
+      "answer": "Enter positive integers up to JavaScript's safe limit."
+    },
+    {
+      "question": "Does the order of factors matter?",
+      "answer": "The calculator lists prime factors in ascending order."
+    },
+    {
+      "question": "Is 1 considered a prime factor?",
+      "answer": "No, 1 is not prime and is not included."
+    }
+  ],
+  "disclaimer": "Educational tool; verify large factorizations with specialized software.",
+  "info": [
+    "Prime factorization expresses a number as a product of prime numbers.",
+    "Useful for simplifying fractions and solving number theory problems."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/radiocarbon-dating.mdx
+++ b/src/pages/calculators/radiocarbon-dating.mdx
@@ -1,0 +1,60 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Radiocarbon Dating Calculator"
+description: "Compute the approximate age of an organic sample using the remaining percentage of carbon-14 compared to a modern reference."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Science & Engineering"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "radiocarbon-dating",
+  "title": "Radiocarbon Dating Calculator",
+  "cluster": "Science & Engineering",
+  "description": "Estimate the age of organic material from remaining carbon-14.",
+  "intro": "Compute the approximate age of an organic sample using the remaining percentage of carbon-14 compared to a modern reference.",
+  "inputs": [
+    {
+      "name": "percent",
+      "label": "Carbon-14 Remaining (%)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "50"
+    }
+  ],
+  "expression": "-8033 * Math.log(percent/100)",
+  "unit": "years",
+  "examples": [
+    {
+      "description": "50% \u21d2 5,568 years"
+    },
+    {
+      "description": "10% \u21d2 18,497 years"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What half-life is assumed?",
+      "answer": "The calculation uses a mean life of 8,033 years (half-life \u2248 5,730 years)."
+    },
+    {
+      "question": "Does contamination affect results?",
+      "answer": "Yes, contamination can skew the carbon-14 percentage."
+    },
+    {
+      "question": "Is radiocarbon dating precise?",
+      "answer": "It provides an estimate; calibration improves accuracy."
+    }
+  ],
+  "disclaimer": "For archaeological estimation only; laboratory analysis required for precise dating.",
+  "info": [
+    "Based on exponential decay N_t/N_0 = e^{-t/8033}.",
+    "Valid for samples up to about 50,000 years old."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/sleep-efficiency.mdx
+++ b/src/pages/calculators/sleep-efficiency.mdx
@@ -1,0 +1,67 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Sleep Efficiency Calculator"
+description: "Calculate sleep efficiency by comparing actual sleep time to total time spent in bed. Enter hours in bed and hours slept."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Health & Fitness"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "sleep-efficiency",
+  "title": "Sleep Efficiency Calculator",
+  "cluster": "Health & Fitness",
+  "description": "Measure the percentage of time in bed spent asleep.",
+  "intro": "Calculate sleep efficiency by comparing actual sleep time to total time spent in bed. Enter hours in bed and hours slept.",
+  "inputs": [
+    {
+      "name": "timeInBed",
+      "label": "Time in Bed (hours)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "8"
+    },
+    {
+      "name": "sleep",
+      "label": "Time Asleep (hours)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "6.5"
+    }
+  ],
+  "expression": "(sleep / timeInBed) * 100",
+  "unit": "%",
+  "examples": [
+    {
+      "description": "8 h in bed, 6.5 h asleep \u21d2 81.25 %"
+    },
+    {
+      "description": "7 h in bed, 7 h asleep \u21d2 100 %"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What is a good sleep efficiency?",
+      "answer": "Typically above 85% is considered healthy."
+    },
+    {
+      "question": "Can efficiency exceed 100%?",
+      "answer": "No, time asleep cannot exceed time in bed."
+    },
+    {
+      "question": "Should I track naps separately?",
+      "answer": "This calculator focuses on one sleep session; track naps separately."
+    }
+  ],
+  "disclaimer": "For educational purposes; consult a sleep specialist for health concerns.",
+  "info": [
+    "Sleep efficiency = (time asleep / time in bed) \u00d7 100.",
+    "Helpful for evaluating sleep quality."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/travel-insurance-cost.mdx
+++ b/src/pages/calculators/travel-insurance-cost.mdx
@@ -1,0 +1,71 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "Travel Insurance Cost Estimator"
+description: "Get a rough estimate of travel insurance cost using trip price, traveler age, and trip length. This is a simplified model for planning purposes."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Lifestyle & Travel"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "travel-insurance-cost",
+  "title": "Travel Insurance Cost Estimator",
+  "cluster": "Lifestyle & Travel",
+  "description": "Approximate travel insurance premium based on trip details.",
+  "intro": "Get a rough estimate of travel insurance cost using trip price, traveler age, and trip length. This is a simplified model for planning purposes.",
+  "inputs": [
+    {
+      "name": "cost",
+      "label": "Trip Cost ($)",
+      "type": "number",
+      "placeholder": "2000"
+    },
+    {
+      "name": "age",
+      "label": "Traveler Age",
+      "type": "number",
+      "placeholder": "30"
+    },
+    {
+      "name": "days",
+      "label": "Trip Length (days)",
+      "type": "number",
+      "placeholder": "7"
+    }
+  ],
+  "expression": "(cost * 0.04) + (age * 1) + (days * 0.5)",
+  "unit": "USD",
+  "examples": [
+    {
+      "description": "$2,000 trip, age 30, 7 days \u21d2 $113.50"
+    },
+    {
+      "description": "$3,500 trip, age 50, 14 days \u21d2 $197.00"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Does this include medical coverage specifics?",
+      "answer": "No, it's a general estimate and doesn't factor policy details."
+    },
+    {
+      "question": "Why does age affect cost?",
+      "answer": "Insurers often charge higher premiums for older travelers."
+    },
+    {
+      "question": "Are high-risk activities covered?",
+      "answer": "This estimator doesn't account for special activities; check policy terms."
+    }
+  ],
+  "disclaimer": "Rough estimate only; obtain quotes from insurance providers for actual premiums.",
+  "info": [
+    "Real insurers consider destination, coverage limits, and medical history.",
+    "Premiums typically range between 4%\u201310% of trip cost."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />

--- a/src/pages/calculators/usb-voltage-drop.mdx
+++ b/src/pages/calculators/usb-voltage-drop.mdx
@@ -1,0 +1,73 @@
+---
+layout: ../../layouts/CalculatorLayout.astro
+title: "USB Voltage Drop Calculator"
+description: "Calculate the expected voltage drop along a USB cable given its length, current draw, and wire gauge."
+date: 2025-09-13
+updated: 2025-09-13
+cluster: "Technology & Coding"
+---
+
+import Calculator from '../../components/Calculator.astro';
+
+export const schema = {
+  "slug": "usb-voltage-drop",
+  "title": "USB Voltage Drop Calculator",
+  "cluster": "Technology & Coding",
+  "description": "Estimate voltage drop across a USB cable.",
+  "intro": "Calculate the expected voltage drop along a USB cable given its length, current draw, and wire gauge.",
+  "inputs": [
+    {
+      "name": "current",
+      "label": "Current (A)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "2"
+    },
+    {
+      "name": "length",
+      "label": "Cable Length (m)",
+      "type": "number",
+      "step": "any",
+      "placeholder": "1"
+    },
+    {
+      "name": "awg",
+      "label": "Wire Gauge (AWG)",
+      "type": "number",
+      "placeholder": "28"
+    }
+  ],
+  "expression": "(() => { const r = awg==28?0.214:awg==24?0.0842:0.1339; return current * r * length * 2; })()",
+  "unit": "V",
+  "examples": [
+    {
+      "description": "2 A, 1 m, AWG 28 \u21d2 0.86 V"
+    },
+    {
+      "description": "1 A, 2 m, AWG 24 \u21d2 0.34 V"
+    }
+  ],
+  "faqs": [
+    {
+      "question": "Why multiply by two for length?",
+      "answer": "Current travels to the device and back, doubling the resistance."
+    },
+    {
+      "question": "What if my gauge is different?",
+      "answer": "Use the closest AWG value; results are approximate."
+    },
+    {
+      "question": "Can voltage drop cause charging issues?",
+      "answer": "Yes, excessive drop can prevent devices from receiving sufficient power."
+    }
+  ],
+  "disclaimer": "Approximate calculation; check manufacturer specs for exact values.",
+  "info": [
+    "Based on ohmic resistance per conductor.",
+    "USB standards recommend keeping drop below 0.25 V for reliable operation."
+  ],
+  "locale": "en",
+  "related": []
+}
+
+<Calculator schema={schema} />


### PR DESCRIPTION
## Summary
- add calculators for decibel power percentage, next full moon, CEFR study hours, dividend reinvestment, sleep efficiency, grass seed coverage, travel insurance cost, prime factorization, BNPL APR, radiocarbon dating, USB voltage drop, and A/B test sample size
- implement prime factorization algorithm in Calculator component

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c52a40e63c83218bb95cb8e92a6c60