### PR TITLE
Add units to calculator results

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -361,6 +361,7 @@
       }
     ],
     "expression": "km * 0.621371",
+    "unit": "miles",
     "examples": [
       {
         "description": "10 km \u21d2 6.21371 miles"
@@ -15865,6 +15866,7 @@
       }
     ],
     "expression": "(map * scale) / 100000",
+    "unit": "km",
     "examples": [
       {
         "description": "5 cm at 1:50,000 \u21d2 2.5 km"

--- a/src/pages/calculators/3d-print-time.mdx
+++ b/src/pages/calculators/3d-print-time.mdx
@@ -36,6 +36,7 @@ export const schema = {
     }
   ],
   "expression": "(model_height / layer_height) * 60 / speed",
+  "unit": "minutes",
   "intro": "Estimate how long a vertical 3D print will take based on layer and speed settings.",
   "examples": [
     {

--- a/src/pages/calculators/accounts-receivable-turnover.mdx
+++ b/src/pages/calculators/accounts-receivable-turnover.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "net_credit_sales / average_accounts_receivable",
+  "unit": "times",
   "intro": "Compute accounts receivable turnover by dividing net credit sales by average accounts receivable.",
   "examples": [
     {

--- a/src/pages/calculators/age-in-days.mdx
+++ b/src/pages/calculators/age-in-days.mdx
@@ -22,6 +22,7 @@ export const schema = {
     }
   ],
   "expression": "years * 365.25",
+  "unit": "days",
   "intro": "Convert age in years to days.",
   "examples": [
     {

--- a/src/pages/calculators/age-in-months.mdx
+++ b/src/pages/calculators/age-in-months.mdx
@@ -22,6 +22,7 @@ export const schema = {
     }
   ],
   "expression": "years * 12",
+  "unit": "months",
   "intro": "Convert an age expressed in years to total months. Enter the years and press Calculate.",
   "examples": [
     {

--- a/src/pages/calculators/air-conditioner-btu.mdx
+++ b/src/pages/calculators/air-conditioner-btu.mdx
@@ -31,6 +31,7 @@ export const schema = {
     }
   ],
   "expression": "area * btu",
+  "unit": "BTU",
   "intro": "Estimate cooling capacity needed for a room.",
   "examples": [
     {

--- a/src/pages/calculators/amp-hours-to-watt-hours.mdx
+++ b/src/pages/calculators/amp-hours-to-watt-hours.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "ah * volts",
+  "unit": "Wh",
   "intro": "Convert a battery's capacity in amp-hours to energy in watt-hours using its voltage.",
   "examples": [
     {

--- a/src/pages/calculators/arc-length-circle.mdx
+++ b/src/pages/calculators/arc-length-circle.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "2 * Math.PI * radius * (angle / 360)",
+  "unit": "units",
   "intro": "Find the length of a circular arc.",
   "examples": [
     {

--- a/src/pages/calculators/arithmetic-series-sum.mdx
+++ b/src/pages/calculators/arithmetic-series-sum.mdx
@@ -17,7 +17,7 @@ export const schema = {
   "slug": "arithmetic-series-sum",
   "title": "Arithmetic Series Sum",
   "locale": "en",
-  "unit": "number",
+  "unit": "units",
   "expression": "n/2 * (2*a1 + (n-1)*d)",
   "intro": "Calculate the total of the first n terms in an arithmetic sequence using its first term and common difference.",
   "examples": [

--- a/src/pages/calculators/attendance-requirement.mdx
+++ b/src/pages/calculators/attendance-requirement.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "total - Math.ceil(total * required / 100)",
+  "unit": "classes",
   "intro": "Enter total class sessions and the required attendance percentage to find allowable absences.",
   "examples": [
     {

--- a/src/pages/calculators/km-to-miles.mdx
+++ b/src/pages/calculators/km-to-miles.mdx
@@ -23,6 +23,7 @@ export const schema = {
   title: "Kilometers to Miles",
   locale: "en",
   expression: "km * 0.621371",
+  unit: "miles",
   intro: "Convert kilometers into miles.",
   examples: [
     {

--- a/src/pages/calculators/map-scale-distance.mdx
+++ b/src/pages/calculators/map-scale-distance.mdx
@@ -32,6 +32,7 @@ export const schema = {
     },
   ],
   expression: "(map * scale) / 100000",
+  unit: "km",
   intro: "Find real-world distance from map measurement and scale.",
   examples: [
     {


### PR DESCRIPTION
## Summary
- ensure multiple calculators output correct units by defining `unit` in their schemas
- add corresponding unit metadata to calculators dataset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c5644d12908321aa47c6e3a8e18787