### PR TITLE
Add missing units to calculator results

### DIFF
--- a/src/pages/calculators/compression-ratio.mdx
+++ b/src/pages/calculators/compression-ratio.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "original / compressed",
+  "unit": "ratio",
   "intro": "Compare original and compressed file sizes.",
   "examples": [
     {

--- a/src/pages/calculators/conversion-rate.mdx
+++ b/src/pages/calculators/conversion-rate.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "(conversions / visitors) * 100",
+  "unit": "%",
   "intro": "Determine the percentage of visitors who complete a desired action such as a purchase or signup.",
   "examples": [
     {

--- a/src/pages/calculators/gpa-calculator.mdx
+++ b/src/pages/calculators/gpa-calculator.mdx
@@ -31,6 +31,7 @@ export const schema = {
     }
   ],
   "expression": "points / credits",
+  "unit": "GPA",
   "intro": "Compute your grade point average by dividing total quality points by total credits attempted.",
   "examples": [
     {

--- a/src/pages/calculators/gross-margin.mdx
+++ b/src/pages/calculators/gross-margin.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "(revenue - cogs) / revenue * 100",
+  "unit": "%",
   "intro": "Determine gross margin percentage from revenue and cost of goods sold. Enter the values and press Calculate.",
   "examples": [
     {

--- a/src/pages/calculators/hexagon-area.mdx
+++ b/src/pages/calculators/hexagon-area.mdx
@@ -22,6 +22,7 @@ export const schema = {
     }
   ],
   "expression": "(3 * Math.sqrt(3) / 2) * side * side",
+  "unit": "unit²",
   "intro": "Find the area of a regular hexagon using the standard formula based on side length. Enter the side length and press Calculate.",
   "examples": [
     {

--- a/src/pages/calculators/lightning-distance.mdx
+++ b/src/pages/calculators/lightning-distance.mdx
@@ -22,6 +22,7 @@ export const schema = {
     }
   ],
   "expression": "seconds * 0.343",
+  "unit": "km",
   "intro": "Approximate how far lightning struck by multiplying the seconds until thunder by the speed of sound in air (0.343 km/s).",
   "examples": [
     {

--- a/src/pages/calculators/password-entropy.mdx
+++ b/src/pages/calculators/password-entropy.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "length * Math.log(charset) / Math.log(2)",
+  "unit": "bits",
   "intro": "Gauge the theoretical strength of a password using entropy in bits.",
   "examples": [
     {

--- a/src/pages/calculators/shadow-length.mdx
+++ b/src/pages/calculators/shadow-length.mdx
@@ -29,6 +29,7 @@ export const schema = {
     }
   ],
   "expression": "height / Math.tan(angle * Math.PI / 180)",
+  "unit": "m",
   "intro": "Calculate how long a shadow will be based on object height and sun elevation angle.",
   "examples": [
     {


### PR DESCRIPTION
## Summary
- add unit property for password entropy, conversion rate, shadow length, GPA, lightning distance, hexagon area, gross margin, and compression ratio calculators so outputs display correct units

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c57410619883218b21f10f88619ba2