### PR TITLE
Mejora textos de Additional Information

### DIFF
--- a/data/calculators.json
+++ b/data/calculators.json
@@ -10768,7 +10768,10 @@
     ],
     "disclaimer": "Entropy is theoretical; follow best practices for secure passwords.",
     "unit": "bits",
-    "info": []
+    "info": [
+      "Entropy assumes characters are selected independently at random.",
+      "Real-world passwords often contain patterns that lower true strength."
+    ]
   },
   {
     "slug": "ohms-law-power",
@@ -10920,7 +10923,10 @@
     ],
     "disclaimer": "Idealized calculation without atmospheric refraction.",
     "unit": "m",
-    "info": []
+    "info": [
+      "Higher sun angles create shorter shadows.",
+      "Shadows become much longer as the sun nears the horizon."
+    ]
   },
   {
     "slug": "torque-nm-to-ftlb",
@@ -12786,7 +12792,10 @@
       }
     ],
     "disclaimer": "For training guidance only; adjust for personal fitness levels.",
-    "info": []
+    "info": [
+      "Pace may also be expressed per mile after converting distance units.",
+      "Even pacing helps conserve energy and reduce early fatigue."
+    ]
   },
   {
     "slug": "permutation-calculator",
@@ -15092,7 +15101,10 @@
       }
     ],
     "disclaimer": "Check your course syllabus for exact grading policies.",
-    "info": []
+    "info": [
+      "Assumes all coursework prior to the final exam has been graded.",
+      "Verify with your instructor how final grades are rounded."
+    ]
   },
   {
     "slug": "hydrostatic-pressure",
@@ -15144,7 +15156,10 @@
       }
     ],
     "disclaimer": "Assumes uniform fluid density and ignores temperature variations.",
-    "info": []
+    "info": [
+      "Hydrostatic pressure increases linearly with depth in incompressible fluids.",
+      "Fluid density varies with temperature and salinity, slightly changing results."
+    ]
   },
   {
     "slug": "binary-to-decimal",
@@ -15729,7 +15744,10 @@
         "answer": "Total classes must be greater than zero."
       }
     ],
-    "info": []
+    "info": [
+      "Many courses require a minimum attendance rate to earn credit.",
+      "Policies may treat excused and unexcused absences differently."
+    ]
   },
   {
     "slug": "spring-force",
@@ -17412,7 +17430,10 @@
       }
     ],
     "disclaimer": "Educational estimate only; individual results may vary.",
-    "info": []
+    "info": [
+      "Retention rate provides a snapshot of recall and should be monitored over time.",
+      "Comparing rates across subjects can highlight areas needing more review."
+    ]
   },
   {
     "slug": "led-series-resistor",
@@ -18086,7 +18107,10 @@
       }
     ],
     "disclaimer": "For study planning only; adjust based on personal progress.",
-    "info": []
+    "info": [
+      "Spaced repetition intervals usually lengthen after each successful review.",
+      "Choose an ease factor that reflects how confidently you recalled the card."
+    ]
   },
   {
     "slug": "force-from-mass-acceleration",

--- a/src/pages/calculators/class-attendance-percentage.mdx
+++ b/src/pages/calculators/class-attendance-percentage.mdx
@@ -38,7 +38,10 @@ export const schema = {
       "description": "18 attended of 20 ⇒ 90%"
     }
   ],
-  "info": [],
+    "info": [
+      "Some institutions require a minimum attendance percentage to sit for exams.",
+      "Excused and unexcused absences may be counted differently depending on policy."
+    ],
   "faqs": [
     {
       "question": "Can total be zero?",

--- a/src/pages/calculators/final-exam-score-needed.mdx
+++ b/src/pages/calculators/final-exam-score-needed.mdx
@@ -49,7 +49,10 @@ export const schema = {
       "description": "Current 92%, final 50%, target 95% ⇒ 98%"
     }
   ],
-  "info": [],
+    "info": [
+      "This estimate assumes all prior coursework has been fully graded.",
+      "Grade rounding rules vary, so confirm exact requirements with your instructor."
+    ],
   "faqs": [
     {
       "question": "Can this result exceed 100%?",

--- a/src/pages/calculators/flashcard-interval.mdx
+++ b/src/pages/calculators/flashcard-interval.mdx
@@ -41,7 +41,10 @@ export const schema = {
       "description": "10-day interval with 1.5 ease ⇒ 15 days"
     }
   ],
-  "info": [],
+    "info": [
+      "Spaced repetition intervals typically expand after each successful review.",
+      "Adjust the ease factor based on how confidently you remembered the card."
+    ],
   "faqs": [
     {
       "question": "What is the ease factor?",

--- a/src/pages/calculators/flashcard-retention-rate.mdx
+++ b/src/pages/calculators/flashcard-retention-rate.mdx
@@ -39,7 +39,10 @@ export const schema = {
       "description": "24 of 30 cards correct ⇒ 80%"
     }
   ],
-  "info": [],
+    "info": [
+      "Retention rate reflects short-term recall and should be tracked across sessions.",
+      "Analyzing rates by subject helps identify topics that need extra practice."
+    ],
   "faqs": [
     {
       "question": "Why use a percentage?",

--- a/src/pages/calculators/hydrostatic-pressure.mdx
+++ b/src/pages/calculators/hydrostatic-pressure.mdx
@@ -42,7 +42,10 @@ export const schema = {
       "description": "850 kg/m³ at 3 m ⇒ 25,011.5 Pa"
     }
   ],
-  "info": [],
+    "info": [
+      "Hydrostatic pressure rises linearly with depth in incompressible fluids.",
+      "Density varies with temperature and salinity, slightly affecting pressure."
+    ],
   "faqs": [
     {
       "question": "What constant is used for gravity?",

--- a/src/pages/calculators/password-entropy.mdx
+++ b/src/pages/calculators/password-entropy.mdx
@@ -35,15 +35,19 @@ export const schema = {
     {
       "description": "Length 8, charset 62 ⇒ 47.60 bits"
     },
-    {
-      "description": "Length 12, charset 96 ⇒ 79.61 bits"
-    }
-  ],
-  "faqs": [
-    {
-      "question": "What is character set size?",
-      "answer": "The number of possible characters for each position."
-    },
+      {
+        "description": "Length 12, charset 96 ⇒ 79.61 bits"
+      }
+    ],
+    "info": [
+      "Entropy calculations assume characters are chosen uniformly at random.",
+      "Predictable patterns or words can significantly reduce actual security."
+    ],
+    "faqs": [
+      {
+        "question": "What is character set size?",
+        "answer": "The number of possible characters for each position."
+      },
     {
       "question": "Does higher entropy mean stronger?",
       "answer": "Yes, more entropy indicates a harder-to-guess password."

--- a/src/pages/calculators/running-pace.mdx
+++ b/src/pages/calculators/running-pace.mdx
@@ -40,15 +40,19 @@ export const schema = {
     {
       "description": "10 km in 45 min ⇒ 4.5 min/km"
     },
-    {
-      "description": "1 km in 4 min ⇒ 4 min/km"
-    }
-  ],
-  "faqs": [
-    {
-      "question": "Does this work for miles?",
-      "answer": "Yes, convert miles to kilometers first."
-    },
+      {
+        "description": "1 km in 4 min ⇒ 4 min/km"
+      }
+    ],
+    "info": [
+      "Pace can also be shown in minutes per mile after unit conversion.",
+      "Even pacing conserves energy and helps prevent early fatigue."
+    ],
+    "faqs": [
+      {
+        "question": "Does this work for miles?",
+        "answer": "Yes, convert miles to kilometers first."
+      },
     {
       "question": "Can time be in hours?",
       "answer": "Convert hours to minutes before calculating."

--- a/src/pages/calculators/shadow-length.mdx
+++ b/src/pages/calculators/shadow-length.mdx
@@ -35,15 +35,19 @@ export const schema = {
     {
       "description": "Height 2 m, angle 45° ⇒ 2 m"
     },
-    {
-      "description": "Height 1.5 m, angle 30° ⇒ 2.60 m"
-    }
-  ],
-  "faqs": [
-    {
-      "question": "What is sun angle?",
-      "answer": "The elevation of the sun above the horizon."
-    },
+      {
+        "description": "Height 1.5 m, angle 30° ⇒ 2.60 m"
+      }
+    ],
+    "info": [
+      "Shadows shorten as the sun climbs higher in the sky.",
+      "Near sunrise or sunset, small angle changes produce large shadow variations."
+    ],
+    "faqs": [
+      {
+        "question": "What is sun angle?",
+        "answer": "The elevation of the sun above the horizon."
+      },
     {
       "question": "Can the angle be zero?",
       "answer": "No, a zero angle would produce an infinite shadow."


### PR DESCRIPTION
## Summary
- Amplía la sección **Additional Information** en ocho calculadoras, añadiendo detalles sobre asistencia, notas finales, métodos de estudio, física, ritmo de carrera, entropía de contraseñas y longitudes de sombra.
- Sincroniza los nuevos textos en `data/calculators.json` para mantener la coherencia de los metadatos.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c599c883ec8321a7a4fabc06152ba2